### PR TITLE
Browser compatibility: replace Node.js APIs with cross-platform alts

### DIFF
--- a/packages/api/build/esbuild-browser-config.cjs
+++ b/packages/api/build/esbuild-browser-config.cjs
@@ -23,14 +23,6 @@ module.exports = {
     inject: [require.resolve('node-stdlib-browser/helpers/esbuild/shim')],
     plugins: [
         polyfillProviderPlugin(polyfills),
-        {
-            name: 'alias-ecc',
-            setup(build) {
-                build.onResolve({ filter: /^tiny-secp256k1$/ }, () => ({
-                    path: require.resolve('@bitcoinerlab/secp256k1'),
-                }));
-            },
-        },
     ],
     loader: { '.wasm': 'binary' },
     define: { 'global': 'globalThis' },

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/bitcoin",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "type": "module",
     "description": "Bitcoin Core RPC and Rest Client Implementations in JS/TS. Used by @did-btcr2/method.",
     "main": "./dist/cjs/index.js",
@@ -86,10 +86,10 @@
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
         "@noble/secp256k1": "^2.3.0",
-        "bitcoinjs-lib": "7.0.0-rc.0",
-        "tiny-secp256k1": "^2.2.3"
+        "bitcoinjs-lib": "7.0.0-rc.0"
     },
     "devDependencies": {
+        "tiny-secp256k1": "^2.2.3",
         "@eslint/js": "^9.22.0",
         "@types/chai": "^5.0.1",
         "@types/chai-as-promised": "^8.0.1",

--- a/packages/cryptosuite/package.json
+++ b/packages/cryptosuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cryptosuite",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "type": "module",
   "description": "W3C Data Integrity proof suite using BIP-340 Schnorr signatures over JCS-canonicalized documents. Creates and verifies bip340-jcs-2025 proofs for did:btcr2 DID updates.",
   "main": "./dist/cjs/index.js",
@@ -92,11 +92,7 @@
     "@noble/curves": "^1.8.1",
     "@noble/hashes": "^1.7.1",
     "@web5/dids": "^1.2.0",
-    "jsonld-document-loader": "^2.3.0",
-    "jsonld-signatures": "^11.5.0",
-    "multiformats": "^13.3.2",
-    "rdf-canonize": "^4.0.1",
-    "tiny-secp256k1": "^2.2.3"
+    "multiformats": "^13.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/packages/cryptosuite/src/cryptosuite/index.ts
+++ b/packages/cryptosuite/src/cryptosuite/index.ts
@@ -11,6 +11,7 @@ import {
   SignatureBytes
 } from '@did-btcr2/common';
 import { sha256 } from '@noble/hashes/sha2';
+import { concatBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { base58btc } from 'multiformats/bases/base58';
 import { BIP340DataIntegrityProof } from '../data-integrity-proof/index.js';
 import { SignedBTCR2Update, BTCR2Update, DataIntegrityConfig, DataIntegrityProofObject } from '../data-integrity-proof/interface.js';
@@ -165,14 +166,14 @@ export class BIP340Cryptosuite implements Cryptosuite {
    * @returns {HashBytes} The hash bytes of the proof configuration and document.
    */
   generateHash(config: string, document: string): HashBytes {
-    // Convert the canonical proof config to buffer and sha256 hash it
-    const configHash = sha256(Buffer.from(config, 'utf-8'));
+    // Convert the canonical proof config to bytes and sha256 hash it
+    const configHash = sha256(utf8ToBytes(config));
 
-    // Convert the canonical document to buffer and sha256 hash it
-    const documentHash = sha256(Buffer.from(document, 'utf-8'));
+    // Convert the canonical document to bytes and sha256 hash it
+    const documentHash = sha256(utf8ToBytes(document));
 
     // Concatenate the hashes
-    const combinedHash = Buffer.concat([configHash, documentHash]);
+    const combinedHash = concatBytes(configHash, documentHash);
 
     // sha256 hash the combined hashes and return
     return sha256(combinedHash);

--- a/packages/keypair/package.json
+++ b/packages/keypair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/keypair",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "description": "Secp256k1 key pairs with BIP-340 Schnorr and ECDSA signing, multibase encoding, and constant-time operations.",
   "main": "./dist/cjs/index.js",

--- a/packages/keypair/src/pair.ts
+++ b/packages/keypair/src/pair.ts
@@ -6,6 +6,7 @@ import {
   PublicKeyObject,
   SchnorrKeyPairObject
 } from '@did-btcr2/common';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { CompressedSecp256k1PublicKey, PublicKey } from './public.js';
 import { Secp256k1SecretKey, SecretKey } from './secret.js';
 import { HexSchnorrKeyPair, MultibaseKeys, RawSchnorrKeyPair, SchnorrKeyPairParams } from './types.js';
@@ -214,7 +215,7 @@ export class SchnorrKeyPair implements KeyPair {
     // Else if data is string, convert to byte array
     // Else must be bytes, use them
     const secret = typeof data === 'string'
-      ? Buffer.from(data, 'hex')
+      ? hexToBytes(data)
       : data;
 
     // Check the lenth
@@ -247,7 +248,7 @@ export class SchnorrKeyPair implements KeyPair {
    * @returns {Hex} The key bytes as a hex string.
    */
   static toHex(keyBytes: KeyBytes): Hex {
-    return Buffer.from(keyBytes).toString('hex');
+    return bytesToHex(keyBytes);
   }
 
   /**

--- a/packages/keypair/src/public.ts
+++ b/packages/keypair/src/public.ts
@@ -8,6 +8,7 @@ import {
 } from '@did-btcr2/common';
 import { secp256k1, schnorr } from '@noble/curves/secp256k1.js';
 import { equalBytes } from '@noble/curves/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { base58 } from '@scure/base';
 import { CryptoOptions } from './types.js';
 
@@ -140,7 +141,7 @@ export class CompressedSecp256k1PublicKey implements PublicKey {
     // Convert hex string to Uint8Array if necessary
     const keyBytes = initialBytes instanceof Uint8Array
       ? initialBytes
-      : Uint8Array.from(Buffer.from(initialBytes, 'hex'));
+      : hexToBytes(initialBytes);
 
     // If the byte length is not 33, throw an error
     if(!keyBytes || keyBytes.length !== 33) {
@@ -249,7 +250,7 @@ export class CompressedSecp256k1PublicKey implements PublicKey {
    * @returns {string} The public key as a hex string.
    */
   get hex(): string {
-    const hex = Buffer.from(this.compressed).toString('hex');
+    const hex = bytesToHex(this.compressed);
     return hex;
   }
 

--- a/packages/keypair/src/secret.ts
+++ b/packages/keypair/src/secret.ts
@@ -166,7 +166,7 @@ export class Secp256k1SecretKey implements SecretKey {
    */
   get hex(): HexString {
     // Convert the raw secret key bytes to a hex string
-    return Buffer.from(this.bytes).toString('hex');
+    return bytesToHex(this.bytes);
   }
 
 
@@ -302,7 +302,7 @@ export class Secp256k1SecretKey implements SecretKey {
     const prefix = decoded.slice(0, 2);
 
     // Compute the prefix hash
-    const prefixHash = Buffer.from(sha256(prefix)).toString('hex');
+    const prefixHash = bytesToHex(sha256(prefix));
 
     // If the prefix hash does not equal the BIP340 prefix hash, throw an error
     if (prefixHash !== BIP340_SECRET_KEY_MULTIBASE_PREFIX_HASH) {

--- a/packages/method/build/esbuild-browser-config.cjs
+++ b/packages/method/build/esbuild-browser-config.cjs
@@ -23,14 +23,6 @@ module.exports = {
     inject: [require.resolve('node-stdlib-browser/helpers/esbuild/shim')],
     plugins: [
         polyfillProviderPlugin(polyfills),
-        {
-            name: 'alias-ecc',
-            setup(build) {
-                build.onResolve({ filter: /^tiny-secp256k1$/ }, () => ({
-                    path: require.resolve('@bitcoinerlab/secp256k1'),
-                }));
-            },
-        },
     ],
     loader: { '.wasm': 'binary' },
     define: { 'global': 'globalThis' },

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",
@@ -115,8 +115,7 @@
         "dotenv": "^16.5.0",
         "helia": "^5.2.1",
         "multiformats": "^13.3.1",
-        "nostr-tools": "^2.15.0",
-        "tiny-secp256k1": "^2.2.3"
+        "nostr-tools": "^2.15.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",

--- a/packages/method/src/core/beacon/aggregation/cohort/index.ts
+++ b/packages/method/src/core/beacon/aggregation/cohort/index.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@noble/hashes/utils';
 import { keyAggExport, keyAggregate, sortKeys } from '@scure/btc-signer/musig2';
 import { payments, Transaction } from 'bitcoinjs-lib';
 import { BeaconCoordinatorError } from '../../error.js';
@@ -133,7 +134,7 @@ export class AggregateBeaconCohort implements BeaconCohort {
         );
       }
     }
-    this.cohortKeys = cohortKeys.map(key => Buffer.from(key, 'hex'));
+    this.cohortKeys = cohortKeys.map(key => hexToBytes(key));
     const calculatedAddress = this.calulateBeaconAddress();
     if (calculatedAddress !== beaconAddress) {
       this.status = COHORT_STATUS.COHORT_FAILED;

--- a/packages/method/src/core/beacon/aggregation/communication/adapter/nostr.ts
+++ b/packages/method/src/core/beacon/aggregation/communication/adapter/nostr.ts
@@ -2,6 +2,7 @@
 
 import { Did } from '@did-btcr2/common';
 import { CompressedSecp256k1PublicKey, RawSchnorrKeyPair, SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
+import { bytesToHex } from '@noble/hashes/utils';
 import { nonceGen } from '@scure/btc-signer/musig2';
 import { Event, EventTemplate, Filter, finalizeEvent, nip44 } from 'nostr-tools';
 import { SimplePool } from 'nostr-tools/pool';
@@ -217,10 +218,10 @@ export class NostrAdapter implements CommunicationService {
     //   this.config.coordinatorDids.push(recipient);
     // }
 
-    const tags = [['p', Buffer.from(sender.x).toString('hex')]];
+    const tags = [['p', bytesToHex(sender.x)]];
     if(to) {
       const recipient = new CompressedSecp256k1PublicKey(Identifier.decode(to).genesisBytes);
-      tags.push(['p', Buffer.from(recipient.x).toString('hex')]);
+      tags.push(['p', bytesToHex(recipient.x)]);
     }
     const { type } = message as any ?? {};
     if(!type) {

--- a/packages/method/src/core/beacon/aggregation/coordinator.ts
+++ b/packages/method/src/core/beacon/aggregation/coordinator.ts
@@ -1,5 +1,6 @@
 import { Maybe } from '@did-btcr2/common';
 import { RawSchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex } from '@noble/hashes/utils';
 import { BeaconCoordinatorError } from '../error.js';
 import { AggregateBeaconCohort } from './cohort/index.js';
 import {
@@ -253,7 +254,7 @@ export class BeaconCoordinator {
 
     if (signingSession.status === SIGNING_SESSION_STATUS.PARTIAL_SIGNATURES_RECEIVED) {
       const signature = await signingSession.generateFinalSignature();
-      console.info(`Final signature ${Buffer.from(signature).toString('hex')} generated for session ${signingSession.id}`);
+      console.info(`Final signature ${bytesToHex(signature)} generated for session ${signingSession.id}`);
     }
   }
 

--- a/packages/method/src/core/beacon/aggregation/participant.ts
+++ b/packages/method/src/core/beacon/aggregation/participant.ts
@@ -1,4 +1,5 @@
 import { KeyBytes, Maybe } from '@did-btcr2/common';
+import { bytesToHex } from '@noble/hashes/utils';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import * as musig2 from '@scure/btc-signer/musig2';
@@ -280,7 +281,7 @@ export class BeaconParticipant {
       console.error(`Failed to derive public key for cohort ${cohortId}`);
       return;
     }
-    const participantPk = Buffer.from(participantPkBytes).toString('hex');
+    const participantPk = bytesToHex(participantPkBytes);
     const beaconAddress = cohortSetMessage.body?.beaconAddress;
     if(!beaconAddress) {
       console.error(`Beacon address not provided in cohort set message for ${cohortId}`);
@@ -291,7 +292,7 @@ export class BeaconParticipant {
       console.error(`Cohort keys not provided in cohort set message for ${cohortId}`);
       return;
     }
-    const keys = cohortKeys.map(key => Buffer.from(key).toString('hex'));
+    const keys = cohortKeys.map(key => bytesToHex(new Uint8Array(key)));
     cohort.validateCohort([participantPk], keys, beaconAddress);
     console.info(`BeaconParticipant w/ pk ${participantPk} successfully joined cohort ${cohortId} with beacon address ${beaconAddress}.`);
     console.info(`Cohort status: ${cohort.status}`);

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -2,6 +2,7 @@ import { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
 import { canonicalHash, canonicalize, decode, encode, hash, KeyBytes } from '@did-btcr2/common';
 import { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { hexToBytes } from '@noble/hashes/utils';
 import { opcodes, Psbt, script } from 'bitcoinjs-lib';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import { SidecarData } from '../types.js';
@@ -166,7 +167,7 @@ export class CASBeacon extends Beacon {
       .addInput({
         hash           : utxo.txid,
         index          : utxo.vout,
-        nonWitnessUtxo : Buffer.from(prevTx, 'hex')
+        nonWitnessUtxo : hexToBytes(prevTx)
       })
       // Add a change output minus a fee of 500 sats
       // TODO: calculate fee based on transaction vsize and current fee rates

--- a/packages/method/src/core/beacon/singleton-beacon.ts
+++ b/packages/method/src/core/beacon/singleton-beacon.ts
@@ -2,6 +2,7 @@ import { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
 import { canonicalize, decode, encode, hash, KeyBytes } from '@did-btcr2/common';
 import { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { hexToBytes } from '@noble/hashes/utils';
 import { opcodes, Psbt, script } from 'bitcoinjs-lib';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import { SidecarData } from '../types.js';
@@ -112,7 +113,7 @@ export class SingletonBeacon extends Beacon {
       .addInput({
         hash           : utxo.txid,
         index          : utxo.vout,
-        nonWitnessUtxo : Buffer.from(prevTx, 'hex')
+        nonWitnessUtxo : hexToBytes(prevTx)
       })
       // Add a change output minus a fee of 500 sats
       // TODO: calculate fee based on transaction vsize and current fee rates

--- a/packages/method/src/did-btcr2.ts
+++ b/packages/method/src/did-btcr2.ts
@@ -18,8 +18,9 @@ import {
   DidErrorCode,
   DidMethod,
 } from '@web5/dids';
+import * as ecc from '@bitcoinerlab/secp256k1';
+import { hexToBytes } from '@noble/hashes/utils';
 import { initEccLib } from 'bitcoinjs-lib';
-import * as tinysecp from 'tiny-secp256k1';
 import { BeaconService } from './core/beacon/interfaces.js';
 import { Identifier } from './core/identifier.js';
 import { ResolutionOptions } from './core/interfaces.js';
@@ -37,8 +38,8 @@ export interface DidCreateOptions {
   network?: string;
 }
 
-/** Initialize tiny secp256k1 */
-initEccLib(tinysecp);
+/** Initialize secp256k1 ECC library */
+initEccLib(ecc);
 
 /**
  * Implements {@link https://dcdpr.github.io/did-btcr2 | did:btcr2 DID Method Specification}.
@@ -183,7 +184,7 @@ export class DidBtcr2 implements DidMethod {
 
     // Convert signingMaterial to bytes if it's a hex string
     const secretKey = typeof signingMaterial === 'string'
-      ? Buffer.from(signingMaterial, 'hex')
+      ? hexToBytes(signingMaterial)
       : signingMaterial;
 
     // Validate that the verificationMethodId is authorized for capabilityInvocation

--- a/packages/smt/package.json
+++ b/packages/smt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/smt",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "module",
     "description": "Optimized Sparse Merkle Tree with converge bitmap proofs, depth-byte padding, and did:btcr2-specific leaf hash construction.",
     "main": "./dist/cjs/index.js",
@@ -78,6 +78,11 @@
         "build:test": "pnpm build && pnpm build:tests && pnpm c8 mocha",
         "build:lint:test": "pnpm build && pnpm build:tests && pnpm lint:fix",
         "prepublish": "pnpm build"
+    },
+    "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^1.7.1",
+        "@scure/base": "^1.2.6"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",

--- a/packages/smt/src/hash.ts
+++ b/packages/smt/src/hash.ts
@@ -1,4 +1,7 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { equalBytes } from '@noble/curves/utils.js';
+import { sha256 } from '@noble/hashes/sha2';
+import { concatBytes } from '@noble/hashes/utils';
+import { base64 } from '@scure/base';
 import { HASH_BYTE_LENGTH, HASH_HEX_LENGTH } from './constants.js';
 
 /**
@@ -21,11 +24,7 @@ export function validateHash(hash: Uint8Array): void {
  * SHA-256 digest of all `blocks` concatenated in order.
  */
 export function blockHash(...blocks: Uint8Array[]): Uint8Array {
-  const sha256 = createHash('sha256');
-  for (const block of blocks) {
-    sha256.update(block);
-  }
-  return new Uint8Array(sha256.digest());
+  return sha256(concatBytes(...blocks));
 }
 
 /**
@@ -109,7 +108,7 @@ export function hexToBigInt(hex: string, padded: boolean): bigint {
  */
 export function hashesEqual(a: Uint8Array, b: Uint8Array): boolean {
   if (!isValidHash(a) || !isValidHash(b)) return false;
-  return timingSafeEqual(a, b);
+  return equalBytes(a, b);
 }
 
 /**
@@ -117,7 +116,7 @@ export function hashesEqual(a: Uint8Array, b: Uint8Array): boolean {
  */
 export function hashToBase64(hash: Uint8Array): string {
   validateHash(hash);
-  return Buffer.from(hash).toString('base64');
+  return base64.encode(hash);
 }
 
 /**
@@ -125,8 +124,7 @@ export function hashToBase64(hash: Uint8Array): string {
  * Throws `RangeError` if the decoded result is not 32 bytes.
  */
 export function base64ToHash(b64: string): Uint8Array {
-  const buf = Buffer.from(b64, 'base64');
-  const hash = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  const hash = base64.decode(b64);
   if (hash.length !== HASH_BYTE_LENGTH) {
     throw new RangeError(`Invalid base64 hash: expected ${HASH_BYTE_LENGTH} decoded bytes, got ${hash.length}`);
   }
@@ -144,7 +142,7 @@ export function bigIntToBase64(value: bigint, padded: boolean): string {
     const firstNonZero = bytes.findIndex(b => b !== 0x00);
     bytes = firstNonZero === -1 ? new Uint8Array(1) : bytes.slice(firstNonZero);
   }
-  return Buffer.from(bytes).toString('base64');
+  return base64.encode(bytes);
 }
 
 /**
@@ -152,8 +150,7 @@ export function bigIntToBase64(value: bigint, padded: boolean): string {
  * When `padded` is true, the decoded bytes must be exactly 32.
  */
 export function base64ToBigInt(b64: string, padded: boolean): bigint {
-  const buf = Buffer.from(b64, 'base64');
-  const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  const bytes = base64.decode(b64);
   if (padded && bytes.length !== HASH_BYTE_LENGTH) {
     throw new RangeError(`Invalid padded base64 bigint: expected ${HASH_BYTE_LENGTH} decoded bytes, got ${bytes.length}`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
       bitcoinjs-lib:
         specifier: 7.0.0-rc.0
         version: 7.0.0-rc.0(typescript@5.7.3)
-      tiny-secp256k1:
-        specifier: ^2.2.3
-        version: 2.2.4
     devDependencies:
       '@eslint/js':
         specifier: ^9.22.0
@@ -298,6 +295,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tiny-secp256k1:
+        specifier: ^2.2.3
+        version: 2.2.4
       typedoc-plugin-markdown:
         specifier: ^4.7.0
         version: 4.8.1(typedoc@0.28.13(typescript@5.7.3))
@@ -501,21 +501,9 @@ importers:
       '@web5/dids':
         specifier: ^1.2.0
         version: 1.2.0
-      jsonld-document-loader:
-        specifier: ^2.3.0
-        version: 2.3.0
-      jsonld-signatures:
-        specifier: ^11.5.0
-        version: 11.5.0(web-streams-polyfill@3.3.3)
       multiformats:
         specifier: ^13.3.2
         version: 13.4.1
-      rdf-canonize:
-        specifier: ^4.0.1
-        version: 4.0.1
-      tiny-secp256k1:
-        specifier: ^2.2.3
-        version: 2.2.4
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -813,9 +801,6 @@ importers:
       nostr-tools:
         specifier: ^2.15.0
         version: 2.16.2(typescript@5.7.3)
-      tiny-secp256k1:
-        specifier: ^2.2.3
-        version: 2.2.4
     devDependencies:
       '@eslint/js':
         specifier: ^9.22.0
@@ -885,6 +870,16 @@ importers:
         version: 8.44.0(eslint@9.35.0)(typescript@5.7.3)
 
   packages/smt:
+    dependencies:
+      '@noble/curves':
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@noble/hashes':
+        specifier: ^1.7.1
+        version: 1.8.0
+      '@scure/base':
+        specifier: ^1.2.6
+        version: 1.2.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -1309,13 +1304,6 @@ packages:
 
   '@decentralized-identity/ion-sdk@1.0.4':
     resolution: {integrity: sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A==}
-
-  '@digitalbazaar/http-client@3.4.1':
-    resolution: {integrity: sha512-Ahk1N+s7urkgj7WvvUND5f8GiWEPfUw0D41hdElaqLgu8wZScI8gdI0q+qWw5N1d35x7GCRH2uk9mi+Uzo9M3g==}
-    engines: {node: '>=14.0'}
-
-  '@digitalbazaar/security-context@1.0.1':
-    resolution: {integrity: sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA==}
 
   '@dnsquery/dns-packet@6.1.1':
     resolution: {integrity: sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==}
@@ -1981,10 +1969,6 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@gerrit0/mini-shiki@3.12.2':
     resolution: {integrity: sha512-HKZPmO8OSSAAo20H2B3xgJdxZaLTwtlMwxg0967scnrDlPwe6j5+ULGHyIqwgTbFCn9yv/ff8CmfWZLE9YKBzA==}
@@ -3334,9 +3318,6 @@ packages:
   caniuse-lite@1.0.30001743:
     resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
 
-  canonicalize@1.0.8:
-    resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
-
   canonicalize@2.1.0:
     resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
     hasBin: true
@@ -3710,10 +3691,6 @@ packages:
 
   dagre-d3-es@7.0.11:
     resolution: {integrity: sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==}
-
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -4102,10 +4079,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -4166,10 +4139,6 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   freeport-promise@2.0.0:
     resolution: {integrity: sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==}
@@ -4798,18 +4767,6 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
-  jsonld-document-loader@2.3.0:
-    resolution: {integrity: sha512-u06N5O5sCewgXyxFnnRSm0w3o47ps834QjYzpOMc13Nq+AJQd/JGYrW/WZnz5D+8NEvnKXph7AFi6MA7ZJ8Q0Q==}
-    engines: {node: '>=18'}
-
-  jsonld-signatures@11.5.0:
-    resolution: {integrity: sha512-Kdto+e8uvY/5u3HYkmAbpy52bplWX9uqS8fmqdCv6oxnCFwCTM0hMt6r4rWqlhw5/aHoCHJIRxwYb4QKGC69Jw==}
-    engines: {node: '>=18'}
-
-  jsonld@8.3.3:
-    resolution: {integrity: sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==}
-    engines: {node: '>=14'}
-
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
@@ -4831,20 +4788,6 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
-
-  ky-universal@0.11.0:
-    resolution: {integrity: sha512-65KyweaWvk+uKKkCrfAf+xqN2/epw1IJDtlyCPxYffFCMR8u1sp2U65NtWpnozYfZxQ6IUzIlvUcw+hQ82U2Xw==}
-    engines: {node: '>=14.16'}
-    peerDependencies:
-      ky: '>=0.31.4'
-      web-streams-polyfill: '>=3.2.1'
-    peerDependenciesMeta:
-      web-streams-polyfill:
-        optional: true
-
-  ky@0.33.3:
-    resolution: {integrity: sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==}
-    engines: {node: '>=14.16'}
 
   langium@3.3.1:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
@@ -4940,10 +4883,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -5250,11 +5189,6 @@ packages:
     resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
     engines: {node: '>=10'}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -5267,10 +5201,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -5693,14 +5623,6 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  rdf-canonize@3.4.0:
-    resolution: {integrity: sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==}
-    engines: {node: '>=12'}
-
-  rdf-canonize@4.0.1:
-    resolution: {integrity: sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==}
-    engines: {node: '>=18'}
-
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
@@ -5892,10 +5814,6 @@ packages:
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
-
-  serialize-error@8.1.0:
-    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
-    engines: {node: '>=10'}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
@@ -6363,10 +6281,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
     engines: {node: '>=18.17'}
@@ -6548,10 +6462,6 @@ packages:
   weald@1.0.6:
     resolution: {integrity: sha512-sX1PzkcMJZUJ848JbFzB6aKHHglTxqACEnq2KgI75b7vWYvfXFBNbOuDKqFKwCT44CrP6c5r+L4+5GmPnb5/SQ==}
 
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
   webcrypto-core@1.8.1:
     resolution: {integrity: sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==}
 
@@ -6663,9 +6573,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -7258,16 +7165,6 @@ snapshots:
       multiformats: 12.1.3
       uri-js: 4.4.1
 
-  '@digitalbazaar/http-client@3.4.1(web-streams-polyfill@3.3.3)':
-    dependencies:
-      ky: 0.33.3
-      ky-universal: 0.11.0(ky@0.33.3)(web-streams-polyfill@3.3.3)
-      undici: 5.29.0
-    transitivePeerDependencies:
-      - web-streams-polyfill
-
-  '@digitalbazaar/security-context@1.0.1': {}
-
   '@dnsquery/dns-packet@6.1.1':
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
@@ -7640,8 +7537,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@gerrit0/mini-shiki@3.12.2':
     dependencies:
@@ -9748,8 +9643,6 @@ snapshots:
 
   caniuse-lite@1.0.30001743: {}
 
-  canonicalize@1.0.8: {}
-
   canonicalize@2.1.0: {}
 
   catering@2.1.1: {}
@@ -10184,8 +10077,6 @@ snapshots:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.21
-
-  data-uri-to-buffer@4.0.1: {}
 
   dataloader@1.4.0: {}
 
@@ -10641,11 +10532,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -10717,10 +10603,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   freeport-promise@2.0.0: {}
 
@@ -11432,26 +11314,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonld-document-loader@2.3.0: {}
-
-  jsonld-signatures@11.5.0(web-streams-polyfill@3.3.3):
-    dependencies:
-      '@digitalbazaar/security-context': 1.0.1
-      jsonld: 8.3.3(web-streams-polyfill@3.3.3)
-      rdf-canonize: 4.0.1
-      serialize-error: 8.1.0
-    transitivePeerDependencies:
-      - web-streams-polyfill
-
-  jsonld@8.3.3(web-streams-polyfill@3.3.3):
-    dependencies:
-      '@digitalbazaar/http-client': 3.4.1(web-streams-polyfill@3.3.3)
-      canonicalize: 1.0.8
-      lru-cache: 6.0.0
-      rdf-canonize: 3.4.0
-    transitivePeerDependencies:
-      - web-streams-polyfill
-
   jsonparse@1.3.1: {}
 
   jsonstream-next@3.0.0:
@@ -11470,16 +11332,6 @@ snapshots:
   khroma@2.1.0: {}
 
   kolorist@1.8.0: {}
-
-  ky-universal@0.11.0(ky@0.33.3)(web-streams-polyfill@3.3.3):
-    dependencies:
-      abort-controller: 3.0.0
-      ky: 0.33.3
-      node-fetch: 3.3.2
-    optionalDependencies:
-      web-streams-polyfill: 3.3.3
-
-  ky@0.33.3: {}
 
   langium@3.3.1:
     dependencies:
@@ -11601,10 +11453,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
 
   lunr@2.3.9: {}
 
@@ -12080,8 +11928,6 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  node-domexception@1.0.0: {}
-
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -12092,12 +11938,6 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -12537,14 +12377,6 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  rdf-canonize@3.4.0:
-    dependencies:
-      setimmediate: 1.0.5
-
-  rdf-canonize@4.0.1:
-    dependencies:
-      setimmediate: 1.0.5
-
   react-devtools-core@6.1.5:
     dependencies:
       shell-quote: 1.8.3
@@ -12804,10 +12636,6 @@ snapshots:
       - supports-color
 
   serialize-error@2.1.0: {}
-
-  serialize-error@8.1.0:
-    dependencies:
-      type-fest: 0.20.2
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -13296,10 +13124,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@6.21.3: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -13501,8 +13325,6 @@ snapshots:
       ms: 3.0.0-canary.202508261828
       supports-color: 10.2.2
 
-  web-streams-polyfill@3.3.3: {}
-
   webcrypto-core@1.8.1:
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
@@ -13589,8 +13411,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yaml@2.8.1: {}
 


### PR DESCRIPTION
PACKAGE VERSIONS
* @did-btcr2/smt@0.2.1
* @did-btcr2/keypair@0.11.2
* @did-btcr2/cryptosuite@6.0.4
* @did-btcr2/method@0.25.1
* @did-btcr2/bitcoin@0.5.1

SMT
* Replace node:crypto createHash with @noble/hashes sha256
* Replace node:crypto timingSafeEqual with @noble/curves equalBytes
* Replace Buffer base64 encode/decode with @scure/base
* Add @noble/hashes, @noble/curves, @scure/base as dependencies

KEYPAIR
* Replace Buffer hex conversions with bytesToHex/hexToBytes from @noble/hashes
* Update package description

CRYPTOSUITE
* Replace Buffer utf-8/concat with utf8ToBytes/concatBytes from @noble/hashes
* Remove dead deps: tiny-secp256k1, jsonld-document-loader, jsonld-signatures, rdf-canonize
* Update package description

METHOD
* Replace tiny-secp256k1 (native C++ addon) with @bitcoinerlab/secp256k1 (pure JS)
* Replace Buffer hex conversions across 7 beacon/aggregation files
* Remove tiny-secp256k1 from dependencies
* Remove alias-ecc esbuild plugin (no longer needed)

BITCOIN
* Move tiny-secp256k1 from dependencies to devDependencies (unused in src/)