### PR TITLE
bound MuSig2 key custody and fix cohort beacon networks

### DIFF
--- a/docs/adr/038-musig2-key-custody.md
+++ b/docs/adr/038-musig2-key-custody.md
@@ -1,0 +1,82 @@
+---
+title: "ADR 038: MuSig2 Key Custody - Bounded, Zeroized Secrets at the Participant Boundary"
+---
+
+# ADR 038: MuSig2 Key Custody - Bounded, Zeroized Secrets at the Participant Boundary
+
+**Status:** Accepted
+
+**Date:** 2026-06-20
+
+**Branch / PR:** `feat/aggregation-kms`
+**References:** [ADR 008](008-aggregation-subsystem-inception.md), [ADR 020](020-aggregation-layered-architecture.md), [ADR 034](034-key-manager-capability-pattern.md), [ADR 037](037-single-party-beacon-and-two-axis-model.md)
+
+## Context
+
+[ADR 008](008-aggregation-subsystem-inception.md) chose **MuSig2 (BIP-327) over a Taproot key-path** as the aggregate-signing primitive and set the trust model: the coordinator is trusted for **liveness only, never signing authority**, and every participant **self-custodies** its key. [ADR 020](020-aggregation-layered-architecture.md) placed keys in the layer-2 wrapper classes (`AggregationParticipant`, `AggregationService`), outside the pluggable transport. [ADR 037](037-single-party-beacon-and-two-axis-model.md) shipped the two-axis beacon model and explicitly deferred "the MuSig2 key-custody story (KMS)" to a later ADR. This is that ADR: it pins down exactly how a participant's raw secret is held and handled across a signing round.
+
+**MuSig2 requires the raw 32-byte secret, twice, and a generic signer cannot stand in.** A participant's secret enters the protocol at two call sites in [`signing-session.ts`](../../packages/method/src/core/aggregation/signing-session.ts):
+
+- `nonceGen(publicKey, secretKey, aggPublicKey)` derives the per-session secret/public nonce pair. BIP-327 mixes the signer's own secret into the nonce derivation as a hardening measure against weak RNGs; this is nonce *pre-generation*, not "signing a message," and it must also take the cohort aggregate pubkey.
+- `Session.sign(secretNonce, secretKey)` computes the partial signature `s_i = k1 + b*k2 + e*a_i*d_i (mod n)`, where `d_i` is the raw scalar secret, `a_i` is this signer's key-aggregation coefficient (derived from the full cohort key set), `e` is the challenge over the **aggregate** nonce and pubkey, and `(k1, k2)` are this session's secret nonce.
+
+A generic `KeyManager.sign(message)` / `Signer.sign(data, scheme)` is a one-shot `(digest) -> signature` primitive. It cannot express MuSig2: there is no stateful nonce-commitment round, no hook to feed back the aggregated nonce, and a partial signature is not a standalone `bip340`/`bip341` signature that any `SigningScheme` can return. The secret must remain a raw scalar so the library can multiply it by `a_i` and add the nonce scalars. The only `KeyManager` route to the raw secret is `exportKey()` (the [ADR 034](034-key-manager-capability-pattern.md) `canExport` capability), which defeats a non-extractable / HSM-backed manager: a `canExport: false` manager cannot participate in aggregation at all. **Full KMS opacity is therefore mathematically unavailable for MuSig2.**
+
+**What the current code actually does** (verified against the source):
+
+- `AggregationParticipant` holds its secret as a long-lived `public readonly keys: SchnorrKeyPair` field, set once in the constructor and **never cleared**. The raw secret is reachable as `participant.keys.secretKey.bytes` for the participant's entire lifetime (potentially many cohorts).
+- Each MuSig2 call dereferences `this.keys.secretKey.bytes` ([`participant.ts`](../../packages/method/src/core/aggregation/participant.ts) nonce + partial-sign paths). The `.bytes` getter returns a **fresh copy** each access; those transient copies are passed into `nonceGen` / `Session.sign` and are **never wiped**.
+- The only secret that is zeroized today is the MuSig2 **secret nonce** (`secretNonce.fill(0)` in `generatePartialSignature`), and only on the **success path**. `secretNonce` is a **public** mutable field, and on an aborted or failed session it is never cleared. There is no `dispose()` / `clear()` and no cleanup on any failure or phase-transition path.
+- `AggregationService` (the coordinator) **already never receives a participant secret**: it ingests only public keys, public nonce contributions, and partial signatures, and aggregates them. Its own `keys` field, however, is typed as a full `SchnorrKeyPair` even though only `this.keys.publicKey.compressed` is ever read - the type permits a secret the code never uses.
+- **No reusable secret-wipe utility exists.** The only zeroization anywhere in `common` / `key-manager` / `keypair` is `Secp256k1SecretKey.destroy()` (opt-in, never called from the aggregation path) and the one ad-hoc nonce `fill(0)`.
+- `AggregationRunner.solo()` aliases the **same** secret-bearing keypair into the transport actor registry, the runner, and the session, widening the read surface for the secret.
+
+The design question this ADR answers: **how does a participant supply its raw secret to the two MuSig2 calls without holding it for its whole lifetime, without leaking unwiped copies, and without the coordinator or transport ever touching it?**
+
+|  | Secret lifetime | Zeroization | Coordinator holds secret? | MuSig2 works? |
+| --- | --- | --- | --- | --- |
+| **A** — route through `KeyManager.sign()` (KMS-opaque) | n/a | n/a | no | **no** (partial sig not expressible; only `exportKey()` yields the secret) |
+| **B** — bound + zeroized at the participant boundary *(chosen)* | one signing session | all transient copies + nonce, all paths | no (type-enforced) | yes |
+| **B2** — KMS-native MuSig2 capability (secret never copied out) | inside the keypair/KMS | inherent (no copy-out) | no | yes |
+| **C** — status quo | participant lifetime | nonce only, success path only | no | yes |
+
+## Decision
+
+Adopt **Option B: confine the raw secret to a per-signing-session boundary that zeroizes after use, and make the coordinator's pubkey-only status a type-level invariant.** The secret crosses no boundary outward; only public material (compressed pubkey, public nonce, partial signature) leaves the participant.
+
+1. **Bound the secret's lifetime to a signing session, not the participant.** Replace the long-lived `keys: SchnorrKeyPair` on `AggregationParticipant` with a narrower secret-provider boundary: the raw secret is yielded to the two MuSig2 calls only for the duration of nonce-generation and partial-signing (a scoped `withSecret(fn)` / per-session signer), after which the transient copy is wiped. The participant no longer retains a secret-bearing keypair across cohorts.
+2. **Add a reusable zeroization utility** (`wipe(bytes: Uint8Array)`), shared from the keypair/common layer, and apply it to **every transient raw-secret copy** at the `nonceGen` and `Session.sign` call sites. This complements the existing `Secp256k1SecretKey.destroy()` rather than re-inventing it.
+3. **Give `BeaconSigningSession` deterministic secret-nonce teardown on all paths.** Make `secretNonce` private, add an explicit `clear()` / `dispose()` that zeroizes it, and invoke it on **abort, failure, and completion** - not only on the success path of `generatePartialSignature`. A second partial-sign attempt continues to throw rather than reuse a nonce (MuSig2 nonce reuse is catastrophic key leakage).
+4. **Narrow the coordinator to a public-key type.** Type `AggregationService` (and `AggregationServiceRunner`) key material as public-key-only, since the service never signs. This turns "the coordinator never holds signing authority" ([ADR 008](008-aggregation-subsystem-inception.md)) from a runtime fact into a **compile-time invariant**.
+5. **Keep secrets out of the transport registry.** `AggregationRunner.solo()` registers only public keys with the transport actor registry; the secret stays at the participant boundary and is not aliased across the runner/transport/session.
+
+### Rejected alternatives
+
+- **Option A - route MuSig2 through `KeyManager.sign()` (full KMS opacity).** Mathematically impossible: a MuSig2 partial signature is not a one-shot signature over a digest, and the only `KeyManager` path to the raw scalar is `exportKey()` ([ADR 034](034-key-manager-capability-pattern.md)), which defeats a non-extractable manager. A `canExport: false` / HSM manager cannot aggregate at all.
+- **Option B2 - push MuSig2 into the keypair/KMS as first-class capabilities** (`musig2NonceGen` / `musig2PartialSign`) so the raw bytes never leave `Secp256k1SecretKey`. This is the **strongest** custody (no copy-out at all) and aligns with the [ADR 034](034-key-manager-capability-pattern.md) capability pattern, but it widens the keypair/key-manager API with protocol-specific, two-round stateful MuSig2 state. **Deferred, not discarded:** it is the natural follow-on once the bounded/zeroized boundary from Option B exists, and it is the only path that removes the raw-secret-in-process requirement. It warrants its own ADR.
+- **Option C - status quo.** Unbounded secret lifetime (participant-lifetime field), unwiped transient copies, and nonce cleanup only on the success path. This is the baseline Option B moves off of.
+
+## Consequences
+
+**Positive**
+- The secret's in-memory exposure window shrinks from "participant lifetime" (many cohorts) to "one MuSig2 round."
+- Defense in depth: every transient secret copy and the secret nonce are wiped on **all** terminal paths via one shared, testable utility, instead of a single ad-hoc success-path `fill(0)`.
+- "The coordinator never holds signing authority" becomes a compile-time invariant, not just an observed runtime property.
+- The transport actor registry holds only public keys.
+
+**Negative**
+- MuSig2 still requires the raw secret **in process** at the participant. Aggregation cannot be driven by a non-extractable / HSM `KeyManager` (`canExport: false`); that remains a documented limitation until Option B2 is adopted.
+- Zeroization in a managed-memory runtime (V8) is **best-effort, not a guarantee**: the garbage collector may relocate or copy buffers, and we cannot wipe copies the runtime makes internally. We wipe the `Uint8Array` buffers we control and document the residual rather than overstating the guarantee.
+- Replacing the long-lived `keys` field changes the `AggregationParticipant` constructor and the runner option shapes (a `method` version bump; the change is confined to the aggregation API surface).
+
+**Accepted**
+- Best-effort wipe and raw-secret-in-process for MuSig2 are the accepted residual risk for this stage. **Option B2 (KMS-native MuSig2)** is the path to remove the in-process requirement and is deferred to its own ADR once this boundary lands.
+
+## References
+
+- [`packages/method/src/core/aggregation/signing-session.ts`](../../packages/method/src/core/aggregation/signing-session.ts): the two raw-secret entry points (`generateNonceContribution`, `generatePartialSignature`) and the secret-nonce field to make private and clear on all paths.
+- [`packages/method/src/core/aggregation/participant.ts`](../../packages/method/src/core/aggregation/participant.ts): the long-lived `keys` field and the two `keys.secretKey.bytes` dereferences to bound and wipe.
+- [`packages/method/src/core/aggregation/service.ts`](../../packages/method/src/core/aggregation/service.ts): already pubkey-only in behavior; narrow the `keys` type to a public-key handle.
+- [`packages/method/src/core/aggregation/runner/aggregation-runner.ts`](../../packages/method/src/core/aggregation/runner/aggregation-runner.ts): stop aliasing the secret-bearing keypair into the transport registry in `solo()`.
+- [`packages/keypair/src/secret.ts`](../../packages/keypair/src/secret.ts): `Secp256k1SecretKey.destroy()` and the copy-returning `bytes` getter the shared `wipe()` utility complements.
+- [ADR 008](008-aggregation-subsystem-inception.md): the MuSig2 trust model (coordinator liveness-only, participants self-custody). [ADR 020](020-aggregation-layered-architecture.md): keys live in the layer-2 wrappers. [ADR 034](034-key-manager-capability-pattern.md): the `canExport` capability that Option B2 would extend. [ADR 037](037-single-party-beacon-and-two-axis-model.md): flagged this key-custody stage as next.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -38,6 +38,7 @@ children:
   - ./035-smt-proof-base64url-wire-format.md
   - ./036-zero-hash-smt-model.md
   - ./037-single-party-beacon-and-two-axis-model.md
+  - ./038-musig2-key-custody.md
 ---
 
 # Architecture Decision Records
@@ -83,3 +84,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 035 | 2026-06-15 | [SMT Proof Wire Format: base64url no-pad and the Zero-Node Collapsed Bitmap](035-smt-proof-base64url-wire-format.md) |
 | 036 | 2026-06-16 | [Adopt the Zero-Hash SMT Model per algorithms.html](036-zero-hash-smt-model.md) |
 | 037 | 2026-06-19 | [Rename Beacon to SinglePartyBeacon and the Two-Axis Beacon Model](037-single-party-beacon-and-two-axis-model.md) |
+| 038 | 2026-06-20 | [MuSig2 Key Custody: Bounded, Zeroized Secrets at the Participant Boundary](038-musig2-key-custody.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/keypair/package.json
+++ b/packages/keypair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/keypair",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "Secp256k1 key pairs with ECDSA, BIP-340 Schnorr, and BIP-341 taproot signing, multibase encoding, and constant-time operations.",
   "main": "./dist/cjs/index.js",

--- a/packages/keypair/src/index.ts
+++ b/packages/keypair/src/index.ts
@@ -3,3 +3,4 @@ export * from './secret.js';
 export * from './public.js';
 export * from './signer.js';
 export * from './types.js';
+export * from './utils.js';

--- a/packages/keypair/src/utils.ts
+++ b/packages/keypair/src/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Best-effort zeroization of secret-bearing bytes. Overwrites the buffer in
+ * place with zeros.
+ *
+ * In a managed-memory runtime (V8) this cannot guarantee every copy of the
+ * secret is erased - the garbage collector may relocate buffers and we cannot
+ * wipe copies the runtime makes internally. What it does guarantee is that the
+ * specific buffer handed in no longer holds the secret, which shortens the
+ * in-memory exposure window and prevents reuse or serialization of spent
+ * secret material. Use it on transient secret copies (e.g. the raw bytes pulled
+ * from a keypair for a single signing operation) as soon as the operation
+ * returns.
+ *
+ * @param {Uint8Array | undefined | null} bytes The buffer to zero. No-op if nullish.
+ * @returns {void}
+ */
+export function wipe(bytes: Uint8Array | undefined | null): void {
+  if(bytes) bytes.fill(0);
+}

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.34.0",
+    "version": "0.35.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/aggregation/cohort.ts
+++ b/packages/method/src/core/aggregation/cohort.ts
@@ -1,3 +1,4 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { canonicalHash, canonicalize, hash } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof, TreeEntry } from '@did-btcr2/smt';
@@ -118,7 +119,10 @@ export class AggregationCohort {
     }
     const keyAggContext = keyAggregate(this.#cohortKeys);
     const aggPubkey = keyAggExport(keyAggContext);
-    const payment = p2tr(aggPubkey);
+    // Derive the address for the cohort's network. Without the network arg
+    // p2tr defaults to mainnet, so a mutinynet/signet/regtest cohort would
+    // otherwise advertise a `bc1p...` address that no participant can fund.
+    const payment = p2tr(aggPubkey, undefined, getNetwork(this.network));
 
     // BIP-341: key-path-only P2TR has no script tree. Compute the tweak:
     // taggedHash("TapTweak", internalPubkey).

--- a/packages/method/src/core/aggregation/participant.ts
+++ b/packages/method/src/core/aggregation/participant.ts
@@ -1,6 +1,5 @@
 import { canonicalHash } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
-import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import type { SerializedSMTProof} from '@did-btcr2/smt';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { Transaction } from '@scure/btc-signer';
@@ -26,6 +25,7 @@ import {
 } from './messages/factories.js';
 import type { ParticipantCohortPhaseType } from './phases.js';
 import { ParticipantCohortPhase } from './phases.js';
+import type { AggregationSigner } from './signer.js';
 import { BeaconSigningSession } from './signing-session.js';
 
 /** Cohort advert as discovered by the participant (UI: list of joinable cohorts). */
@@ -82,7 +82,12 @@ interface ParticipantCohortState {
 
 export interface AggregationParticipantParams {
   did: string;
-  keys: SchnorrKeyPair;
+  /**
+   * The participant's MuSig2 signing capability. The raw secret is materialized
+   * only for the duration of a single nonce/partial-sign operation (see ADR 038);
+   * pass a {@link KeyPairAggregationSigner} to back it with an in-memory keypair.
+   */
+  signer: AggregationSigner;
 }
 
 /**
@@ -97,14 +102,21 @@ export interface AggregationParticipantParams {
  */
 export class AggregationParticipant {
   public readonly did: string;
-  public readonly keys: SchnorrKeyPair;
+
+  /** MuSig2 signing capability. The raw secret never lives as a field here. */
+  readonly #signer: AggregationSigner;
 
   /** Per-cohort state, keyed by cohortId. */
   #cohortStates: Map<string, ParticipantCohortState> = new Map();
 
-  constructor({ did, keys }: AggregationParticipantParams) {
+  constructor({ did, signer }: AggregationParticipantParams) {
     this.did = did;
-    this.keys = keys;
+    this.#signer = signer;
+  }
+
+  /** The participant's compressed (33-byte) MuSig2 public key. Not secret. */
+  public get publicKey(): Uint8Array {
+    return this.#signer.publicKey;
   }
 
 
@@ -205,8 +217,8 @@ export class AggregationParticipant {
       from            : this.did,
       to              : state.serviceDid,
       cohortId,
-      participantPk   : this.keys.publicKey.compressed,
-      communicationPk : this.keys.publicKey.compressed,
+      participantPk   : this.publicKey,
+      communicationPk : this.publicKey,
     });
 
     return [optInMessage];
@@ -245,7 +257,7 @@ export class AggregationParticipant {
     const cohortKeys = message.body?.cohortKeys;
     if(!beaconAddress || !cohortKeys) return;
 
-    const participantPkHex = bytesToHex(this.keys.publicKey.compressed);
+    const participantPkHex = bytesToHex(this.publicKey);
     const cohortKeysHex = cohortKeys.map(k => bytesToHex(new Uint8Array(k)));
 
     state.cohort.validateMembership(participantPkHex, cohortKeysHex, beaconAddress);
@@ -435,9 +447,8 @@ export class AggregationParticipant {
     });
     state.signingSession = session;
 
-    const nonceContribution = session.generateNonceContribution(
-      this.keys.publicKey.compressed,
-      this.keys.secretKey.bytes
+    const nonceContribution = this.#signer.withSecret(
+      secretKey => session.generateNonceContribution(this.publicKey, secretKey)
     );
 
     state.phase = ParticipantCohortPhase.NonceSent;
@@ -485,7 +496,10 @@ export class AggregationParticipant {
       );
     }
 
-    const partialSig = state.signingSession.generatePartialSignature(this.keys.secretKey.bytes);
+    const signingSession = state.signingSession;
+    const partialSig = this.#signer.withSecret(
+      secretKey => signingSession.generatePartialSignature(secretKey)
+    );
     state.phase = ParticipantCohortPhase.Complete;
 
     return [createSignatureAuthorizationMessage({
@@ -500,5 +514,17 @@ export class AggregationParticipant {
 
   public getCohortPhase(cohortId: string): ParticipantCohortPhaseType | undefined {
     return this.#cohortStates.get(cohortId)?.phase;
+  }
+
+  /**
+   * Zeroize any retained MuSig2 secret nonces across all cohorts. The raw
+   * signing key is never held here (it lives behind the {@link AggregationSigner}
+   * and is wiped per-operation), but an abandoned signing session can still hold
+   * a secret nonce; call this on teardown to clear it deterministically.
+   */
+  public clearSecrets(): void {
+    for(const state of this.#cohortStates.values()) {
+      state.signingSession?.clearSecrets();
+    }
   }
 }

--- a/packages/method/src/core/aggregation/runner/participant-runner.ts
+++ b/packages/method/src/core/aggregation/runner/participant-runner.ts
@@ -18,6 +18,7 @@ import {
   AggregationParticipant
 } from '../participant.js';
 import { ParticipantCohortPhase } from '../phases.js';
+import { KeyPairAggregationSigner } from '../signer.js';
 import type { Transport } from '../transport/transport.js';
 import type { AggregationParticipantEvents } from './events.js';
 import { TypedEventEmitter } from './typed-emitter.js';
@@ -129,7 +130,10 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
     this.#onValidateData = options.onValidateData ?? (async (info) => ({ approved: info.matches }));
     this.#onApproveSigning = options.onApproveSigning ?? (async () => ({ approved: true }));
 
-    this.session = new AggregationParticipant({ did: options.did, keys: options.keys });
+    this.session = new AggregationParticipant({
+      did    : options.did,
+      signer : new KeyPairAggregationSigner(options.keys),
+    });
   }
 
   /**
@@ -144,6 +148,10 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
   stop(): void {
     this.#stopped = true;
     this.#unregisterHandlers();
+    // Deterministically wipe any secret nonce left on an abandoned signing
+    // session. The signing key itself lives behind the AggregationSigner and is
+    // never retained here.
+    this.session.clearSecrets();
   }
 
   /** Message types this runner listens for on the transport. */

--- a/packages/method/src/core/aggregation/runner/service-runner.ts
+++ b/packages/method/src/core/aggregation/runner/service-runner.ts
@@ -184,8 +184,11 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
     this.#advertRepeatIntervalMs = options.advertRepeatIntervalMs ?? DEFAULT_ADVERT_REPEAT_INTERVAL_MS;
 
     this.session = new AggregationService({
+      // The coordinator never signs, so the state machine receives only the
+      // public half of the operator's keypair (see ADR 038). The full keypair
+      // remains the operator's transport/communication identity.
       did                : options.did,
-      keys               : options.keys,
+      publicKey          : options.keys.publicKey,
       maxUpdateSizeBytes : options.maxUpdateSizeBytes,
     });
   }

--- a/packages/method/src/core/aggregation/service.ts
+++ b/packages/method/src/core/aggregation/service.ts
@@ -1,7 +1,7 @@
 import { canonicalize } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import { BIP340Cryptosuite, SchnorrMultikey } from '@did-btcr2/cryptosuite';
-import type { SchnorrKeyPair } from '@did-btcr2/keypair';
+import type { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils';
 import type { Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from './beacon-strategy.js';
@@ -100,7 +100,13 @@ export const DEFAULT_MAX_UPDATE_SIZE_BYTES = 256 * 1024;
 
 export interface AggregationServiceParams {
   did: string;
-  keys: SchnorrKeyPair;
+  /**
+   * The service's compressed communication public key (placed in cohort adverts).
+   * The coordinator never signs - it aggregates public nonces and partial
+   * signatures - so it is given a public key only, never a secret-bearing
+   * keypair (see ADR 038).
+   */
+  publicKey: CompressedSecp256k1PublicKey;
   /**
    * Maximum canonicalized byte-length of a signed update body accepted by the
    * service. Submissions above this cap are silently dropped and surfaced as
@@ -122,15 +128,15 @@ export interface AggregationServiceParams {
  */
 export class AggregationService {
   readonly did: string;
-  readonly keys: SchnorrKeyPair;
+  readonly publicKey: CompressedSecp256k1PublicKey;
   readonly maxUpdateSizeBytes: number;
 
   /** Per-cohort state, keyed by cohortId. */
   #cohortStates: Map<string, ServiceCohortState> = new Map();
 
-  constructor({ did, keys, maxUpdateSizeBytes }: AggregationServiceParams) {
+  constructor({ did, publicKey, maxUpdateSizeBytes }: AggregationServiceParams) {
     this.did = did;
-    this.keys = keys;
+    this.publicKey = publicKey;
     this.maxUpdateSizeBytes = maxUpdateSizeBytes ?? DEFAULT_MAX_UPDATE_SIZE_BYTES;
   }
 
@@ -234,7 +240,7 @@ export class AggregationService {
       cohortSize      : state.config.minParticipants,
       beaconType      : state.config.beaconType,
       network         : state.config.network,
-      communicationPk : this.keys.publicKey.compressed,
+      communicationPk : this.publicKey.compressed,
     });
 
     state.phase = ServiceCohortPhase.Advertised;

--- a/packages/method/src/core/aggregation/signer.ts
+++ b/packages/method/src/core/aggregation/signer.ts
@@ -1,0 +1,67 @@
+import type { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { wipe } from '@did-btcr2/keypair';
+
+/**
+ * A signing capability for MuSig2 aggregation.
+ *
+ * MuSig2 (BIP-327) cannot be driven through a generic `sign(message)` primitive:
+ * both nonce generation and partial signing need the raw 32-byte secret scalar
+ * (see ADR 038). Rather than hand that scalar around as a long-lived field, the
+ * participant holds an `AggregationSigner` and materializes the secret only for
+ * the duration of a single operation via {@link AggregationSigner.withSecret},
+ * which is responsible for wiping its working copy afterward.
+ *
+ * This is the seam a non-extractable / KMS-backed signer (or a session-scoped
+ * signer that destroys its key after the cohort completes) plugs into without
+ * changing the participant state machine.
+ *
+ * @interface AggregationSigner
+ */
+export interface AggregationSigner {
+  /** Compressed 33-byte public key. Not secret; always available. */
+  readonly publicKey: Uint8Array;
+
+  /**
+   * Materialize the raw 32-byte secret key, pass it to `fn`, and zeroize the
+   * working copy before returning - even if `fn` throws. The secret must not
+   * escape the callback.
+   *
+   * @typeParam T The callback's return type (e.g. a nonce contribution or partial signature).
+   * @param {(secretKey: Uint8Array) => T} fn Operation that needs the raw secret for its duration.
+   * @returns {T} Whatever `fn` returns.
+   */
+  withSecret<T>(fn: (secretKey: Uint8Array) => T): T;
+}
+
+/**
+ * {@link AggregationSigner} backed by an in-memory {@link SchnorrKeyPair}.
+ *
+ * The keypair is held privately (never exposed as a public field) and each
+ * `withSecret` call pulls a fresh copy of the secret bytes, hands it to the
+ * callback, and wipes that copy on return. The underlying keypair is the
+ * caller's to own and destroy; this signer never mutates or destroys it.
+ *
+ * @class KeyPairAggregationSigner
+ * @implements {AggregationSigner}
+ */
+export class KeyPairAggregationSigner implements AggregationSigner {
+  readonly publicKey: Uint8Array;
+  readonly #keys: SchnorrKeyPair;
+
+  /** @param {SchnorrKeyPair} keys The keypair whose secret backs this signer. */
+  constructor(keys: SchnorrKeyPair) {
+    this.#keys = keys;
+    this.publicKey = keys.publicKey.compressed;
+  }
+
+  withSecret<T>(fn: (secretKey: Uint8Array) => T): T {
+    // `.bytes` returns a fresh copy; wipe it once the operation completes so the
+    // raw scalar does not linger on the heap beyond a single MuSig2 step.
+    const secretKey = this.#keys.secretKey.bytes;
+    try {
+      return fn(secretKey);
+    } finally {
+      wipe(secretKey);
+    }
+  }
+}

--- a/packages/method/src/core/aggregation/signing-session.ts
+++ b/packages/method/src/core/aggregation/signing-session.ts
@@ -1,3 +1,4 @@
+import { wipe } from '@did-btcr2/keypair';
 import type { Transaction } from '@scure/btc-signer';
 import { SigHash } from '@scure/btc-signer';
 import * as musig2 from '@scure/btc-signer/musig2';
@@ -58,8 +59,14 @@ export class BeaconSigningSession {
   /** Current signing session phase. */
   public phase: SigningSessionPhaseType;
 
-  /** Participant's secret nonce (held only by the participant during signing). */
-  public secretNonce?: Uint8Array;
+  /**
+   * Participant's MuSig2 secret nonce, held only on the participant side
+   * between {@link generateNonceContribution} and {@link generatePartialSignature}.
+   * Private and cleared on every terminal path (success, failure, or teardown
+   * via {@link clearSecrets}) so a spent or abandoned nonce cannot be reused or
+   * serialized.
+   */
+  #secretNonce?: Uint8Array;
 
   constructor({ id, cohort, pendingTx, prevOutScripts, prevOutValues }: SigningSessionParams) {
     this.id = id || crypto.randomUUID();
@@ -225,7 +232,7 @@ export class BeaconSigningSession {
   public generateNonceContribution(participantPublicKey: Uint8Array, participantSecretKey: Uint8Array): Uint8Array {
     const aggPublicKey = musig2.keyAggExport(musig2.keyAggregate(this.cohort.cohortKeys));
     const nonces = musig2.nonceGen(participantPublicKey, participantSecretKey, aggPublicKey);
-    this.secretNonce = nonces.secret;
+    this.#secretNonce = nonces.secret;
     return nonces.public;
   }
 
@@ -233,15 +240,17 @@ export class BeaconSigningSession {
    * Generates a partial signature using the participant's secret key + secret nonce.
    * Requires the aggregated nonce to have been set first (via the service).
    *
-   * Zeros the stored `secretNonce` after use. JS cannot truly erase memory (GC
-   * and immutable strings), but overwriting the bytes shortens the exposure
-   * window and prevents accidental reuse or serialization of a spent nonce.
+   * Clears the stored secret nonce after use on every path (success or throw)
+   * via {@link clearSecrets}. JS cannot truly erase memory (GC may relocate
+   * buffers), but overwriting the bytes shortens the exposure window and
+   * prevents accidental reuse or serialization of a spent nonce - reuse of a
+   * MuSig2 nonce leaks the secret key.
    */
   public generatePartialSignature(participantSecretKey: Uint8Array): Uint8Array {
     if(!this.aggregatedNonce) {
       throw new SigningSessionError('Aggregated nonce not available.', 'MISSING_AGGREGATED_NONCE');
     }
-    if(!this.secretNonce) {
+    if(!this.#secretNonce) {
       throw new SigningSessionError('Secret nonce not available — generateNonceContribution() must be called first.', 'MISSING_SECRET_NONCE');
     }
     const session = new musig2.Session(
@@ -251,10 +260,24 @@ export class BeaconSigningSession {
       [this.cohort.tapTweak],
       [true]
     );
-    const partialSig = session.sign(this.secretNonce, participantSecretKey);
-    this.secretNonce.fill(0);
-    this.secretNonce = undefined;
-    return partialSig;
+    try {
+      return session.sign(this.#secretNonce, participantSecretKey);
+    } finally {
+      this.clearSecrets();
+    }
+  }
+
+  /**
+   * Zeroize any retained secret nonce. Safe to call repeatedly and on any path
+   * (completion, failure, or teardown of an abandoned session). Callers that
+   * drop a session before it reaches a partial signature should invoke this so
+   * the secret nonce does not linger on the live object.
+   */
+  public clearSecrets(): void {
+    if(this.#secretNonce) {
+      wipe(this.#secretNonce);
+      this.#secretNonce = undefined;
+    }
   }
 
   public isComplete(): boolean {

--- a/packages/method/src/core/aggregation/transport/in-memory.ts
+++ b/packages/method/src/core/aggregation/transport/in-memory.ts
@@ -5,7 +5,8 @@ import type { MessageHandler, Transport } from './transport.js';
 
 /** Internal registration for a single actor sharing an {@link InMemoryTransport}. */
 interface ActorEntry {
-  keys: SchnorrKeyPair;
+  /** Compressed communication public key. The in-process bus does no encryption, so no secret is retained. */
+  publicKey: Uint8Array;
   handlers: Map<string, MessageHandler>;
 }
 
@@ -97,11 +98,14 @@ export class InMemoryTransport implements Transport {
   }
 
   registerActor(did: string, keys: SchnorrKeyPair): void {
-    this.#actors.set(did, { keys, handlers: new Map() });
+    // In-process delivery does no signing or encryption (same trust domain), so
+    // retain only the public key - the secret-bearing keypair is never stored in
+    // the transport registry (see ADR 038).
+    this.#actors.set(did, { publicKey: keys.publicKey.compressed, handlers: new Map() });
   }
 
   getActorPk(did: string): Uint8Array | undefined {
-    return this.#actors.get(did)?.keys.publicKey.compressed;
+    return this.#actors.get(did)?.publicKey;
   }
 
   /** True if `did` is registered on this transport. Used by the bus for routing. */

--- a/packages/method/src/index.ts
+++ b/packages/method/src/index.ts
@@ -1,6 +1,7 @@
 // Aggregation
 export * from './core/aggregation/service.js';
 export * from './core/aggregation/participant.js';
+export * from './core/aggregation/signer.js';
 export * from './core/aggregation/cohort.js';
 export * from './core/aggregation/signing-session.js';
 export * from './core/aggregation/phases.js';

--- a/packages/method/tests/aggregation-key-custody.spec.ts
+++ b/packages/method/tests/aggregation-key-custody.spec.ts
@@ -1,0 +1,98 @@
+import { SchnorrKeyPair, wipe } from '@did-btcr2/keypair';
+import { expect } from 'chai';
+import {
+  AggregationParticipant,
+  AggregationService,
+  KeyPairAggregationSigner,
+} from '../src/index.js';
+
+/**
+ * Executable guarantees for ADR 038 (MuSig2 key custody): the raw secret is
+ * confined behind a withSecret boundary that wipes its working copy on every
+ * path, is never a public field on the participant, and the coordinator holds a
+ * public key only.
+ */
+describe('ADR 038: MuSig2 key custody', () => {
+  describe('wipe()', () => {
+    it('zeroes a buffer in place', () => {
+      const b = new Uint8Array([1, 2, 3, 4]);
+      wipe(b);
+      expect([...b]).to.deep.equal([0, 0, 0, 0]);
+    });
+
+    it('is a no-op for nullish input', () => {
+      expect(() => wipe(undefined)).to.not.throw();
+      expect(() => wipe(null)).to.not.throw();
+    });
+  });
+
+  describe('KeyPairAggregationSigner', () => {
+    it('exposes the compressed public key, never the secret as a field', () => {
+      const kp = SchnorrKeyPair.generate();
+      const signer = new KeyPairAggregationSigner(kp);
+      expect([...signer.publicKey]).to.deep.equal([...kp.publicKey.compressed]);
+      // The secret backs the signer privately; it is not reachable as a field.
+      expect((signer as unknown as Record<string, unknown>).keys).to.equal(undefined);
+      expect((signer as unknown as Record<string, unknown>).secretKey).to.equal(undefined);
+    });
+
+    it('provides the raw secret to the callback and returns its value', () => {
+      const kp = SchnorrKeyPair.generate();
+      const signer = new KeyPairAggregationSigner(kp);
+      const expected = [...kp.secretKey.bytes];
+      const result = signer.withSecret(sk => {
+        expect([...sk]).to.deep.equal(expected);
+        return 'ok';
+      });
+      expect(result).to.equal('ok');
+    });
+
+    it('wipes the working copy after the callback returns', () => {
+      const kp = SchnorrKeyPair.generate();
+      const signer = new KeyPairAggregationSigner(kp);
+      let captured: Uint8Array | undefined;
+      signer.withSecret(sk => { captured = sk; });
+      expect(captured).to.be.instanceOf(Uint8Array);
+      expect(captured!.every(byte => byte === 0)).to.equal(true);
+    });
+
+    it('wipes the working copy even when the callback throws', () => {
+      const kp = SchnorrKeyPair.generate();
+      const signer = new KeyPairAggregationSigner(kp);
+      let captured: Uint8Array | undefined;
+      expect(() => signer.withSecret(sk => {
+        captured = sk;
+        throw new Error('boom');
+      })).to.throw('boom');
+      expect(captured!.every(byte => byte === 0)).to.equal(true);
+    });
+
+    it('does not mutate or destroy the underlying keypair', () => {
+      const kp = SchnorrKeyPair.generate();
+      const before = [...kp.secretKey.bytes];
+      const signer = new KeyPairAggregationSigner(kp);
+      signer.withSecret(() => undefined);
+      // The caller's keypair is still intact and usable after signing.
+      expect([...kp.secretKey.bytes]).to.deep.equal(before);
+    });
+  });
+
+  describe('state machine custody', () => {
+    it('AggregationParticipant exposes only the public key, not a secret-bearing keypair', () => {
+      const kp = SchnorrKeyPair.generate();
+      const participant = new AggregationParticipant({
+        did    : 'did:btcr2:alice',
+        signer : new KeyPairAggregationSigner(kp),
+      });
+      expect([...participant.publicKey]).to.deep.equal([...kp.publicKey.compressed]);
+      // The pre-ADR-038 `public readonly keys` field is gone.
+      expect((participant as unknown as Record<string, unknown>).keys).to.equal(undefined);
+    });
+
+    it('AggregationService is constructed with a public key only', () => {
+      const kp = SchnorrKeyPair.generate();
+      const service = new AggregationService({ did: 'did:btcr2:svc', publicKey: kp.publicKey });
+      expect([...service.publicKey.compressed]).to.deep.equal([...kp.publicKey.compressed]);
+    });
+  });
+});

--- a/packages/method/tests/aggregation-security.spec.ts
+++ b/packages/method/tests/aggregation-security.spec.ts
@@ -8,6 +8,7 @@ import {
   BaseMessage,
   COHORT_ADVERT,
   DidBtcr2,
+  KeyPairAggregationSigner,
   ServiceCohortPhase,
   createCohortOptInMessage,
   createSubmitUpdateMessage,
@@ -48,7 +49,7 @@ describe('Aggregation security regressions', () => {
       const aliceDid = DidBtcr2.create(aliceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
       const aliceKeys2 = SchnorrKeyPair.generate();
 
-      const service = new AggregationService({ did: serviceDid, keys: serviceKeys });
+      const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
       const cohortId = service.createCohort({ minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon' });
       service.advertise(cohortId);
 
@@ -89,7 +90,7 @@ describe('Aggregation security regressions', () => {
 
       const service = new AggregationService({
         did                : serviceDid,
-        keys               : serviceKeys,
+        publicKey          : serviceKeys.publicKey,
         maxUpdateSizeBytes : 1024,
       });
       const cohortId = service.createCohort({ minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon' });
@@ -132,7 +133,7 @@ describe('Aggregation security regressions', () => {
       const aliceKeys = SchnorrKeyPair.generate();
       const aliceDid = DidBtcr2.create(aliceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
-      const service = new AggregationService({ did: serviceDid, keys: serviceKeys });
+      const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
       const cohortId = service.createCohort({ minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon' });
       service.advertise(cohortId);
 
@@ -157,7 +158,7 @@ describe('Aggregation security regressions', () => {
     it('participant rejects messages with a mismatched version', () => {
       const keys = SchnorrKeyPair.generate();
       const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
-      const participant = new AggregationParticipant({ did, keys });
+      const participant = new AggregationParticipant({ did, signer: new KeyPairAggregationSigner(keys) });
 
       const badAdvert = new BaseMessage({
         type    : COHORT_ADVERT,
@@ -180,7 +181,7 @@ describe('Aggregation security regressions', () => {
     it('phase transitions to Failed when a participant rejects', () => {
       const serviceKeys = SchnorrKeyPair.generate();
       const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
-      const service = new AggregationService({ did: serviceDid, keys: serviceKeys });
+      const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
       const cohortId = service.createCohort({ minParticipants: 1, network: 'mutinynet', beaconType: 'CASBeacon' });
       service.advertise(cohortId);
 

--- a/packages/method/tests/aggregation-signing.spec.ts
+++ b/packages/method/tests/aggregation-signing.spec.ts
@@ -20,11 +20,11 @@ function buildDummyTx(outputScript: Uint8Array, prevOutValue: bigint): Transacti
 
 describe('Aggregation signing regressions', () => {
 
-  describe('T1.4: secretNonce zeroization', () => {
-    it('clears secretNonce after generatePartialSignature', () => {
+  describe('T1.4: secret nonce cleared after signing', () => {
+    it('clears the secret nonce so a second generatePartialSignature throws', () => {
       const kp1 = SchnorrKeyPair.generate();
       const kp2 = SchnorrKeyPair.generate();
-      const cohort = new AggregationCohort({ minParticipants: 2, network: 'mainnet' });
+      const cohort = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
       cohort.participants.push('did:btcr2:alice', 'did:btcr2:bob');
       cohort.participantKeys.set('did:btcr2:alice', kp1.publicKey.compressed);
       cohort.participantKeys.set('did:btcr2:bob', kp2.publicKey.compressed);
@@ -48,17 +48,18 @@ describe('Aggregation signing regressions', () => {
         prevOutScripts : [payment.script],
         prevOutValues  : [100000n],
       });
-      p1.generateNonceContribution(kp1.publicKey.compressed, kp1.secretKey.bytes);
-      expect(p1.secretNonce).to.be.instanceOf(Uint8Array);
-
-      // Fake an aggregated nonce so generatePartialSignature can run
       const nonce1 = p1.generateNonceContribution(kp1.publicKey.compressed, kp1.secretKey.bytes);
       const nonce2 = p2.generateNonceContribution(kp2.publicKey.compressed, kp2.secretKey.bytes);
       const agg = musig2.nonceAggregate([nonce1, nonce2]);
       p1.aggregatedNonce = agg;
 
+      // First partial sign succeeds and wipes the secret nonce.
       p1.generatePartialSignature(kp1.secretKey.bytes);
-      expect(p1.secretNonce).to.be.undefined;
+
+      // The secret nonce is private and cleared on every path; a second attempt
+      // must throw rather than reuse it (MuSig2 nonce reuse leaks the secret key).
+      expect(() => p1.generatePartialSignature(kp1.secretKey.bytes))
+        .to.throw(/MISSING_SECRET_NONCE|Secret nonce not available/);
     });
   });
 
@@ -66,7 +67,7 @@ describe('Aggregation signing regressions', () => {
     it('generateFinalSignature throws BAD_PARTIAL_SIG on a corrupted contribution', () => {
       const kp1 = SchnorrKeyPair.generate();
       const kp2 = SchnorrKeyPair.generate();
-      const cohort = new AggregationCohort({ minParticipants: 2, network: 'mainnet' });
+      const cohort = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
       cohort.participants.push('did:btcr2:alice', 'did:btcr2:bob');
       cohort.participantKeys.set('did:btcr2:alice', kp1.publicKey.compressed);
       cohort.participantKeys.set('did:btcr2:bob', kp2.publicKey.compressed);

--- a/packages/method/tests/aggregation-solo.spec.ts
+++ b/packages/method/tests/aggregation-solo.spec.ts
@@ -1,3 +1,4 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { Address, OutScript, SigHash, Transaction } from '@scure/btc-signer';
@@ -51,10 +52,10 @@ describe('AggregationRunner.solo (cohort of one)', () => {
 
       onProvideTxData : async ({ beaconAddress }) => {
         // The cohort beacon address is a P2TR key-path output of the aggregated
-        // cohort key. AggregationCohort.computeBeaconAddress() derives it with
-        // scure's default (mainnet) network, so decode it the same way. From the
-        // scriptPubKey we get the tweaked output key to verify against.
-        const script = OutScript.encode(Address().decode(beaconAddress));
+        // cohort key. AggregationCohort.computeBeaconAddress() derives it for the
+        // cohort's network (here mutinynet → tb1p), so decode it with the same
+        // network. From the scriptPubKey we get the tweaked output key to verify.
+        const script = OutScript.encode(Address(getNetwork('mutinynet')).decode(beaconAddress));
         const tweakedPk = script.slice(2); // P2TR: OP_1 (0x51) OP_PUSHBYTES_32 (0x20) <32-byte x-only key>
         const prevOutValue = 100_000n;
 
@@ -64,7 +65,7 @@ describe('AggregationRunner.solo (cohort of one)', () => {
           index       : 0,
           witnessUtxo : { amount: prevOutValue, script },
         });
-        tx.addOutputAddress(beaconAddress, prevOutValue - 500n);
+        tx.addOutputAddress(beaconAddress, prevOutValue - 500n, getNetwork('mutinynet'));
 
         capturedSighash = tx.preimageWitnessV1(0, [script], SigHash.DEFAULT, [prevOutValue]);
         capturedTweakedPk = tweakedPk;

--- a/packages/method/tests/aggregation.spec.ts
+++ b/packages/method/tests/aggregation.spec.ts
@@ -14,6 +14,7 @@ import {
   COHORT_ADVERT,
   COHORT_OPT_IN,
   DidBtcr2,
+  KeyPairAggregationSigner,
   NostrTransport,
   ParticipantCohortPhase,
   ServiceCohortPhase,
@@ -84,7 +85,7 @@ describe('Aggregation', () => {
     it('cohortKeys are sorted on assignment', () => {
       const kp1 = SchnorrKeyPair.generate();
       const kp2 = SchnorrKeyPair.generate();
-      const cohort = new AggregationCohort({ minParticipants: 2, network: 'mainnet' });
+      const cohort = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
       cohort.cohortKeys = [kp1.publicKey.compressed, kp2.publicKey.compressed];
       const keys = cohort.cohortKeys;
       for(let i = 1; i < keys.length; i++) {
@@ -97,13 +98,32 @@ describe('Aggregation', () => {
     it('computeBeaconAddress returns a Taproot address', () => {
       const kp1 = SchnorrKeyPair.generate();
       const kp2 = SchnorrKeyPair.generate();
-      const cohort = new AggregationCohort({ minParticipants: 2, network: 'mainnet' });
+      const cohort = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
       cohort.participants.push('did:btcr2:alice', 'did:btcr2:bob');
       cohort.cohortKeys = [kp1.publicKey.compressed, kp2.publicKey.compressed];
       const addr = cohort.computeBeaconAddress();
       expect(addr).to.be.a('string');
       expect(addr.startsWith('bc1p')).to.be.true;
       expect(cohort.tapTweak.length).to.equal(32);
+    });
+
+    it('derives the beacon address for the cohort network (not always mainnet)', () => {
+      const kp1 = SchnorrKeyPair.generate();
+      const kp2 = SchnorrKeyPair.generate();
+      const keys = [kp1.publicKey.compressed, kp2.publicKey.compressed];
+
+      const mutiny = new AggregationCohort({ minParticipants: 2, network: 'mutinynet' });
+      mutiny.cohortKeys = keys;
+      expect(mutiny.computeBeaconAddress().startsWith('tb1p')).to.be.true;
+
+      const regtest = new AggregationCohort({ minParticipants: 2, network: 'regtest' });
+      regtest.cohortKeys = keys;
+      expect(regtest.computeBeaconAddress().startsWith('bcrt1p')).to.be.true;
+
+      // Same keys, different network → different address (only the HRP differs).
+      const mainnet = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
+      mainnet.cohortKeys = keys;
+      expect(mainnet.computeBeaconAddress().startsWith('bc1p')).to.be.true;
     });
   });
 
@@ -118,7 +138,7 @@ describe('Aggregation', () => {
     beforeEach(() => {
       kp1 = SchnorrKeyPair.generate();
       kp2 = SchnorrKeyPair.generate();
-      cohort = new AggregationCohort({ minParticipants: 2, network: 'mainnet' });
+      cohort = new AggregationCohort({ minParticipants: 2, network: 'bitcoin' });
       cohort.participants.push('did:btcr2:alice', 'did:btcr2:bob');
       cohort.participantKeys.set('did:btcr2:alice', kp1.publicKey.compressed);
       cohort.participantKeys.set('did:btcr2:bob', kp2.publicKey.compressed);
@@ -296,9 +316,9 @@ describe('Aggregation', () => {
       bobDid = DidBtcr2.create(bobKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
       // Create state machines
-      service = new AggregationService({ did: serviceDid, keys: serviceKeys });
-      alice = new AggregationParticipant({ did: aliceDid, keys: aliceKeys });
-      bob = new AggregationParticipant({ did: bobDid, keys: bobKeys });
+      service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
+      alice = new AggregationParticipant({ did: aliceDid, signer: new KeyPairAggregationSigner(aliceKeys) });
+      bob = new AggregationParticipant({ did: bobDid, signer: new KeyPairAggregationSigner(bobKeys) });
 
       // Each actor gets its own transport (multi-process simulation)
       bus = new MessageBus();
@@ -370,7 +390,8 @@ describe('Aggregation', () => {
       const readyMsgs = service.finalizeKeygen(cohortId);
       expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
       const beaconAddress = service.getCohort(cohortId)!.beaconAddress;
-      expect(beaconAddress).to.match(/^bc1p/);
+      // Cohort network is mutinynet (signet address format) → tb1p, not bc1p.
+      expect(beaconAddress).to.match(/^tb1p/);
       await send(serviceTransport, serviceDid, readyMsgs);
 
       // Both participants reached CohortReady with the same beacon address
@@ -714,7 +735,7 @@ describe('Aggregation', () => {
       await aliceRunner.start();
 
       // Use raw state machine to advertise without running the full service runner
-      const service = new AggregationService({ did: serviceDid, keys: serviceKeys });
+      const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
       const cohortId = service.createCohort({ minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon' });
       const advertMsgs = service.advertise(cohortId);
       for(const m of advertMsgs) await serviceTransport.sendMessage(m, serviceDid, m.to);


### PR DESCRIPTION
* docs: add ADR 038 MuSig2 key custody (bounded, zeroized secrets)
* feat(method)!: bound and zeroize MuSig2 secrets at the participant boundary
* fix(method): derive cohort beacon address for the cohort network, not always mainnet
* chore(release): bump method 0.35.0, keypair 0.13.1, api 0.9.1, cli 0.10.1