### PR TITLE
Eliminate unnecessary hash encoding, byte comparisons for interop

### DIFF
--- a/packages/api/lib/test-api.ts
+++ b/packages/api/lib/test-api.ts
@@ -1,0 +1,47 @@
+import type { NetworkName } from '@did-btcr2/api';
+import { DidBtcr2Api } from '@did-btcr2/api';
+import { createHelia } from 'helia';
+
+const did = 'did:btcr2:k1q5prr73dxh76el6tfl09skfm49uqxxqra8cqxszy9yntqt852ulecrsrxkp82';
+const resolutionOptions = {
+  'sidecar' : {
+    'updates' : [
+      {
+        '@context' : [
+          'https://w3id.org/security/v2',
+          'https://w3id.org/zcap/v1',
+          'https://w3id.org/json-ld-patch/v1',
+          'https://btcr2.dev/context/v1',
+          'https://w3id.org/security/data-integrity/v2'
+        ],
+        'patch' : [
+          {
+            'op'    : 'add',
+            'path'  : '/service/0',
+            'value' : {
+              'id'              : 'did:btcr2:k1q5prr73dxh76el6tfl09skfm49uqxxqra8cqxszy9yntqt852ulecrsrxkp82#service-1',
+              'type'            : 'MyService',
+              'serviceEndpoint' : 'https://localhost:1234/'
+            }
+          }
+        ],
+        'sourceHash'      : 'l7zFAm7uHNMCDDOXqm0GXJqsN1QZd5JpI4J-aM5hpiI=',
+        'targetHash'      : '9izUOyujZSsOpEoMBqmAZ7GSJuQWNs56APNzGz7FlCg=',
+        'targetVersionId' : 2,
+        'proof'           : {
+          'type'               : 'DataIntegrityProof',
+          'cryptosuite'        : 'bip340-jcs-2025',
+          'verificationMethod' : 'did:btcr2:k1q5prr73dxh76el6tfl09skfm49uqxxqra8cqxszy9yntqt852ulecrsrxkp82#initialKey',
+          'proofPurpose'       : 'capabilityInvocation',
+          'capability'         : 'urn:zcap:root:did%3Abtcr2%3Ak1q5prr73dxh76el6tfl09skfm49uqxxqra8cqxszy9yntqt852ulecrsrxkp82',
+          'capabilityAction'   : 'Write',
+          'proofValue'         : 'z5zXkHkNjVarQqTq74Ut9sDt3MYpD8UMnY4MSZgjWiTopefxqbDoQARru8SRA55SqZDdcqbBYdfn4w218F1YaywyE'
+        }
+      }
+    ]
+  }
+};
+const apiConfig = { btc: { network: 'mutinynet' as NetworkName }, cas: { helia: await createHelia() } };
+const api = new DidBtcr2Api(apiConfig);
+const resolutionResult = await api.resolveDid(did, resolutionOptions as any);
+console.log('resolutionResult', JSON.stringify(resolutionResult, null, 2));

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/cas.ts
+++ b/packages/api/src/cas.ts
@@ -1,10 +1,10 @@
-import { canonicalize, decode as decodeHash } from '@did-btcr2/common';
+import type { HashBytes } from '@did-btcr2/common';
+import { canonicalize, decode as decodeHash, encode as encodeHash } from '@did-btcr2/common';
 import type { Helia } from 'helia';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
 import { create as createDigest } from 'multiformats/hashes/digest';
 import { sha256 } from 'multiformats/hashes/sha2';
-import { assertString } from './helpers.js';
 
 /**
  * Executor interface for content-addressed storage.
@@ -36,7 +36,7 @@ export class IpfsCasExecutor implements CasExecutor {
   }
 
   async retrieve(hash: string): Promise<Uint8Array | null> {
-    const hashBytes = decodeHash(hash, 'base64url');
+    const hashBytes = decodeHash(hash, 'base64urlnopad');
     const cid = CID.create(1, raw.code, createDigest(sha256.code, hashBytes));
     try {
       return await this.#helia.blockstore.get(cid);
@@ -96,12 +96,12 @@ export class CasApi {
   }
 
   /**
-   * Retrieve a JSON object from the CAS by its base64url SHA-256 hash.
-   * @param hash Base64url-encoded SHA-256 hash of the JCS-canonicalized object.
+   * Retrieve a JSON object from the CAS by its SHA-256 hash bytes.
+   * @param hashBytes Raw SHA-256 hash bytes of the JCS-canonicalized object.
    * @returns The parsed JSON object, or `null` if not found.
    */
-  async retrieve(hash: string): Promise<object | null> {
-    assertString(hash, 'hash');
+  async retrieve(hashBytes: HashBytes): Promise<object | null> {
+    const hash = encodeHash(hashBytes, 'base64urlnopad');
     const bytes = await this.#executor.retrieve(hash);
     if (!bytes) return null;
     return JSON.parse(new TextDecoder().decode(bytes)) as object;

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -1,6 +1,6 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import type { DocumentBytes, HexString, KeyBytes, PatchOperation } from '@did-btcr2/common';
-import { IdentifierTypes, NotImplementedError } from '@did-btcr2/common';
+import { decode as decodeHash, IdentifierTypes, NotImplementedError } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import type { Btcr2DidDocument, CASAnnouncement, DidCreateOptions, NeedCASAnnouncement, NeedGenesisDocument, NeedSignedUpdate, ResolutionOptions } from '@did-btcr2/method';
 import { BeaconSignalDiscovery, DidBtcr2 } from '@did-btcr2/method';
@@ -96,7 +96,7 @@ export class DidMethodApi {
                 );
               }
               this.#log.debug('Fetching genesis document from CAS: %s', need.genesisHash);
-              const doc = await this.#cas.retrieve(need.genesisHash);
+              const doc = await this.#cas.retrieve(decodeHash(need.genesisHash, 'hex'));
               if(!doc) {
                 throw new Error(
                   `Genesis document not found in CAS (hash: ${need.genesisHash}).`
@@ -114,7 +114,7 @@ export class DidMethodApi {
                 );
               }
               this.#log.debug('Fetching CAS announcement from CAS: %s', need.announcementHash);
-              const announcement = await this.#cas.retrieve(need.announcementHash);
+              const announcement = await this.#cas.retrieve(decodeHash(need.announcementHash, 'hex'));
               if(!announcement) {
                 throw new Error(
                   `CAS announcement not found in CAS (hash: ${need.announcementHash}).`
@@ -132,7 +132,7 @@ export class DidMethodApi {
                 );
               }
               this.#log.debug('Fetching signed update from CAS: %s', need.updateHash);
-              const update = await this.#cas.retrieve(need.updateHash);
+              const update = await this.#cas.retrieve(decodeHash(need.updateHash, 'hex'));
               if(!update) {
                 throw new Error(
                   `Signed update not found in CAS (hash: ${need.updateHash}).`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/common",
-  "version": "8.0.2",
+  "version": "9.0.0",
   "type": "module",
   "description": "Common utilities, types, interfaces, etc. shared across the did-btcr2-js monorepo packages.",
   "main": "./dist/cjs/index.js",

--- a/packages/common/src/canonicalization.ts
+++ b/packages/common/src/canonicalization.ts
@@ -5,7 +5,7 @@ import { CanonicalizationError } from './errors.js';
 import type { HashBytes } from './types.js';
 
 export type CanonicalizationAlgorithm = 'jcs' | 'rdfc';
-export type CanonicalizationEncoding = 'hex' | 'base58' | 'base64url';
+export type CanonicalizationEncoding = 'hex' | 'base58' | 'base64urlnopad';
 
 export interface CanonicalizationOptions {
   algorithm?: CanonicalizationAlgorithm;
@@ -13,7 +13,7 @@ export interface CanonicalizationOptions {
 }
 
 const SUPPORTED_ALGORITHMS: ReadonlySet<CanonicalizationAlgorithm> = new Set(['jcs']);
-const SUPPORTED_ENCODINGS: ReadonlySet<CanonicalizationEncoding> = new Set(['hex', 'base58', 'base64url']);
+const SUPPORTED_ENCODINGS: ReadonlySet<CanonicalizationEncoding> = new Set(['hex', 'base58', 'base64urlnopad']);
 
 /**
  * Normalizes and validates the canonicalization algorithm.
@@ -79,16 +79,16 @@ export function hash(canonicalized: string): HashBytes {
  * Encodes hash bytes using the specified encoding.
  *
  * @param {HashBytes} hashBytes - The hash bytes to encode.
- * @param {CanonicalizationEncoding} [encoding='base64url'] - The encoding format.
+ * @param {CanonicalizationEncoding} [encoding='base64urlnopad'] - The encoding format.
  * @returns {string} The encoded string.
  * @throws {CanonicalizationError} If the encoding is not supported.
  */
-export function encode(hashBytes: HashBytes, encoding: CanonicalizationEncoding = 'base64url'): string {
+export function encode(hashBytes: HashBytes, encoding: CanonicalizationEncoding = 'base64urlnopad'): string {
   const normalized = normalizeEncoding(encoding);
   switch (normalized) {
     case 'hex':       return hex.encode(hashBytes);
     case 'base58':    return base58.encode(hashBytes);
-    case 'base64url': return base64urlnopad.encode(hashBytes);
+    case 'base64urlnopad': return base64urlnopad.encode(hashBytes);
   }
 }
 
@@ -96,17 +96,30 @@ export function encode(hashBytes: HashBytes, encoding: CanonicalizationEncoding 
  * Decodes an encoded hash string back to bytes.
  *
  * @param {string} encoded - The encoded hash string.
- * @param {CanonicalizationEncoding} [encoding='base64url'] - The encoding format.
+ * @param {CanonicalizationEncoding} [encoding='base64urlnopad'] - The encoding format.
  * @returns {HashBytes} The decoded hash bytes.
  * @throws {CanonicalizationError} If the encoding is not supported.
  */
-export function decode(encoded: string, encoding: CanonicalizationEncoding = 'base64url'): HashBytes {
+export function decode(encoded: string, encoding: CanonicalizationEncoding = 'base64urlnopad'): HashBytes {
   const normalized = normalizeEncoding(encoding);
   switch (normalized) {
     case 'hex':       return hex.decode(encoded);
     case 'base58':    return base58.decode(encoded);
-    case 'base64url': return base64urlnopad.decode(encoded);
+    case 'base64urlnopad': return base64urlnopad.decode(encoded);
   }
+}
+
+/**
+ * Implements {@link https://dcdpr.github.io/did-btcr2/algorithms.html#json-document-hashing | 8.c JSON Document Hashing}.
+ *
+ * Pipeline: Canonicalize (JCS) -> Hash (SHA-256) -> raw bytes.
+ *
+ * @param {Record<any, any>} object - The object to process.
+ * @param {CanonicalizationAlgorithm} [algorithm='jcs'] - The canonicalization algorithm.
+ * @returns {HashBytes} The raw SHA-256 hash bytes (Uint8Array).
+ */
+export function canonicalHashBytes(object: Record<any, any>, algorithm: CanonicalizationAlgorithm = 'jcs'): HashBytes {
+  return hash(canonicalize(object, normalizeAlgorithm(algorithm)));
 }
 
 /**
@@ -120,6 +133,6 @@ export function decode(encoded: string, encoding: CanonicalizationEncoding = 'ba
  */
 export function canonicalHash(object: Record<any, any>, options?: CanonicalizationOptions): string {
   const algorithm = normalizeAlgorithm(options?.algorithm ?? 'jcs');
-  const encoding = normalizeEncoding(options?.encoding ?? 'base64url');
+  const encoding = normalizeEncoding(options?.encoding ?? 'base64urlnopad');
   return encode(hash(canonicalize(object, algorithm)), encoding);
 }

--- a/packages/common/tests/canonicalization.spec.ts
+++ b/packages/common/tests/canonicalization.spec.ts
@@ -38,7 +38,7 @@ describe('canonicalization', () => {
       .to.throw(CanonicalizationError, 'Unsupported encoding');
   });
 
-  it('canonicalizes with JCS by default (base64url encoding)', () => {
+  it('canonicalizes with JCS by default (base64urlnopad encoding)', () => {
     const result = canonicalHash(simpleObject);
     const again = canonicalHash(simpleObject);
     expect(result).to.equal(again);
@@ -50,8 +50,8 @@ describe('canonicalization', () => {
     expect(base58).to.equal('5X7XVwWA1NrC4JcuT7teDrhYpVQNA9LhHR3s2Ci6XUWz');
   });
 
-  it('supports base64url encoding', () => {
-    const base64url = canonicalHash(simpleObject, { encoding: 'base64url' });
+  it('supports base64urlnopad encoding', () => {
+    const base64url = canonicalHash(simpleObject, { encoding: 'base64urlnopad' });
     expect(base64url).to.equal('QyWM_3g_5wNtikMDP4MK38YOwDc4JHNUisdCuIgpJ3c');
   });
 
@@ -82,8 +82,8 @@ describe('canonicalization', () => {
     expect(result).to.equal('8ADWw43bTgn9z3n7NjuzrM1GfJa1aNCaaK4RJpwe3sCK');
   });
 
-  it('produces a base64url encoded SHA-256 hash of a canonicalized object', () => {
-    const result = encode(hash(canonicalComplexObject), 'base64url');
+  it('produces a base64urlnopad encoded SHA-256 hash of a canonicalized object', () => {
+    const result = encode(hash(canonicalComplexObject), 'base64urlnopad');
     expect(result).to.equal('al4wDwZaZUH5zT3uwkukyu1tWio7IZ8W6TV0Wf-gGTg');
   });
 
@@ -96,8 +96,8 @@ describe('canonicalization', () => {
     expect(b58Encoded).to.equal('8ADWw43bTgn9z3n7NjuzrM1GfJa1aNCaaK4RJpwe3sCK');
     expect(decode(b58Encoded, 'base58')).to.deep.equal(hashComplexObject);
 
-    const b64urlEncoded = encode(hashComplexObject, 'base64url');
+    const b64urlEncoded = encode(hashComplexObject, 'base64urlnopad');
     expect(b64urlEncoded).to.equal('al4wDwZaZUH5zT3uwkukyu1tWio7IZ8W6TV0Wf-gGTg');
-    expect(decode(b64urlEncoded, 'base64url')).to.deep.equal(hashComplexObject);
+    expect(decode(b64urlEncoded, 'base64urlnopad')).to.deep.equal(hashComplexObject);
   });
 });

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.25.4",
+    "version": "0.26.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -57,8 +57,8 @@ export class CASBeacon extends Beacon {
     const did = this.service.id.split('#')[0];
 
     for(const signal of signals) {
-      // Decode signal bytes from hex and re-encode to base64url for sidecar lookup
-      const announcementHash = encode(decode(signal.signalBytes, 'hex'));
+      // Signal bytes are hex — matches hex-keyed sidecar maps directly
+      const announcementHash = signal.signalBytes;
 
       // Look up the CAS Announcement in sidecar casMap
       const casAnnouncement = sidecar.casMap.get(announcementHash);
@@ -74,12 +74,15 @@ export class CASBeacon extends Beacon {
       }
 
       // Look up this DID's update hash in the CAS Announcement
-      const updateHash = casAnnouncement[did];
+      // Announcement values are base64urlnopad per spec — convert to hex for map lookup
+      const updateHashEncoded = casAnnouncement[did];
 
       // If no entry for this DID, this announcement doesn't contain an update for us — skip
-      if(!updateHash) {
+      if(!updateHashEncoded) {
         continue;
       }
+
+      const updateHash = encode(decode(updateHashEncoded, 'base64urlnopad'), 'hex');
 
       // Look up the signed update in sidecar updateMap
       const signedUpdate = sidecar.updateMap.get(updateHash);

--- a/packages/method/src/core/beacon/singleton-beacon.ts
+++ b/packages/method/src/core/beacon/singleton-beacon.ts
@@ -1,6 +1,6 @@
 import type { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
 import type { KeyBytes } from '@did-btcr2/common';
-import { canonicalize, decode, encode, hash } from '@did-btcr2/common';
+import { canonicalize, hash } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -41,8 +41,8 @@ export class SingletonBeacon extends Beacon {
     const needs = new Array<DataNeed>();
 
     for(const signal of signals) {
-      // Decode signal bytes from hex and re-encode to base64url for sidecar lookup
-      const updateHash = encode(decode(signal.signalBytes, 'hex'));
+      // Signal bytes are hex — matches hex-keyed sidecar maps directly
+      const updateHash = signal.signalBytes;
 
       // Look up the signed update in sidecar updateMap
       const signedUpdate = sidecar.updateMap.get(updateHash);

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -1,6 +1,7 @@
 import { getNetwork } from '@did-btcr2/bitcoin';
 import {
   canonicalHash,
+  canonicalHashBytes,
   canonicalize,
   DateUtils,
   encode as encodeHash,
@@ -12,6 +13,7 @@ import {
   LATE_PUBLISHING_ERROR,
   ResolveError
 } from '@did-btcr2/common';
+import type { HashBytes } from '@did-btcr2/common';
 import type {
   SignedBTCR2Update,
   UnsignedBTCR2Update
@@ -32,6 +34,7 @@ import type { DidComponents} from './identifier.js';
 import { Identifier } from './identifier.js';
 import type { SMTProof } from './interfaces.js';
 import type { CASAnnouncement, Sidecar, SidecarData } from './types.js';
+import { equalBytes } from '@noble/curves/utils.js';
 
 /**
  * The response object for DID Resolution.
@@ -49,7 +52,7 @@ export interface DidResolutionResponse {
 /** The resolver needs a genesis document whose hash matches genesisHash. */
 export interface NeedGenesisDocument {
   readonly kind: 'NeedGenesisDocument';
-  /** Base64url-encoded SHA-256 hash from the DID identifier's genesisBytes. */
+  /** Hex-encoded SHA-256 hash from the DID identifier's genesisBytes. */
   readonly genesisHash: string;
 }
 
@@ -63,7 +66,7 @@ export interface NeedBeaconSignals {
 /** The resolver needs a CAS Announcement whose canonical hash matches announcementHash. */
 export interface NeedCASAnnouncement {
   readonly kind: 'NeedCASAnnouncement';
-  /** Base64url-encoded canonical hash of the CAS Announcement. */
+  /** Hex-encoded canonical hash of the CAS Announcement. */
   readonly announcementHash: string;
   /** The beacon service that produced this signal. */
   readonly beaconServiceId: string;
@@ -72,7 +75,7 @@ export interface NeedCASAnnouncement {
 /** The resolver needs a SignedBTCR2Update whose canonical hash matches updateHash. */
 export interface NeedSignedUpdate {
   readonly kind: 'NeedSignedUpdate';
-  /** Base64url-encoded canonical hash of the signed update. */
+  /** Hex-encoded canonical hash of the signed update. */
   readonly updateHash: string;
   /** The beacon service that produced this signal. */
   readonly beaconServiceId: string;
@@ -223,22 +226,22 @@ export class Resolver {
     didComponents: DidComponents,
     genesisDocument: object,
   ): DidDocument {
-    // Encode the genesis bytes from the did components
-    const genesisBytes = encodeHash(didComponents.genesisBytes);
+    // Canonicalize and sha256 hash the genesis document
+    const genesisDocumentHash = canonicalHashBytes(genesisDocument);
 
-    // Canonicalize and sha256 hash the currentDocument
-    const genesisDocumentBytes = canonicalHash(genesisDocument);
-
-    // If the genesisBytes do not match the hashBytes, throw an error
-    if (genesisBytes !== genesisDocumentBytes) {
+    // Compare genesis bytes from identifier against the document hash (byte comparison)
+    if (!equalBytes(didComponents.genesisBytes, genesisDocumentHash)) {
       throw new ResolveError(
-        `Initial document mismatch: genesisBytes !== genesisDocumentBytes`,
-        INVALID_DID_DOCUMENT, { genesisBytes, genesisDocumentBytes }
+        `Initial document mismatch: genesisBytes !== genesisDocumentHash`,
+        INVALID_DID_DOCUMENT, {
+          genesisBytes        : encodeHash(didComponents.genesisBytes, 'hex'),
+          genesisDocumentHash : encodeHash(genesisDocumentHash, 'hex')
+        }
       );
     }
 
     // Encode the did from the didComponents
-    const did = Identifier.encode(decodeHash(genesisBytes), didComponents);
+    const did = Identifier.encode(didComponents.genesisBytes, didComponents);
 
     // Replace the placeholder did with the did throughout the currentDocument.
     const currentDocument = JSON.parse(
@@ -259,14 +262,14 @@ export class Resolver {
     const updateMap = new Map<string, SignedBTCR2Update>();
     if(sidecar.updates?.length)
       for(const update of sidecar.updates) {
-        updateMap.set(canonicalHash(update), update);
+        updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
       }
 
     // CAS Announcements map
     const casMap = new Map<string, CASAnnouncement>();
     if(sidecar.casUpdates?.length)
       for(const update of sidecar.casUpdates) {
-        casMap.set(canonicalHash(update), update);
+        casMap.set(canonicalHash(update, { encoding: 'hex' }), update);
       }
 
     // SMT Proofs map
@@ -296,8 +299,8 @@ export class Resolver {
     // Start the version number being processed at 1
     let currentVersionId = 1;
 
-    // Initialize an empty array to hold the update hashes
-    const updateHashHistory: string[] = [];
+    // Initialize an empty array to hold the update hashes (raw bytes)
+    const updateHashHistory: HashBytes[] = [];
 
     // 1. Sort updates by targetVersionId (ascending), using blockheight as tie-breaker
     const updates = unsortedUpdates.sort(([upd0, blk0], [upd1, blk1]) =>
@@ -317,8 +320,8 @@ export class Resolver {
 
     // Iterate over each (update block) pair
     for(const [update, block] of updates) {
-      // Get the hash of the current document
-      const currentDocumentHash = canonicalHash(response.didDocument);
+      // Get the hash of the current document as raw bytes
+      const currentDocumentHash = canonicalHashBytes(response.didDocument);
 
       // Safely convert block.time to timestamp
       const blocktime = DateUtils.blocktimeToTimestamp(block.time);
@@ -348,12 +351,15 @@ export class Resolver {
 
       // If update.targetVersionId == currentVersionId + 1, apply the update
       else if (update.targetVersionId === currentVersionId + 1) {
-        // Check if update.sourceHash !== currentDocumentHash
-        if (update.sourceHash !== currentDocumentHash) {
-          // Raise an INVALID_DID_UPDATE error if they do not match
+        // Check if update.sourceHash !== currentDocumentHash (byte comparison)
+        const sourceHashBytes = decodeHash(update.sourceHash, 'base64urlnopad');
+        if (!equalBytes(sourceHashBytes, currentDocumentHash)) {
           throw new ResolveError(
             `Hash mismatch: update.sourceHash !== currentDocumentHash`,
-            INVALID_DID_UPDATE, { sourceHash: update.sourceHash, currentDocumentHash }
+            INVALID_DID_UPDATE, {
+              sourceHash          : update.sourceHash,
+              currentDocumentHash : encodeHash(currentDocumentHash, 'hex')
+            }
           );
         }
         // Apply the update to the currentDocument and set it in the response
@@ -361,8 +367,8 @@ export class Resolver {
 
         // Create unsigned_update by removing the proof property from update.
         const unsignedUpdate = JSONUtils.deleteKeys(update, ['proof']) as UnsignedBTCR2Update;
-        // Push the canonicalized unsigned update hash to the updateHashHistory
-        updateHashHistory.push(canonicalHash(unsignedUpdate));
+        // Push the canonicalized unsigned update hash bytes to the updateHashHistory
+        updateHashHistory.push(canonicalHashBytes(unsignedUpdate));
       }
 
       // If update.targetVersionId > currentVersionId + 1, throw LATE_PUBLISHING error
@@ -405,24 +411,27 @@ export class Resolver {
    * Implements subsection {@link https://dcdpr.github.io/did-btcr2/#confirm-duplicate-update | 7.2.f.1 Confirm Duplicate Update}.
    * This step confirms that an update with a lower-than-expected targetVersionId is a true duplicate.
    * @param {SignedBTCR2Update} update The BTCR2 Signed Update to confirm as a duplicate.
-   * @param {string[]} updateHashHistory The accumulated hash history for comparison.
+   * @param {HashBytes[]} updateHashHistory The accumulated hash history for comparison.
    * @returns {void} Does not return a value, but throws an error if the update is not a valid duplicate.
    */
-  private static confirmDuplicate(update: SignedBTCR2Update, updateHashHistory: string[]): void {
+  private static confirmDuplicate(update: SignedBTCR2Update, updateHashHistory: HashBytes[]): void {
     // Create unsigned_update by removing the proof property from update.
     const { proof: _, ...unsignedUpdate } = update;
 
-    // Hash unsignedUpdate with JSON Document Hashing algorithm
-    const unsignedUpdateHash = canonicalHash(unsignedUpdate);
+    // Hash unsignedUpdate with JSON Document Hashing algorithm (raw bytes)
+    const unsignedUpdateHash = canonicalHashBytes(unsignedUpdate);
 
     // Let historicalUpdateHash equal updateHashHistory[updateHashIndex].
     const historicalUpdateHash = updateHashHistory[update.targetVersionId - 2];
 
-    // Check if the updateHash matches the historical hash
-    if (updateHashHistory[update.targetVersionId - 2] !== unsignedUpdateHash) {
+    // Check if the updateHash matches the historical hash (byte comparison)
+    if (!equalBytes(historicalUpdateHash, unsignedUpdateHash)) {
       throw new ResolveError(
-        `Invalid duplicate: ${unsignedUpdateHash} does not match ${historicalUpdateHash}`,
-        LATE_PUBLISHING_ERROR, { unsignedUpdateHash, updateHashHistory }
+        `Invalid duplicate: unsigned update hash does not match historical hash`,
+        LATE_PUBLISHING_ERROR, {
+          unsignedUpdateHash : encodeHash(unsignedUpdateHash, 'hex'),
+          historicalHash     : encodeHash(historicalUpdateHash, 'hex')
+        }
       );
     }
   }
@@ -500,14 +509,14 @@ export class Resolver {
     // Verify that updatedDocument is conformant to DID Core v1.1.
     DidDocument.validate(updatedDocument);
 
-    // Canonicalize and hash the updatedDocument to get the currentDocumentHash.
-    const currentDocumentHash = canonicalHash(updatedDocument);
+    // Canonicalize and hash the updatedDocument to get the currentDocumentHash (raw bytes).
+    const currentDocumentHash = canonicalHashBytes(updatedDocument);
 
     // Prepare the update targetHash for comparison with currentDocumentHash.
-    const updateTargetHash = update.targetHash;
+    const updateTargetHash = decodeHash(update.targetHash);
 
     // Make sure the update.targetHash equals currentDocumentHash.
-    if (update.targetHash !== currentDocumentHash) {
+    if (!equalBytes(updateTargetHash, currentDocumentHash)) {
       // If they do not match, throw INVALID_DID_UPDATE error.
       throw new ResolveError(
         `Invalid update: update.targetHash !== currentDocumentHash`,
@@ -545,7 +554,7 @@ export class Resolver {
           }
 
           // Need genesis document from caller
-          const genesisHash = encodeHash(this.#didComponents.genesisBytes);
+          const genesisHash = encodeHash(this.#didComponents.genesisBytes, 'hex');
           return {
             status : 'action-required',
             needs  : [{ kind: 'NeedGenesisDocument', genesisHash }]
@@ -691,13 +700,13 @@ export class Resolver {
 
       case 'NeedCASAnnouncement': {
         const announcement = data as CASAnnouncement;
-        this.#sidecarData.casMap.set(canonicalHash(announcement), announcement);
+        this.#sidecarData.casMap.set(canonicalHash(announcement, { encoding: 'hex' }), announcement);
         break;
       }
 
       case 'NeedSignedUpdate': {
         const update = data as SignedBTCR2Update;
-        this.#sidecarData.updateMap.set(canonicalHash(update), update);
+        this.#sidecarData.updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
         break;
       }
     }

--- a/packages/method/src/core/types.ts
+++ b/packages/method/src/core/types.ts
@@ -57,10 +57,12 @@ export type Sidecar = {
 
 /**
  * The Sidecar data structure used for Singleton Beacons.
+ * Map keyed by hex-encoded canonical hash of the signed update.
  */
 export type SingletonBeaconSidecarData = Map<string, SignedBTCR2Update>;
 /**
  * The Sidecar data structure used for CAS Beacons.
+ * Map keyed by hex-encoded canonical hash of the CAS announcement.
  */
 export type CASBeaconSidecarData = Map<string, CASAnnouncement>;
 /**

--- a/packages/method/src/utils/appendix.ts
+++ b/packages/method/src/utils/appendix.ts
@@ -12,10 +12,6 @@ import { CID } from 'multiformats';
 import { create as createDigest } from 'multiformats/hashes/digest';
 import type { RootCapability } from '../core/interfaces.js';
 
-// helia and @helia/strings are ESM-only and depend on native modules (libp2p / node-datachannel).
-// Lazy-load them via dynamic import so this file can be bundled into CJS without pulling in the
-// native binaries at bundle time. Node supports `await import(esm)` from CJS at runtime.
-
 /**
  * Implements {@link https://dcdpr.github.io/did-btcr2/#appendix | 9. Appendix} methods.
  *
@@ -230,8 +226,3 @@ export class Appendix {
     return await node.get(cid, {});
   }
 }
-
-
-
-
-

--- a/packages/method/src/utils/did-document.ts
+++ b/packages/method/src/utils/did-document.ts
@@ -14,9 +14,9 @@ import {
 } from '@did-btcr2/common';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import type { DidDocument as W3CDidDocument, DidVerificationMethod as W3CDidVerificationMethod } from '@web5/dids';
+import { isDidService } from '@web5/dids/utils';
 import { payments } from 'bitcoinjs-lib';
 import type { BeaconService } from '../core/beacon/interfaces.js';
-import { BeaconUtils } from '../core/beacon/utils.js';
 import { Identifier } from '../core/identifier.js';
 import { Appendix } from './appendix.js';
 
@@ -344,7 +344,7 @@ export class DidDocument implements Btcr2DidDocument {
    * @returns {boolean} True if the services are valid.
    */
   private static isValidServices(service: unknown): boolean {
-    return Array.isArray(service) && service.every(BeaconUtils.isBeaconService);
+    return Array.isArray(service) && service.every(isDidService);
   }
 
   /**

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -103,8 +103,8 @@ describe('Resolver', () => {
 
       const need = state.needs[0] as NeedGenesisDocument;
       expect(need.kind).to.equal('NeedGenesisDocument');
-      // genesisHash should be base64url encoding of the genesis bytes
-      expect(need.genesisHash).to.equal(encode(genesisBytes));
+      // genesisHash should be hex encoding of the genesis bytes
+      expect(need.genesisHash).to.equal(encode(genesisBytes, 'hex'));
     });
 
     it('proceeds to NeedBeaconSignals after providing genesis document', () => {
@@ -280,9 +280,10 @@ describe('Resolver', () => {
 
       // Build a fake signed update and CAS announcement that reference each other
       const fakeUpdate = { '@context': ['test'], patch: [], targetHash: 'fake', targetVersionId: 2, sourceHash: 'fake' };
-      const updateHash = canonicalHash(fakeUpdate);
+      const updateHash = canonicalHash(fakeUpdate);        // base64urlnopad (stored in announcement per spec)
+      const updateHashHex = canonicalHash(fakeUpdate, { encoding: 'hex' }); // hex (for assertion, matches beacon output)
 
-      // CAS announcement maps DID → update hash
+      // CAS announcement maps DID → update hash (base64urlnopad per spec)
       const announcement = { [casDid]: updateHash };
       const announcementHashHex = canonicalHash(announcement, { encoding: 'hex' });
 
@@ -309,7 +310,7 @@ describe('Resolver', () => {
       expect(state.status).to.equal('action-required');
       if(state.status !== 'action-required') return;
       expect(state.needs[0].kind).to.equal('NeedSignedUpdate');
-      expect((state.needs[0] as NeedSignedUpdate).updateHash).to.equal(updateHash);
+      expect((state.needs[0] as NeedSignedUpdate).updateHash).to.equal(updateHashHex);
 
       // Provide the signed update — but since it's fake with wrong hashes,
       // we expect it to resolve to complete (update will be collected but


### PR DESCRIPTION
PACKAGE VERSIONS
* @did-btcr2/common@9.0.0
* @did-btcr2/method@0.26.0
* @did-btcr2/api@0.4.0
* @did-btcr2/cli@0.5.3

COMMON (BREAKING)
* Rename base64url encoding to base64urlnopad in CanonicalizationEncoding type
* Add canonicalHashBytes() — returns raw SHA-256 bytes without encoding
* Fix decode() to use base64urlnopad.decode() (was incorrectly using padded variant)
* Remove unused base64url (padded) import from @scure/base

METHOD (BREAKING)
* Switch all hash equality checks from string !== to equalBytes() on raw Uint8Array
* Re-enable sourceHash validation in Resolver.updates() using byte comparison
* Change sidecar map keys and DataNeed hashes from base64url to hex
* Eliminate encode(decode(signalBytes, hex)) round-trip in SingletonBeacon and CASBeacon
* Change updateHashHistory from string[] to HashBytes[]
* Replace hash(canonicalize()) calls with canonicalHashBytes()

API (BREAKING)
* Change CasApi.retrieve() to accept HashBytes instead of string
* Convert hex DataNeed hashes to bytes before passing to CAS executor
* Add decode import for hex→bytes conversion in resolver loop

CLI
* Bump version for transitive dependency updates