### PR TITLE
Lazy API construction, layered config, CAS HTTP gateway

### DIFF
--- a/packages/api/lib/test-ipfs-helia.ts
+++ b/packages/api/lib/test-ipfs-helia.ts
@@ -1,0 +1,70 @@
+/**
+ * One-off test: fetch raw bytes from an IPFS Helia node using the
+ * IpfsCasExecutor. Times the round-trip to measure latency.
+ *
+ * Usage: bun lib/test-ipfs-helia.ts
+ */
+import { decode as decodeHash } from '@did-btcr2/common';
+import { createHelia } from 'helia';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+import { sha256 } from 'multiformats/hashes/sha2';
+// Hash from a real did:btcr2 resolution failure — the signed update the
+// resolver needed but couldn't fetch without CAS.
+const hexHash = 'be822c3da87dfa89ccac1dd552c6f93281e74f3cda257734393b5041d0c0388a';
+
+// Convert hex hash to base64url (executor expects base64url)
+const hashBytes = decodeHash(hexHash, 'hex');
+const base64url = Buffer.from(hashBytes).toString('base64url');
+
+// Show the CID that will be requested
+const cid = CID.create(1, raw.code, createDigest(sha256.code, hashBytes));
+console.log(`Hex hash:   ${hexHash}`);
+console.log(`Base64url:  ${base64url}`);
+console.log(`CID:        ${cid.toString()}`);
+console.log();
+
+const TIMEOUT_MS = 30_000;
+
+const start = performance.now();
+console.log('Creating helia...');
+const helia = await createHelia();
+const heliaElapsed = performance.now() - start;
+console.log(`Helia ready in ${heliaElapsed.toFixed(0)}ms`);
+
+console.log(`Fetching (${TIMEOUT_MS / 1000}s timeout)...`);
+// blockstore.get() has no built-in timeout — it walks the DHT indefinitely.
+// Wrap with AbortSignal so it doesn't hang forever.
+let result: Uint8Array | null;
+try {
+  const fetchStart = performance.now();
+  const res = await helia.blockstore.get(cid, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+  result = res;
+  console.log(`Fetch completed in ${(performance.now() - fetchStart).toFixed(0)}ms`);
+} catch (err: any) {
+  if (err.name === 'AbortError' || err.name === 'TimeoutError') {
+    console.log(`Timed out after ${TIMEOUT_MS}ms — block not found on DHT`);
+  } else {
+    console.log(`Error: ${err.message}`);
+  }
+  result = null;
+}
+const elapsed = performance.now() - start;
+
+if (result) {
+  console.log(`Success:    ${result.byteLength} bytes in ${elapsed.toFixed(0)}ms`);
+  try {
+    const text = new TextDecoder().decode(result);
+    const parsed = JSON.parse(text);
+    console.log(`Parsed JSON:`);
+    console.log(JSON.stringify(parsed, null, 2));
+  } catch {
+    console.log(`Raw bytes (not JSON):`, result.slice(0, 64), '...');
+  }
+} else {
+  console.log(`Not found (null) after ${elapsed.toFixed(0)}ms => ${(elapsed / 1000).toFixed(3)}s`);
+}
+
+// Stop Helia so the process exits (libp2p keeps connections open)
+await helia.stop();

--- a/packages/api/lib/test-ipfs-http-gateway.ts
+++ b/packages/api/lib/test-ipfs-http-gateway.ts
@@ -1,0 +1,54 @@
+/**
+ * One-off test: fetch raw bytes from an IPFS HTTP gateway using the
+ * HttpGatewayCasExecutor. Times the round-trip to measure gateway latency.
+ *
+ * Usage: bun lib/test-ipfs-http-gateway.ts [gateway-url]
+ */
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { decode as decodeHash } from '@did-btcr2/common';
+import { HttpGatewayCasExecutor } from '../src/cas.js';
+
+const gateway = process.argv[2] ?? 'https://ipfs.io';
+
+// Hash from a real did:btcr2 resolution failure — the signed update the
+// resolver needed but couldn't fetch without CAS.
+const hexHash = 'be822c3da87dfa89ccac1dd552c6f93281e74f3cda257734393b5041d0c0388a';
+
+// Convert hex hash to base64url (executor expects base64url)
+const hashBytes = decodeHash(hexHash, 'hex');
+const base64url = Buffer.from(hashBytes).toString('base64url');
+
+// Show the CID that will be requested
+const cid = CID.create(1, raw.code, createDigest(sha256.code, hashBytes));
+console.log(`Gateway:    ${gateway}`);
+console.log(`Hex hash:   ${hexHash}`);
+console.log(`Base64url:  ${base64url}`);
+console.log(`CID:        ${cid.toString()}`);
+console.log(`URL:        ${gateway}/ipfs/${cid.toString()}?format=raw`);
+console.log();
+
+// Fetch via the executor
+const executor = new HttpGatewayCasExecutor(gateway);
+
+console.log('Fetching...');
+const start = performance.now();
+const result = await executor.retrieve(base64url);
+const elapsed = performance.now() - start;
+
+if (result) {
+  console.log(`Success:    ${result.byteLength} bytes in ${elapsed.toFixed(0)}ms`);
+  // Try to parse as JSON (CAS stores JCS-canonicalized JSON)
+  try {
+    const text = new TextDecoder().decode(result);
+    const parsed = JSON.parse(text);
+    console.log(`Parsed JSON:`);
+    console.log(JSON.stringify(parsed, null, 2));
+  } catch {
+    console.log(`Raw bytes (not JSON):`, result.slice(0, 64), '...');
+  }
+} else {
+  console.log(`Not found (null) after ${elapsed.toFixed(0)}ms => ${(elapsed / 1000).toFixed(3)}s`);
+}

--- a/packages/api/lib/tsconfig.json
+++ b/packages/api/lib/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.lib.json",
+  "include": ["./**/*.ts"]
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -6,7 +6,7 @@ import type { KeyIdentifier } from '@did-btcr2/kms';
 import type { Btcr2DidDocument, DidCreateOptions, ResolutionOptions } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 import { BitcoinApi } from './bitcoin.js';
-import { CasApi, type CasConfig } from './cas.js';
+import { CasApi, DEFAULT_CAS_GATEWAY, type CasConfig } from './cas.js';
 import { CryptoApi } from './crypto.js';
 import { DidApi } from './did.js';
 import { assertString, NOOP_LOGGER } from './helpers.js';
@@ -67,19 +67,16 @@ export class DidBtcr2Api {
 
   /**
    * CAS API sub-facade (lazily initialized).
-   * Only available when `cas` config was provided to the constructor.
-   * @throws {Error} If the instance has been disposed or no CAS config was provided.
+   *
+   * When no `cas` config was provided to the constructor, defaults to a
+   * read-only {@link HttpGatewayCasExecutor} backed by the public IPFS
+   * gateway (`https://ipfs.io`). Override via `createApi({ cas: { ... } })`.
+   * @throws {Error} If the instance has been disposed.
    */
   get cas(): CasApi {
     this.#assertNotDisposed();
     if (!this.#cas) {
-      if (!this.#casConfig) {
-        throw new Error(
-          'CAS not configured. Pass a cas config to createApi(), e.g.: '
-          + 'createApi({ cas: { helia: await createHelia() } })'
-        );
-      }
-      this.#cas = new CasApi(this.#casConfig);
+      this.#cas = new CasApi(this.#casConfig ?? { gateway: DEFAULT_CAS_GATEWAY });
     }
     return this.#cas;
   }
@@ -93,7 +90,7 @@ export class DidBtcr2Api {
     if (!this.#btcr2) {
       this.#btcr2 = new DidMethodApi(
         this.#btcConfig ? this.btc : undefined,
-        this.#casConfig ? this.cas : undefined,
+        this.cas,
         this.#log
       );
     }

--- a/packages/api/src/cas.ts
+++ b/packages/api/src/cas.ts
@@ -6,6 +6,9 @@ import * as raw from 'multiformats/codecs/raw';
 import { create as createDigest } from 'multiformats/hashes/digest';
 import { sha256 } from 'multiformats/hashes/sha2';
 
+/** Default IPFS HTTP gateway used for CAS reads when no CAS config is provided. */
+export const DEFAULT_CAS_GATEWAY = 'https://ipfs.io';
+
 /**
  * Executor interface for content-addressed storage.
  *
@@ -56,14 +59,69 @@ export class IpfsCasExecutor implements CasExecutor {
 }
 
 /**
+ * Read-only {@link CasExecutor} backed by an IPFS HTTP gateway.
+ *
+ * Converts the base64url SHA-256 hash to a CIDv1 (raw codec) and fetches
+ * the raw block via the
+ * {@link https://specs.ipfs.tech/http-gateways/trustless-gateway/ | Trustless Gateway}
+ * protocol.
+ *
+ * Publishing is not supported — use {@link IpfsCasExecutor} with a Helia
+ * instance for writes.
+ * @public
+ */
+export class HttpGatewayCasExecutor implements CasExecutor {
+  readonly #gatewayUrl: string;
+
+  constructor(gatewayUrl: string) {
+    this.#gatewayUrl = gatewayUrl.replace(/\/+$/, '');
+  }
+
+  async retrieve(hash: string): Promise<Uint8Array | null> {
+    const hashBytes = decodeHash(hash, 'base64urlnopad');
+    const cid = CID.create(1, raw.code, createDigest(sha256.code, hashBytes));
+    try {
+      const res = await fetch(`${this.#gatewayUrl}/ipfs/${cid.toString()}?format=raw`, {
+        headers : { Accept: 'application/vnd.ipld.raw' },
+      });
+      if (!res.ok) return null;
+      return new Uint8Array(await res.arrayBuffer());
+    } catch {
+      return null;
+    }
+  }
+
+  async publish(): Promise<string> {
+    throw new Error(
+      'HttpGatewayCasExecutor is read-only. '
+      + 'Publishing requires a full IPFS node (use IpfsCasExecutor with Helia).'
+    );
+  }
+}
+
+/** Default timeout (ms) for CAS operations. */
+export const DEFAULT_CAS_TIMEOUT_MS = 30_000;
+
+/**
  * Configuration for the CAS (Content-Addressed Storage) driver.
+ *
+ * Provide exactly one of `executor`, `helia`, or `gateway`.
+ * Priority if multiple are set: `executor` > `helia` > `gateway`.
  * @public
  */
 export type CasConfig = {
-  /** Custom executor implementation (overrides the default IPFS executor). */
+  /** Custom executor implementation (overrides all other options). */
   executor?: CasExecutor;
   /** Pre-existing Helia instance for the default IPFS executor. */
   helia?: Helia;
+  /** IPFS HTTP gateway URL for read-only CAS access (e.g. `'https://ipfs.io'`). */
+  gateway?: string;
+  /**
+   * Timeout in milliseconds for CAS operations. Prevents indefinite hangs
+   * when a Helia DHT lookup or gateway request stalls. Default: 30 000 ms.
+   * Set to `0` to disable.
+   */
+  timeoutMs?: number;
 };
 
 /**
@@ -81,18 +139,22 @@ export type CasConfig = {
  */
 export class CasApi {
   readonly #executor: CasExecutor;
+  readonly #timeoutMs: number;
 
   constructor(config: CasConfig) {
     if (config.executor) {
       this.#executor = config.executor;
     } else if (config.helia) {
       this.#executor = new IpfsCasExecutor(config.helia);
+    } else if (config.gateway) {
+      this.#executor = new HttpGatewayCasExecutor(config.gateway);
     } else {
       throw new Error(
-        'CAS configuration requires either an executor or a Helia instance. '
-        + 'Example: createApi({ cas: { helia: await createHelia() } })'
+        'CAS configuration requires an executor, Helia instance, or gateway URL. '
+        + 'Example: createApi({ cas: { gateway: \'https://ipfs.io\' } })'
       );
     }
+    this.#timeoutMs = config.timeoutMs ?? DEFAULT_CAS_TIMEOUT_MS;
   }
 
   /**
@@ -102,7 +164,7 @@ export class CasApi {
    */
   async retrieve(hashBytes: HashBytes): Promise<object | null> {
     const hash = encodeHash(hashBytes, 'base64urlnopad');
-    const bytes = await this.#executor.retrieve(hash);
+    const bytes = await this.#withTimeout(this.#executor.retrieve(hash));
     if (!bytes) return null;
     return JSON.parse(new TextDecoder().decode(bytes)) as object;
   }
@@ -116,6 +178,23 @@ export class CasApi {
    */
   async publish(object: object): Promise<string> {
     const bytes = new TextEncoder().encode(canonicalize(object as Record<string, any>));
-    return await this.#executor.publish(bytes);
+    return await this.#withTimeout(this.#executor.publish(bytes));
+  }
+
+  /**
+   * Wraps a promise with a timeout. If `#timeoutMs` is 0, no timeout is applied.
+   */
+  #withTimeout<T>(promise: Promise<T>): Promise<T> {
+    if (!this.#timeoutMs) return promise;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`CAS operation timed out after ${this.#timeoutMs}ms`)),
+        this.#timeoutMs
+      );
+      promise.then(
+        (val) => { clearTimeout(timer); resolve(val); },
+        (err) => { clearTimeout(timer); reject(err); },
+      );
+    });
   }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -7,7 +7,6 @@ import type { CasConfig } from './cas.js';
 /**
  * Pluggable logger interface. All methods are optional-call; the default
  * implementation is a silent no-op.
- * @public
  */
 export type Logger = {
   debug(message: string, ...args: unknown[]): void;
@@ -23,7 +22,6 @@ export type Logger = {
  * than a union. This local alias provides compile-time safety at the API
  * facade level. Upstream runtime validation in `Identifier.encode()` still
  * catches invalid values.
- * @public
  */
 export type IdType = 'KEY' | 'EXTERNAL';
 
@@ -38,13 +36,11 @@ export type IdType = 'KEY' | 'EXTERNAL';
  * api.resolveDid(did); // OK
  * api.btc.getTransaction(did); // Type error — DidString is not TxId
  * ```
- * @public
  */
 export type DidString = string & { readonly __brand: 'DidString' };
 
 /**
  * A branded string representing a Bitcoin transaction ID (64-char hex).
- * @public
  */
 export type TxId = string & { readonly __brand: 'TxId' };
 
@@ -62,7 +58,6 @@ export type TxId = string & { readonly __brand: 'TxId' };
  *   console.log(result.error, result.errorMessage);
  * }
  * ```
- * @public
  */
 export type ResolutionResult =
   | { ok: true;  document: Btcr2DidDocument; metadata: DidResolutionResult['didDocumentMetadata']; raw: DidResolutionResult }
@@ -85,7 +80,6 @@ export type ResolutionResult =
  * // Use regtest with custom RPC credentials, default REST
  * { network: 'regtest', rpc: { host: 'http://mynode:18443', username: 'u', password: 'p' } }
  * ```
- * @public
  */
 export type BitcoinApiConfig = {
   /** Bitcoin network name (e.g., 'regtest', 'testnet4', 'bitcoin'). */
@@ -111,7 +105,6 @@ export type BitcoinApiConfig = {
 
 /**
  * Top-level API configuration options.
- * @public
  */
 export type ApiConfig = {
   btc?: BitcoinApiConfig;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,138 @@
-# CLI
+# @did-btcr2/cli
 
-Command Line Interface (CLI) for interacting with did:btcr2 method.
+Command-line interface for the [did:btcr2](https://dcdpr.github.io/did-btcr2/) DID method.
+
+Part of the [`did-btcr2-js`](https://github.com/dcdpr/did-btcr2-js) monorepo.
+
+## Summary
+
+This package provides the `btcr2` CLI for creating, resolving, updating, and deactivating did:btcr2 decentralized identifiers. It wraps the `@did-btcr2/api` SDK via dependency injection, using [commander.js](https://github.com/tj/commander.js/) for argument parsing.
+
+Out of the box, `btcr2 resolve` works with zero configuration. The Bitcoin network is derived from the DID itself, and public endpoints (mempool.space, ipfs.io) are used as defaults. Override endpoints via CLI flags, environment variables, or a config file.
+
+## Install
+
+```bash
+npm install -g @did-btcr2/cli
+```
+
+Or with pnpm:
+
+```bash
+pnpm add -g @did-btcr2/cli
+```
+
+Requires Node.js >= 22.
+
+## Usage
+
+### Create a DID
+
+```bash
+# Deterministic (type=k) — from a compressed secp256k1 public key (33 bytes hex)
+btcr2 create -t k -n regtest -b 02aa...
+
+# External (type=x) — from a SHA-256 hash of a genesis document (32 bytes hex)
+btcr2 create -t x -n bitcoin -b bb...
+```
+
+### Resolve a DID
+
+```bash
+# Zero-config — network and endpoints are derived from the DID
+btcr2 resolve -i did:btcr2:k1qq...
+
+# With resolution options from a JSON file
+btcr2 resolve -i did:btcr2:k1qq... -p resolution-options.json
+
+# JSON output
+btcr2 -o json resolve -i did:btcr2:k1qq...
+```
+
+### Update a DID
+
+```bash
+btcr2 update \
+  -s '{"id":"did:btcr2:k1qq...","service":[...]}' \
+  --source-version-id 1 \
+  -p '[{"op":"add","path":"/service/1","value":{...}}]' \
+  -m '#initialKey' \
+  -b '#beacon-0'
+```
+
+### Deactivate a DID
+
+```bash
+btcr2 deactivate \
+  -s '{"id":"did:btcr2:k1qq...","service":[...]}' \
+  --source-version-id 2 \
+  -m '#initialKey' \
+  -b '#beacon-0'
+```
+
+## Configuration
+
+Override precedence (highest wins): CLI flags > environment variables > config file > network defaults.
+
+### CLI flags
+
+| Flag | Description |
+|---|---|
+| `-o, --output <format>` | Output format: `json` or `text` (default: `text`) |
+| `-c, --config <path>` | Path to config file |
+| `--profile <name>` | Config profile name (default: auto-detected from network) |
+| `--btc-rest <url>` | Override Bitcoin REST endpoint (Esplora API) |
+| `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
+| `--btc-rpc-user <user>` | Bitcoin Core RPC username |
+| `--btc-rpc-pass <pass>` | Bitcoin Core RPC password |
+| `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads |
+
+### Environment variables
+
+| Variable | Equivalent flag |
+|---|---|
+| `BTCR2_BTC_REST` | `--btc-rest` |
+| `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
+| `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
+| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` |
+| `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
+
+### Config file
+
+Default location: `$XDG_CONFIG_HOME/btcr2/config.json` (falls back to `~/.config/btcr2/config.json`).
+
+Profiles are matched by network name when `--profile` is not specified. For example, resolving a regtest DID automatically selects the `"regtest"` profile.
+
+```json
+{
+  "profiles": {
+    "regtest": {
+      "btc": {
+        "rest": "http://localhost:3000",
+        "rpcUrl": "http://localhost:18443",
+        "rpcUser": "polaruser",
+        "rpcPass": "polarpass"
+      }
+    },
+    "bitcoin": {
+      "btc": { "rest": "https://my-mempool/api" },
+      "cas": { "gateway": "https://ipfs.io" }
+    }
+  }
+}
+```
+
+### Defaults
+
+When no overrides are configured:
+
+- **Bitcoin REST**: [mempool.space](https://mempool.space) for public networks, `localhost:3000` for regtest
+- **Bitcoin RPC**: `localhost:18443` for regtest (credentials required), not configured for public networks
+- **CAS**: [ipfs.io](https://ipfs.io) HTTP gateway (read-only)
+
+## Links
+
+- [did:btcr2 specification](https://dcdpr.github.io/did-btcr2/)
+- [did-btcr2-js monorepo](https://github.com/dcdpr/did-btcr2-js)
+- [npm: @did-btcr2/cli](https://www.npmjs.com/package/@did-btcr2/cli)
+- [Implementation docs](https://btcr2.dev/impls/ts)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,12 +1,11 @@
 import { Command, CommanderError } from 'commander';
-import type { DidBtcr2Api} from '@did-btcr2/api';
-import { createApi } from '@did-btcr2/api';
 import {
   registerCreateCommand,
   registerDeactivateCommand,
   registerResolveCommand,
   registerUpdateCommand,
 } from './commands/index.js';
+import { defaultApiFactory, type ApiFactory } from './config.js';
 import { CLIError } from './error.js';
 import type { GlobalOptions } from './types.js';
 import { VERSION } from './version.js';
@@ -16,27 +15,38 @@ import { VERSION } from './version.js';
  */
 export class DidBtcr2Cli {
   public readonly program: Command;
-  private readonly api: DidBtcr2Api;
 
   /**
-   * Initializes the CLI with an optional pre-configured API instance.
-   * @param {DidBtcr2Api} api - Optional API instance. Defaults to an unconfigured instance.
+   * Initializes the CLI with an optional API factory.
+   *
+   * The factory is called lazily by each command with the appropriate
+   * network derived from the DID being operated on. Defaults to
+   * {@link defaultApiFactory} which uses public endpoints (mempool.space)
+   * for known networks and localhost Polar for regtest.
+   *
+   * @param factory - Optional API factory. Defaults to {@link defaultApiFactory}.
    */
-  constructor(api: DidBtcr2Api = createApi({ btc: { network: 'mutinynet' } })) {
-    this.api = api;
+  constructor(factory: ApiFactory = defaultApiFactory) {
     this.program = new Command('btcr2')
       .version(`btcr2 ${VERSION}`, '-v, --version', 'Output the current version')
       .description('CLI tool for the did:btcr2 method')
       .option('-o, --output <format>', 'Output format <json|text>', 'text')
       .option('--verbose', 'Verbose output', false)
-      .option('--quiet', 'Suppress non-essential output', false);
+      .option('--quiet', 'Suppress non-essential output', false)
+      .option('-c, --config <path>', 'Path to config file (default: $XDG_CONFIG_HOME/btcr2/config.json)')
+      .option('--profile <name>', 'Config profile name (default: auto-detected from network)')
+      .option('--btc-rest <url>', 'Override Bitcoin REST endpoint (Esplora API)')
+      .option('--btc-rpc-url <url>', 'Override Bitcoin Core RPC endpoint')
+      .option('--btc-rpc-user <user>', 'Bitcoin Core RPC username')
+      .option('--btc-rpc-pass <pass>', 'Bitcoin Core RPC password')
+      .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads');
 
     const globals = (): GlobalOptions => this.program.opts() as GlobalOptions;
 
-    registerCreateCommand(this.program, this.api, globals);
-    registerResolveCommand(this.program, this.api, globals);
-    registerUpdateCommand(this.program, this.api, globals);
-    registerDeactivateCommand(this.program, this.api, globals);
+    registerCreateCommand(this.program, factory, globals);
+    registerResolveCommand(this.program, factory, globals);
+    registerUpdateCommand(this.program, factory, globals);
+    registerDeactivateCommand(this.program, factory, globals);
   }
 
   /**

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,5 +1,5 @@
-import type { DidBtcr2Api } from '@did-btcr2/api';
 import type { Command } from 'commander';
+import type { ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { formatResult } from '../output.js';
 import type {
@@ -18,7 +18,7 @@ const EXPECTED_BYTES: Record<'k' | 'x', { length: number; label: string }> = {
 
 export function registerCreateCommand(
   program : Command,
-  api     : DidBtcr2Api,
+  factory : ApiFactory,
   globals : () => GlobalOptions,
 ): void {
   program
@@ -37,6 +37,7 @@ export function registerCreateCommand(
     )
     .action(async (options: { type: string; network: string; bytes: string }) => {
       const parsed = validateCreateOptions(options);
+      const api = factory();
       const type = parsed.type === 'k' ? 'deterministic' : 'external';
       const genesisBytes = Buffer.from(parsed.bytes, 'hex');
       const data = api.createDid(type, genesisBytes, { network: parsed.network });

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -1,5 +1,5 @@
-import type { DidBtcr2Api } from '@did-btcr2/api';
 import type { Command } from 'commander';
+import { deriveNetwork, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { formatResult } from '../output.js';
 import type { GlobalOptions, UpdateCommandOptions } from '../types.js';
@@ -9,7 +9,7 @@ const DEACTIVATION_PATCH = [{ op: 'add' as const, path: '/deactivated', value: t
 
 export function registerDeactivateCommand(
   program : Command,
-  api     : DidBtcr2Api,
+  factory : ApiFactory,
   globals : () => GlobalOptions,
 ): void {
   program
@@ -47,6 +47,16 @@ export function registerDeactivateCommand(
         verificationMethodId : options.verificationMethodId,
         beaconId             : options.beaconId as UpdateCommandOptions['beaconId'],
       };
+      const did = parsed.sourceDocument?.id;
+      if (!did) {
+        throw new CLIError(
+          'Source document must contain an "id" field.',
+          'INVALID_ARGUMENT_ERROR',
+          options
+        );
+      }
+      const network = deriveNetwork(did);
+      const api = factory(network, globals());
       const data = await api.btcr2.update(parsed);
       const result = { action: 'deactivate' as const, data };
       console.log(formatResult(result, globals()));

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -1,14 +1,14 @@
-import type { DidBtcr2Api } from '@did-btcr2/api';
 import { Identifier } from '@did-btcr2/api';
 import type { Command } from 'commander';
 import { readFile } from 'node:fs/promises';
+import { deriveNetwork, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { formatResult } from '../output.js';
 import type { GlobalOptions, ResolveCommandOptions } from '../types.js';
 
 export function registerResolveCommand(
   program : Command,
-  api     : DidBtcr2Api,
+  factory : ApiFactory,
   globals : () => GlobalOptions,
 ): void {
   program
@@ -23,9 +23,9 @@ export function registerResolveCommand(
       resolutionOptions?: string;
       resolutionOptionsPath?: string;
     }) => {
-      console.log('resolve command options prevalidation', options);
       const parsed = await validateResolveOptions(options);
-      console.log('resolve command options postvalidation', options);
+      const network = deriveNetwork(parsed.identifier);
+      const api = factory(network, globals());
       const data = await api.resolveDid(parsed.identifier, parsed.options);
       const result = { action: 'resolve' as const, data };
       console.log(formatResult(result, globals()));

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,12 +1,12 @@
-import type { DidBtcr2Api } from '@did-btcr2/api';
 import type { Command } from 'commander';
+import { deriveNetwork, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { formatResult } from '../output.js';
 import type { GlobalOptions, UpdateCommandOptions } from '../types.js';
 
 export function registerUpdateCommand(
   program : Command,
-  api     : DidBtcr2Api,
+  factory : ApiFactory,
   globals : () => GlobalOptions,
 ): void {
   program
@@ -49,6 +49,16 @@ export function registerUpdateCommand(
         verificationMethodId : options.verificationMethodId,
         beaconId             : options.beaconId as UpdateCommandOptions['beaconId'],
       };
+      const did = parsed.sourceDocument?.id;
+      if (!did) {
+        throw new CLIError(
+          'Source document must contain an "id" field.',
+          'INVALID_ARGUMENT_ERROR',
+          options
+        );
+      }
+      const network = deriveNetwork(did);
+      const api = factory(network, globals());
       const data = await api.btcr2.update(parsed);
       const result = { action: 'update' as const, data };
       console.log(formatResult(result, globals()));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,226 @@
+import { createApi, Identifier, type BitcoinApiConfig, type DidBtcr2Api } from '@did-btcr2/api';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { CLIError } from './error.js';
+import { SUPPORTED_NETWORKS, type NetworkOption } from './types.js';
+
+/**
+ * Endpoint overrides provided via CLI flags, env vars, or config file.
+ * These override the per-network defaults from
+ * `DEFAULT_BITCOIN_NETWORK_CONFIG`.
+ *
+ * `config` and `profile` control config-file resolution and are only
+ * meaningful when passed through the full merge chain.
+ */
+export type ConnectionOverrides = {
+  btcRest?   : string;
+  btcRpcUrl? : string;
+  btcRpcUser?: string;
+  btcRpcPass?: string;
+  casGateway?: string;
+  config?    : string;
+  profile?   : string;
+};
+
+/**
+ * On-disk config file schema.
+ *
+ * @example
+ * ```json
+ * {
+ *   "profiles": {
+ *     "regtest": {
+ *       "btc": {
+ *         "rest": "http://localhost:3000",
+ *         "rpcUrl": "http://localhost:18443",
+ *         "rpcUser": "polaruser",
+ *         "rpcPass": "polarpass"
+ *       }
+ *     },
+ *     "bitcoin": {
+ *       "btc": { "rest": "https://my-mempool/api" },
+ *       "cas": { "gateway": "https://ipfs.io" }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type ConfigFile = {
+  profiles?: Record<string, {
+    btc?: {
+      rest?    : string;
+      rpcUrl?  : string;
+      rpcUser? : string;
+      rpcPass? : string;
+    };
+    cas?: {
+      gateway?: string;
+    };
+  }>;
+};
+
+/**
+ * Factory function that creates a configured {@link DidBtcr2Api} instance.
+ *
+ * When `network` is provided, the returned API is wired to that network's
+ * default Bitcoin endpoints (mempool.space for public networks, localhost
+ * Polar for regtest). Optional `overrides` let callers replace individual
+ * endpoints on top of the defaults. When `network` is omitted, no Bitcoin
+ * or CAS is configured — suitable for offline operations like `create`.
+ */
+export type ApiFactory = (network?: NetworkOption, overrides?: ConnectionOverrides) => DidBtcr2Api;
+
+/**
+ * Environment variable names consulted by {@link defaultApiFactory}.
+ *
+ * | Variable              | Equivalent flag    |
+ * |-----------------------|--------------------|
+ * | `BTCR2_BTC_REST`      | `--btc-rest`       |
+ * | `BTCR2_BTC_RPC_URL`   | `--btc-rpc-url`    |
+ * | `BTCR2_BTC_RPC_USER`  | `--btc-rpc-user`   |
+ * | `BTCR2_BTC_RPC_PASS`  | `--btc-rpc-pass`   |
+ * | `BTCR2_CAS_GATEWAY`   | `--cas-gateway`    |
+ */
+export const ENV_VARS = {
+  BTC_REST     : 'BTCR2_BTC_REST',
+  BTC_RPC_URL  : 'BTCR2_BTC_RPC_URL',
+  BTC_RPC_USER : 'BTCR2_BTC_RPC_USER',
+  BTC_RPC_PASS : 'BTCR2_BTC_RPC_PASS',
+  CAS_GATEWAY  : 'BTCR2_CAS_GATEWAY',
+} as const;
+
+/**
+ * Reads {@link ConnectionOverrides} from environment variables.
+ * Only defined (non-empty) values are included.
+ */
+export function readEnvOverrides(): ConnectionOverrides {
+  const env = (key: string): string | undefined => process.env[key] || undefined;
+  return {
+    btcRest    : env(ENV_VARS.BTC_REST),
+    btcRpcUrl  : env(ENV_VARS.BTC_RPC_URL),
+    btcRpcUser : env(ENV_VARS.BTC_RPC_USER),
+    btcRpcPass : env(ENV_VARS.BTC_RPC_PASS),
+    casGateway : env(ENV_VARS.CAS_GATEWAY),
+  };
+}
+
+/**
+ * Default config file path following the XDG Base Directory Specification.
+ *
+ * Resolution order:
+ * 1. `$XDG_CONFIG_HOME/btcr2/config.json`
+ * 2. `%APPDATA%/btcr2/config.json` (Windows)
+ * 3. `~/.config/btcr2/config.json` (fallback)
+ */
+export function defaultConfigPath(): string {
+  const base = process.env.XDG_CONFIG_HOME
+    ?? process.env.APPDATA
+    ?? join(homedir(), '.config');
+  return join(base, 'btcr2', 'config.json');
+}
+
+/**
+ * Reads and parses a config file. Returns `undefined` if the file does
+ * not exist or cannot be parsed.
+ */
+export function readConfigFile(path: string): ConfigFile | undefined {
+  try {
+    const content = readFileSync(path, 'utf-8');
+    return JSON.parse(content) as ConfigFile;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extracts {@link ConnectionOverrides} from a named profile in a
+ * {@link ConfigFile}. Returns an empty object if the profile does not exist.
+ */
+export function profileToOverrides(
+  config      : ConfigFile,
+  profileName : string,
+): ConnectionOverrides {
+  const profile = config.profiles?.[profileName];
+  if (!profile) return {};
+  return {
+    btcRest    : profile.btc?.rest,
+    btcRpcUrl  : profile.btc?.rpcUrl,
+    btcRpcUser : profile.btc?.rpcUser,
+    btcRpcPass : profile.btc?.rpcPass,
+    casGateway : profile.cas?.gateway,
+  };
+}
+
+/**
+ * Default {@link ApiFactory} backed by network defaults from
+ * `@did-btcr2/bitcoin` (mempool.space for public networks, localhost for
+ * regtest).
+ *
+ * Override precedence (highest wins):
+ * CLI flags → env vars → config file profile → network defaults.
+ *
+ * When no `--profile` is given, the network name is used as the profile
+ * key (e.g. a regtest DID auto-selects the `"regtest"` profile).
+ */
+export function defaultApiFactory(network?: NetworkOption, overrides?: ConnectionOverrides): DidBtcr2Api {
+  if (!network) return createApi();
+
+  // Layer 1: Config file profile (lowest precedence of the three override layers)
+  const configPath = overrides?.config ?? defaultConfigPath();
+  const profileName = overrides?.profile ?? network;
+  const file = readConfigFile(configPath);
+  const fileOverrides = file ? profileToOverrides(file, profileName) : {};
+
+  // Layer 2: Environment variables
+  const env = readEnvOverrides();
+
+  // Merge: CLI flags → env vars → config file → (network defaults handled by BitcoinConnection)
+  const merged: ConnectionOverrides = {
+    btcRest    : overrides?.btcRest    ?? env.btcRest    ?? fileOverrides.btcRest,
+    btcRpcUrl  : overrides?.btcRpcUrl  ?? env.btcRpcUrl  ?? fileOverrides.btcRpcUrl,
+    btcRpcUser : overrides?.btcRpcUser ?? env.btcRpcUser ?? fileOverrides.btcRpcUser,
+    btcRpcPass : overrides?.btcRpcPass ?? env.btcRpcPass ?? fileOverrides.btcRpcPass,
+    casGateway : overrides?.casGateway ?? env.casGateway ?? fileOverrides.casGateway,
+  };
+
+  const btc: BitcoinApiConfig = { network };
+
+  if (merged.btcRest) {
+    btc.rest = { host: merged.btcRest };
+  }
+
+  if (merged.btcRpcUrl) {
+    btc.rpc = {
+      host     : merged.btcRpcUrl,
+      username : merged.btcRpcUser,
+      password : merged.btcRpcPass,
+    };
+  }
+
+  const cas = merged.casGateway ? { gateway: merged.casGateway } : undefined;
+
+  return createApi({ btc, ...(cas && { cas }) });
+}
+
+/**
+ * Extracts and validates the Bitcoin network from a DID string.
+ *
+ * Decodes the DID via {@link Identifier.decode}, then checks that the
+ * embedded network is one of the supported values.
+ *
+ * @param did A `did:btcr2:...` identifier string.
+ * @returns The validated {@link NetworkOption}.
+ * @throws {CLIError} If the network is unsupported.
+ */
+export function deriveNetwork(did: string): NetworkOption {
+  const { network } = Identifier.decode(did);
+  if (!SUPPORTED_NETWORKS.includes(network as NetworkOption)) {
+    throw new CLIError(
+      `Unsupported network "${network}" in DID.`,
+      'INVALID_ARGUMENT_ERROR',
+      { did, network }
+    );
+  }
+  return network as NetworkOption;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 export * from './cli.js';
 export * from './commands/index.js';
+export * from './config.js';
 export * from './error.js';
 export * from './output.js';
 export * from './types.js';

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -36,7 +36,14 @@ export type CommandResult =
   | { action: 'deactivate'; data: SignedBTCR2Update };
 
 export interface GlobalOptions {
-  output  : OutputFormat;
-  verbose : boolean;
-  quiet   : boolean;
+  output     : OutputFormat;
+  verbose    : boolean;
+  quiet      : boolean;
+  config?    : string;
+  profile?   : string;
+  btcRest?   : string;
+  btcRpcUrl? : string;
+  btcRpcUser?: string;
+  btcRpcPass?: string;
+  casGateway?: string;
 }

--- a/packages/cli/tests/cli-helpers.spec.ts
+++ b/packages/cli/tests/cli-helpers.spec.ts
@@ -1,5 +1,7 @@
+import { createApi } from '@did-btcr2/api';
 import { DidBtcr2Cli } from '../src/cli.js';
-import { createTestApi, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
+import type { ApiFactory, ConnectionOverrides } from '../src/config.js';
+import { createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
 
 describe('CLI Helpers', () => {
   afterEach(() => {
@@ -9,7 +11,7 @@ describe('CLI Helpers', () => {
   });
 
   it('shows help when no command is provided', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const program = cli.program;
     program.exitOverride();
 
@@ -21,7 +23,7 @@ describe('CLI Helpers', () => {
   });
 
   it('handles --help silently', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const program = cli.program;
     program.exitOverride();
 
@@ -33,7 +35,7 @@ describe('CLI Helpers', () => {
   });
 
   it('handles errors by printing message and setting exitCode', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const errors: any[] = [];
     console.error = (...args: any[]) => errors.push(args[0]);
 
@@ -46,7 +48,7 @@ describe('CLI Helpers', () => {
   });
 
   it('normalizes empty argv', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const program = cli.program;
     program.exitOverride();
 
@@ -58,7 +60,7 @@ describe('CLI Helpers', () => {
   });
 
   it('normalizes single-element argv', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const program = cli.program;
     program.exitOverride();
 
@@ -70,7 +72,7 @@ describe('CLI Helpers', () => {
   });
 
   it('outputs JSON format when --output json is used', async () => {
-    const cli = new DidBtcr2Cli(createTestApi());
+    const cli = new DidBtcr2Cli(createTestApiFactory());
     const messages: string[] = [];
     console.log = (msg?: any) => { if (msg !== undefined) messages.push(String(msg)); };
 
@@ -81,5 +83,50 @@ describe('CLI Helpers', () => {
     const parsed = JSON.parse(messages[0]);
     expect(parsed.action).to.equal('create');
     expect(parsed.data).to.include('did:btcr2:');
+  });
+
+  it('passes --btc-rest override to factory on resolve', async () => {
+    let capturedNetwork: string | undefined;
+    let capturedOverrides: ConnectionOverrides | undefined;
+    const spy: ApiFactory = (network, overrides) => {
+      capturedNetwork = network;
+      capturedOverrides = overrides;
+      return createApi(); // unconfigured — resolve will fail, that's OK
+    };
+    const cli = new DidBtcr2Cli(spy);
+    console.error = () => {}; // suppress error output from expected failure
+
+    const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+    await cli.run([
+      'node', 'btcr2',
+      '--btc-rest', 'http://custom:3000',
+      'resolve', '-i', validDid,
+    ]);
+
+    expect(capturedNetwork).to.be.a('string');
+    expect(capturedOverrides?.btcRest).to.equal('http://custom:3000');
+  });
+
+  it('passes --btc-rpc-* overrides to factory on resolve', async () => {
+    let capturedOverrides: ConnectionOverrides | undefined;
+    const spy: ApiFactory = (_network, overrides) => {
+      capturedOverrides = overrides;
+      return createApi();
+    };
+    const cli = new DidBtcr2Cli(spy);
+    console.error = () => {};
+
+    const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+    await cli.run([
+      'node', 'btcr2',
+      '--btc-rpc-url', 'http://node:18443',
+      '--btc-rpc-user', 'alice',
+      '--btc-rpc-pass', 'secret',
+      'resolve', '-i', validDid,
+    ]);
+
+    expect(capturedOverrides?.btcRpcUrl).to.equal('http://node:18443');
+    expect(capturedOverrides?.btcRpcUser).to.equal('alice');
+    expect(capturedOverrides?.btcRpcPass).to.equal('secret');
   });
 });

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
 import { CLIError } from '../src/error.js';
-import { createTestApi, expect, originalConsoleLog } from './helpers.js';
+import { createTestApiFactory, expect, originalConsoleLog } from './helpers.js';
 
 function getSubcommand(cli: DidBtcr2Cli, name: string): Command {
   const command = cli.program.commands.find((cmd: Command) => cmd.name() === name);
@@ -19,7 +19,7 @@ describe('DidBtcr2Cli', () => {
 
   describe('create', () => {
     it('rejects invalid type', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const create = getSubcommand(cli, 'create');
       await expect(
         create.parseAsync(['-t', 'z', '-n', 'bitcoin', '-b', 'aa'.repeat(33)], { from: 'user' })
@@ -27,7 +27,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects invalid network', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const create = getSubcommand(cli, 'create');
       await expect(
         create.parseAsync(['-t', 'k', '-n', 'not-a-network', '-b', 'aa'.repeat(33)], { from: 'user' })
@@ -35,7 +35,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects empty bytes', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const create = getSubcommand(cli, 'create');
       await expect(
         create.parseAsync(['-t', 'k', '-n', 'bitcoin', '-b', ''], { from: 'user' })
@@ -43,7 +43,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects wrong byte length for type=k', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const create = getSubcommand(cli, 'create');
       await expect(
         create.parseAsync(['-t', 'k', '-n', 'bitcoin', '-b', 'aa'], { from: 'user' })
@@ -51,7 +51,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects wrong byte length for type=x', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const create = getSubcommand(cli, 'create');
       await expect(
         create.parseAsync(['-t', 'x', '-n', 'bitcoin', '-b', 'aa'.repeat(33)], { from: 'user' })
@@ -59,7 +59,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('creates a deterministic DID with valid input', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const messages: string[] = [];
       console.log = (msg?: any) => { if (msg !== undefined) messages.push(String(msg)); };
 
@@ -71,7 +71,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('creates an external DID with valid input', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const messages: string[] = [];
       console.log = (msg?: any) => { if (msg !== undefined) messages.push(String(msg)); };
 
@@ -84,7 +84,7 @@ describe('DidBtcr2Cli', () => {
 
   describe('resolve', () => {
     it('rejects invalid identifiers', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const resolve = getSubcommand(cli, 'resolve');
       await expect(
         resolve.parseAsync(['-i', 'not-a-did'], { from: 'user' })
@@ -93,7 +93,7 @@ describe('DidBtcr2Cli', () => {
 
     it('rejects invalid resolution options JSON', async () => {
       const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const resolve = getSubcommand(cli, 'resolve');
       await expect(
         resolve.parseAsync(['-i', validDid, '-r', 'not json'], { from: 'user' })
@@ -102,7 +102,7 @@ describe('DidBtcr2Cli', () => {
 
     it('reads resolution options from a file', async () => {
       const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const tempPath = join(tmpdir(), 'btcr2-resolve-test.json');
       await writeFile(tempPath, '{"versionId":"1"}', 'utf-8');
 
@@ -119,7 +119,7 @@ describe('DidBtcr2Cli', () => {
 
     it('rejects invalid resolution options file path', async () => {
       const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const resolve = getSubcommand(cli, 'resolve');
       await expect(
         resolve.parseAsync(['-i', validDid, '-p', '/no/file/here.json'], { from: 'user' })
@@ -129,7 +129,7 @@ describe('DidBtcr2Cli', () => {
 
   describe('update', () => {
     it('rejects invalid JSON for --source-document', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const update = getSubcommand(cli, 'update');
       await expect(
         update.parseAsync(['-s', '{bad', '--source-version-id', '1', '-p', '[]', '-m', 'vm', '-b', '[]'], { from: 'user' })
@@ -137,7 +137,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects invalid JSON for --patches', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const update = getSubcommand(cli, 'update');
       await expect(
         update.parseAsync(['-s', '{}', '--source-version-id', '1', '-p', 'not json', '-m', 'vm', '-b', '[]'], { from: 'user' })
@@ -145,7 +145,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects invalid JSON for --beacon-id', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const update = getSubcommand(cli, 'update');
       await expect(
         update.parseAsync(['-s', '{}', '--source-version-id', '1', '-p', '[]', '-m', 'vm', '-b', 'not json'], { from: 'user' })
@@ -155,7 +155,7 @@ describe('DidBtcr2Cli', () => {
 
   describe('deactivate', () => {
     it('rejects invalid JSON for --source-document', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const deactivate = getSubcommand(cli, 'deactivate');
       await expect(
         deactivate.parseAsync(['-s', '{bad', '--source-version-id', '1', '-m', 'vm', '-b', '[]'], { from: 'user' })
@@ -163,7 +163,7 @@ describe('DidBtcr2Cli', () => {
     });
 
     it('rejects invalid JSON for --beacon-id', async () => {
-      const cli = new DidBtcr2Cli(createTestApi());
+      const cli = new DidBtcr2Cli(createTestApiFactory());
       const deactivate = getSubcommand(cli, 'deactivate');
       await expect(
         deactivate.parseAsync(['-s', '{}', '--source-version-id', '1', '-m', 'vm', '-b', 'not json'], { from: 'user' })

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -1,0 +1,273 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  defaultApiFactory,
+  defaultConfigPath,
+  ENV_VARS,
+  profileToOverrides,
+  readConfigFile,
+  readEnvOverrides,
+} from '../src/config.js';
+import type { ConfigFile } from '../src/config.js';
+import { expect } from './helpers.js';
+
+describe('readEnvOverrides', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of Object.values(ENV_VARS)) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.values(ENV_VARS)) {
+      if (saved[key] !== undefined) {
+        process.env[key] = saved[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('returns undefined fields when no env vars are set', () => {
+    const overrides = readEnvOverrides();
+    expect(overrides.btcRest).to.be.undefined;
+    expect(overrides.btcRpcUrl).to.be.undefined;
+    expect(overrides.btcRpcUser).to.be.undefined;
+    expect(overrides.btcRpcPass).to.be.undefined;
+    expect(overrides.casGateway).to.be.undefined;
+  });
+
+  it('reads BTCR2_BTC_REST', () => {
+    process.env[ENV_VARS.BTC_REST] = 'http://env-rest:3000';
+    const overrides = readEnvOverrides();
+    expect(overrides.btcRest).to.equal('http://env-rest:3000');
+  });
+
+  it('reads BTCR2_BTC_RPC_* vars', () => {
+    process.env[ENV_VARS.BTC_RPC_URL] = 'http://env-rpc:18443';
+    process.env[ENV_VARS.BTC_RPC_USER] = 'envuser';
+    process.env[ENV_VARS.BTC_RPC_PASS] = 'envpass';
+    const overrides = readEnvOverrides();
+    expect(overrides.btcRpcUrl).to.equal('http://env-rpc:18443');
+    expect(overrides.btcRpcUser).to.equal('envuser');
+    expect(overrides.btcRpcPass).to.equal('envpass');
+  });
+
+  it('treats empty string as undefined', () => {
+    process.env[ENV_VARS.BTC_REST] = '';
+    const overrides = readEnvOverrides();
+    expect(overrides.btcRest).to.be.undefined;
+  });
+});
+
+
+
+describe('readConfigFile', () => {
+  const tempDir = join(tmpdir(), 'btcr2-config-test');
+
+  before(() => {
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  after(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads a valid config file', () => {
+    const path = join(tempDir, 'valid.json');
+    const content: ConfigFile = {
+      profiles : {
+        regtest : {
+          btc : { rest: 'http://localhost:3000' },
+        },
+      },
+    };
+    writeFileSync(path, JSON.stringify(content));
+    const result = readConfigFile(path);
+    expect(result).to.deep.equal(content);
+  });
+
+  it('returns undefined for missing file', () => {
+    const result = readConfigFile(join(tempDir, 'nope.json'));
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined for invalid JSON', () => {
+    const path = join(tempDir, 'bad.json');
+    writeFileSync(path, 'not json');
+    const result = readConfigFile(path);
+    expect(result).to.be.undefined;
+  });
+});
+
+describe('profileToOverrides', () => {
+  const config: ConfigFile = {
+    profiles : {
+      regtest : {
+        btc : {
+          rest    : 'http://localhost:3000',
+          rpcUrl  : 'http://localhost:18443',
+          rpcUser : 'polaruser',
+          rpcPass : 'polarpass',
+        },
+        cas : { gateway: 'http://localhost:8080' },
+      },
+      bitcoin : {
+        btc : { rest: 'https://my-mempool/api' },
+      },
+    },
+  };
+
+  it('extracts all fields from a full profile', () => {
+    const o = profileToOverrides(config, 'regtest');
+    expect(o.btcRest).to.equal('http://localhost:3000');
+    expect(o.btcRpcUrl).to.equal('http://localhost:18443');
+    expect(o.btcRpcUser).to.equal('polaruser');
+    expect(o.btcRpcPass).to.equal('polarpass');
+    expect(o.casGateway).to.equal('http://localhost:8080');
+  });
+
+  it('extracts partial profile', () => {
+    const o = profileToOverrides(config, 'bitcoin');
+    expect(o.btcRest).to.equal('https://my-mempool/api');
+    expect(o.btcRpcUrl).to.be.undefined;
+    expect(o.casGateway).to.be.undefined;
+  });
+
+  it('returns empty object for missing profile', () => {
+    const o = profileToOverrides(config, 'testnet4');
+    expect(o).to.deep.equal({});
+  });
+
+  it('returns empty object for config with no profiles', () => {
+    const o = profileToOverrides({}, 'regtest');
+    expect(o).to.deep.equal({});
+  });
+});
+
+describe('defaultConfigPath', () => {
+  it('returns a string ending with btcr2/config.json', () => {
+    const path = defaultConfigPath();
+    expect(path).to.be.a('string');
+    expect(path).to.match(/btcr2[/\\]config\.json$/);
+  });
+});
+
+
+
+describe('defaultApiFactory', () => {
+  const saved: Record<string, string | undefined> = {};
+  const tempDir = join(tmpdir(), 'btcr2-factory-test');
+
+  before(() => {
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  beforeEach(() => {
+    for (const key of Object.values(ENV_VARS)) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.values(ENV_VARS)) {
+      if (saved[key] !== undefined) {
+        process.env[key] = saved[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  after(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns unconfigured API when no network is provided', () => {
+    const api = defaultApiFactory();
+    expect(api).to.exist;
+    expect(() => api.btc).to.throw(/Bitcoin not configured/);
+  });
+
+  it('creates API with network defaults', () => {
+    // Point at a nonexistent config so file layer is empty
+    const api = defaultApiFactory('regtest', { config: join(tempDir, 'nope.json') });
+    expect(api).to.exist;
+    expect(api.btc.connection.name).to.equal('regtest');
+  });
+
+  it('applies config file profile by network name', () => {
+    const configPath = join(tempDir, 'auto-profile.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        regtest : { btc: { rest: 'http://profile-rest:3000' } },
+      },
+    }));
+    const api = defaultApiFactory('regtest', { config: configPath });
+    expect(api).to.exist;
+    expect(api.btc.connection.name).to.equal('regtest');
+  });
+
+  it('applies named --profile over auto-detected network', () => {
+    const configPath = join(tempDir, 'named-profile.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        custom : { btc: { rest: 'http://custom-rest:5000' } },
+      },
+    }));
+    const api = defaultApiFactory('regtest', { config: configPath, profile: 'custom' });
+    expect(api).to.exist;
+    expect(api.btc.connection.name).to.equal('regtest');
+  });
+
+  it('env var overrides config file', () => {
+    const configPath = join(tempDir, 'env-over-file.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        regtest : { btc: { rest: 'http://file-rest:3000' } },
+      },
+    }));
+    process.env[ENV_VARS.BTC_REST] = 'http://env-rest:4000';
+    const api = defaultApiFactory('regtest', { config: configPath });
+    expect(api).to.exist;
+    expect(api.btc.connection.name).to.equal('regtest');
+  });
+
+  it('CLI flag overrides env var and config file', () => {
+    const configPath = join(tempDir, 'flag-over-all.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        regtest : { btc: { rest: 'http://file-rest:3000' } },
+      },
+    }));
+    process.env[ENV_VARS.BTC_REST] = 'http://env-rest:4000';
+    const api = defaultApiFactory('regtest', {
+      config  : configPath,
+      btcRest : 'http://flag-rest:5000',
+    });
+    expect(api).to.exist;
+    expect(api.btc.connection.name).to.equal('regtest');
+  });
+
+  it('wires casGateway through to CAS executor', () => {
+    const api = defaultApiFactory('regtest', {
+      config     : join(tempDir, 'nope.json'),
+      casGateway : 'https://ipfs.io',
+    });
+    expect(api).to.exist;
+    // Accessing api.cas should NOT throw — gateway config was wired through
+    expect(() => api.cas).to.not.throw();
+  });
+
+  it('defaults to public IPFS gateway when no casGateway is provided', () => {
+    const api = defaultApiFactory('regtest', { config: join(tempDir, 'nope.json') });
+    expect(api).to.exist;
+    // CAS should be configured with the default gateway — no throw
+    expect(() => api.cas).to.not.throw();
+  });
+});

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import type { DidBtcr2Api } from '@did-btcr2/api';
 import { createApi } from '@did-btcr2/api';
+import type { ApiFactory } from '../src/config.js';
 
 chai.use(chaiAsPromised);
 export const { expect } = chai;
@@ -11,9 +11,10 @@ export const originalConsoleError = console.error;
 export const originalConsoleWarn = console.warn;
 
 /**
- * Creates a DidBtcr2Api instance for testing.
- * No Bitcoin or CAS configured — suitable for create-only tests.
+ * Creates an {@link ApiFactory} for testing.
+ * No Bitcoin or CAS configured — suitable for create-only tests and
+ * argument-validation tests (which throw before reaching the API).
  */
-export function createTestApi(): DidBtcr2Api {
-  return createApi();
+export function createTestApiFactory(): ApiFactory {
+  return () => createApi();
 }


### PR DESCRIPTION
PACKAGE VERSIONS
* @did-btcr2/api@0.5.0
* @did-btcr2/cli@0.6.0

API
* Add HttpGatewayCasExecutor for read-only CAS via IPFS trustless gateway
* Add gateway option to CasConfig (priority: executor > helia > gateway)
* Default CAS to public IPFS gateway (ipfs.io) when no cas config provided
* Add configurable timeout (default 30s) to CasApi to prevent indefinite hangs
* Always wire CAS into DidMethodApi so resolution can fetch from CAS

CLI (BREAKING)
* Replace DidBtcr2Api constructor param with ApiFactory for lazy construction
* Derive Bitcoin network from DID identifier — zero-config resolve/update
* Add global flags: --btc-rest, --btc-rpc-url, --btc-rpc-user, --btc-rpc-pass, --cas-gateway
* Add config file support (XDG standard, --config, --profile with auto-detect)
* Add env var support (BTCR2_BTC_REST, BTCR2_BTC_RPC_*, BTCR2_CAS_GATEWAY)
* Override precedence: CLI flags > env vars > config file > network defaults
* Add config.ts module (ApiFactory, ConnectionOverrides, ConfigFile types)
* Wire casGateway through full config chain to HttpGatewayCasExecutor
* Fix tsconfig: add lib ES2022 + types node for Node-only CLI package
* Rewrite README with usage examples, config reference, and defaults