### PR TITLE
Fix bug in method Resolver

### DIFF
--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.25.1",
+    "version": "0.25.2",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/signal-discovery.ts
+++ b/packages/method/src/core/beacon/signal-discovery.ts
@@ -38,7 +38,7 @@ export class BeaconSignalDiscovery {
       beaconServiceSignals.set(beaconService, []);
       // Get the transactions for the beacon address via REST
       const beaconSignals = await bitcoin.rest.address.getTxs(
-        beaconService.serviceEndpoint as string
+        BeaconUtils.parseBitcoinAddress(beaconService.serviceEndpoint as string)
       );
 
       // If no signals are found, continue


### PR DESCRIPTION
PACKAGE VERSIONS
* @did-btcr2/method@0.25.2

METHOD
* Not removing BIP21 "bitcoin:" URI before signal-discovery indexer call