### PR TITLE
adopt the cohort-condition model for aggregate beacons

### DIFF
--- a/docs/adr/039-cohort-condition-model.md
+++ b/docs/adr/039-cohort-condition-model.md
@@ -1,0 +1,118 @@
+---
+title: "ADR 039: Cohort Condition Model"
+---
+
+# ADR 039: Cohort Condition Model
+
+**Status:** Accepted
+
+**Date:** 2026-06-21
+
+**Branch / PR:** `feat/aggregation-cohort-conditions`
+**References:** [ADR 008](008-aggregation-subsystem-inception.md), [ADR 020](020-aggregation-layered-architecture.md), [ADR 027](027-aggregation-security-hardening.md), [ADR 038](038-musig2-key-custody.md)
+
+## Context
+
+When an Aggregation Service creates a cohort, it advertises the conditions under which prospective participants may enroll. The did:btcr2 specification ([Aggregate Beacons, "Step 1: Create Aggregation Cohort"](https://dcdpr.github.io/did-btcr2/beacons/aggregate-beacons.html#step-1-create-aggregation-cohort), source `src/beacons/aggregate-beacons.md`, last substantively edited 2026-05-26) enumerates the conditions a service **can** define:
+
+> When defining an Aggregation Cohort, the Aggregation Service **can** define conditions **such as**:
+> - Beacon Type (CAS or SMT);
+> - Minimum and/or maximum number of Aggregation Participants;
+> - Minimum and/or maximum number of DIDs per Aggregation Participant;
+> - Cost of enrollment;
+> - Cost per announcement per DID or Aggregation Participant;
+> - Minimum and/or maximum time between announcements; and
+> - Number of pending updates that trigger an announcement.
+
+The phrasing ("**can** define conditions **such as**") makes this an **illustrative, optional menu**, not a closed normative set: the spec also declares the full coordination protocol out of scope. The repo's `TODO.md` records the same seven and notes the implementation "only defines three."
+
+**What the implementation models today** (verified against `service.ts`, `cohort.ts`, `messages/bodies.ts`):
+
+- `CohortConfig` has exactly three fields: `minParticipants`, `network`, `beaconType`. Of the spec's seven conditions, only **beacon type** and **a participant floor** are modeled (`network` is a separate cohort parameter, not one of the seven).
+- The participant floor is carried on the wire as `cohortSize` (`CohortAdvertBody.cohortSize`), sourced from `config.minParticipants` and read back by the participant as `minParticipants`. The name implies an exact target; the service enforces it **only as a lower bound** at `finalizeKeygen` (`accepted >= minParticipants`). A participant cannot tell from the advert whether the number is a floor, a target, or a cap.
+- **No maximum exists anywhere.** `acceptParticipant()` appends unconditionally, so a cohort can grow without bound (the unbounded-growth concern carried over from the [ADR 038](038-musig2-key-custody.md) milestone notes).
+- **No validation.** `createCohort()` accepts any `minParticipants` (including 0 or negative); `AggregationCohort` silently coerces a falsy value to 2 via `|| 2`; the participant defaults a missing `cohortSize` to `0`; advert guards check only that `cohortSize` is a number, never its range.
+- The other five conditions (DIDs-per-participant, cost of enrollment, cost per announcement, timing/cadence, pending-update-count trigger) are **entirely absent** from the config, the wire format, and the state machines.
+
+**Prior decisions to reconcile:**
+
+- [ADR 008](008-aggregation-subsystem-inception.md) deliberately put economics out of scope: *"No incentive mechanism ... the protocol makes the cryptography possible without mandating an economic model."* Two of the seven conditions (cost of enrollment, cost per announcement) are economic.
+- [ADR 027](027-aggregation-security-hardening.md) introduced a **Cohort TTL** (timed-out cohorts transition to `Failed`) and **idempotent membership** (a re-opt-in from an accepted DID does not get a second slot). These are the hooks any timing and DIDs-per-participant conditions must build on.
+- The aggregation milestone **locked an advertise-only economics decision**: model and advertise the cost conditions, do not implement payment/settlement now. The spec agrees: it lists costs as advertised conditions but defines no settlement, escrow, or billing.
+
+| # | Spec condition | Modeled today | This ADR: how handled |
+| --- | --- | --- | --- |
+| 1 | Beacon Type (CAS / SMT) | yes | keep; validate at `createCohort` |
+| 2 | Min / max participants | floor only (as `cohortSize`) | **enforced**: rename to `minParticipants` + optional `maxParticipants`; gate accept + finalize |
+| 3 | Min / max DIDs per participant | no | model now; **enforcement staged** (couples to the submission model / AGG-5) |
+| 4 | Cost of enrollment | no | model now; **advertised-only**, no settlement |
+| 5 | Cost per announcement | no | model now; **advertised-only**, no settlement |
+| 6 | Min / max time between announcements | no (TTL is adjacent) | model now; **enforcement staged** (generalizes the ADR 027 TTL; couples to multi-round/AGG-5) |
+| 7 | Pending-update-count trigger | no (`hasAllUpdates` only) | model now; **enforcement staged** (generalizes `hasAllUpdates`; couples to AGG-5) |
+
+## Decision
+
+Adopt the spec's seven conditions as an explicit, mostly-optional **cohort-condition model** carried in `CohortConfig` and the `COHORT_ADVERT` body. Enforce the self-contained structural conditions now; model the rest as a stable wire format with enforcement staged to the tracks they couple to; advertise economics without settlement.
+
+1. **Introduce a `CohortConditions` structure** (embedded in `CohortConfig` and serialized into `CohortAdvertBody`). `beaconType` and `minParticipants` are required; every other condition is **optional, and absent means unconstrained** - matching the spec's "can define ... such as" menu. Sketch:
+
+   ```ts
+   interface CohortConditions {
+     beaconType: 'CASBeacon' | 'SMTBeacon';        // 1  required
+     minParticipants: number;                       // 2  required (lower bound)
+     maxParticipants?: number;                      // 2  optional (upper bound)
+     minDidsPerParticipant?: number;                // 3  optional
+     maxDidsPerParticipant?: number;                // 3  optional
+     costOfEnrollment?: CohortCost;                 // 4  optional, advertised-only
+     costPerAnnouncement?: CohortCost;              // 5  optional, advertised-only
+     minSecondsBetweenAnnouncements?: number;       // 6  optional
+     maxSecondsBetweenAnnouncements?: number;       // 6  optional
+     pendingUpdateTrigger?: number;                 // 7  optional
+   }
+   interface CohortCost { amount: number; unit: string; basis?: 'per-did' | 'per-participant'; }
+   ```
+   `network` stays a separate cohort parameter (it is not one of the seven conditions).
+
+2. **Replace the conflated `cohortSize` wire field** with an explicit `minParticipants` + optional `maxParticipants` pair. This is a breaking change to the `COHORT_ADVERT` body; pre-1.0, a clean rename is preferred over keeping a misleadingly-named field.
+
+3. **Enforce the structural participant bounds now.** `maxParticipants` gates `acceptParticipant()` (reject once the cohort is full) and is a ceiling at `finalizeKeygen`; `minParticipants` remains the finalize floor. This closes the unbounded-growth path.
+
+4. **Validate conditions fail-fast at `createCohort()`** rather than discovering invalidity at finalize: `minParticipants >= 1`, `maxParticipants >= minParticipants` when present, `min* <= max*` for every paired bound, non-negative costs and counts. Remove the `|| 2` silent default-drift (reject a missing/zero `minParticipants` instead of coercing it) and the participant's `?? 0` silent zero-floor (reject a malformed advert). Make the advert/opt-in guards range-check, not presence-check.
+
+5. **Economics are advertised-only.** `costOfEnrollment` and `costPerAnnouncement` are operator-published metadata a participant uses to decide whether to join. The service performs **no payment, settlement, escrow, or enforcement** of them - consistent with [ADR 008](008-aggregation-subsystem-inception.md) ("no economic model mandated") and the spec (which advertises costs but defines no settlement). A future payment milestone, if any, gets its own ADR.
+
+6. **Model the remaining conditions now, stage their enforcement.** Add the wire/config fields for DIDs-per-participant (3), timing/cadence (6), and the pending-update-count trigger (7) so the advert format is stable before multi-cohort (AGG-4) builds on it, but land full enforcement with the tracks they couple to: DIDs-per-participant and the update-count trigger depend on the multi-DID / long-standing-cohort submission model from non-inclusion (AGG-5); `maxSecondsBetweenAnnouncements` generalizes the [ADR 027](027-aggregation-security-hardening.md) Cohort TTL, and `pendingUpdateTrigger` generalizes `hasAllUpdates()` (announce at a threshold, not only when all participants have submitted). Fields modeled-but-not-yet-enforced are documented as such so the advert never implies enforcement that does not exist.
+
+7. **Conditions are advisory to participants, structural to the service.** Per the spec, the advertised conditions let a participant decide whether to enroll; the service enforces only the structural subset (participant bounds now; DIDs-per-participant, timing, and trigger as they land).
+
+### Rejected alternatives
+
+- **Keep `cohortSize`, add `maxParticipants` beside it.** Perpetuates the floor-vs-exact ambiguity and the misleading name. Pre-1.0, a clean rename to a `minParticipants`/`maxParticipants` pair is clearer than layering a second field onto a misnamed one.
+- **Implement payment / settlement for the cost conditions.** Out of scope per [ADR 008](008-aggregation-subsystem-inception.md), the spec (no settlement defined), and the locked milestone decision. Advertise-only keeps the protocol honest about what it enforces.
+- **Model only the structural conditions, skip the rest.** Leaves the advert format unstable for multi-cohort (AGG-4) and diverges from the spec's menu. Modeling all seven now (even with staged enforcement) freezes the wire format once.
+- **Treat the seven as a closed MUST-set.** The spec says "can define ... such as" - an open, optional menu. The model uses optional fields (absent = unconstrained) and stays extensible rather than mandating all seven.
+
+## Consequences
+
+**Positive**
+- The advert format mirrors the spec's condition menu and is stable for multi-cohort (AGG-4) to build on without re-churn.
+- The `minParticipants`/`maxParticipants` pair closes the unbounded-cohort growth path and removes the `cohortSize` floor-vs-exact ambiguity; participants can read the real bounds.
+- Fail-fast validation surfaces a bad `CohortConfig` at creation instead of at finalize, and the guards stop accepting out-of-range adverts.
+- Economics are represented honestly: advertised metadata, not enforcement the protocol cannot back.
+
+**Negative**
+- Breaking change to the `COHORT_ADVERT` body (`cohortSize` to `minParticipants` + `maxParticipants`, plus new optional condition fields) and to `CohortConfig` - a `method` version bump; advertise and participant-side parsing change together.
+- Some conditions are modeled but not yet enforced (DIDs-per-participant, timing, update-count trigger). This must be clearly documented in code and types so callers do not assume enforcement that is staged.
+
+**Accepted**
+- Economics are advertise-only with no settlement for the foreseeable future; a payment model, if ever, is a separate milestone and ADR.
+- DIDs-per-participant, timing/cadence, and pending-update-count enforcement are staged to AGG-4 (multi-cohort) and AGG-5 (non-inclusion / long-standing cohorts), which own the submission and multi-round mechanics those conditions need.
+- **Spec-silent choices made here** (flagged for review): cost is modeled as `{ amount, unit, basis }` with an operator-defined `unit` (the spec gives no currency or units); conditions are serialized as explicit advert-body fields rather than a nested object (wire-shape detail the spec does not constrain). Both are reversible during implementation if preferred.
+
+## References
+
+- [did:btcr2 spec - Aggregate Beacons, Step 1: Create Aggregation Cohort](https://dcdpr.github.io/did-btcr2/beacons/aggregate-beacons.html#step-1-create-aggregation-cohort) (source: `src/beacons/aggregate-beacons.md`): the authoritative seven-condition menu.
+- [`packages/method/src/core/aggregation/service.ts`](../../packages/method/src/core/aggregation/service.ts): `CohortConfig`, `createCohort`, `advertise`, `acceptParticipant`, `finalizeKeygen` - where conditions are set and (under-)enforced.
+- [`packages/method/src/core/aggregation/messages/bodies.ts`](../../packages/method/src/core/aggregation/messages/bodies.ts): `CohortAdvertBody` and the guards to range-check.
+- [`packages/method/src/core/aggregation/cohort.ts`](../../packages/method/src/core/aggregation/cohort.ts): `AggregationCohortParams`, the `|| 2` default to remove.
+- [ADR 008](008-aggregation-subsystem-inception.md): economics out of scope (this ADR extends, does not contradict, that boundary). [ADR 020](020-aggregation-layered-architecture.md): the cohort-formation API surface. [ADR 027](027-aggregation-security-hardening.md): the Cohort TTL and idempotent-membership rules the timing and DIDs-per-participant conditions build on. [ADR 038](038-musig2-key-custody.md): the prior aggregation milestone stage.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -39,6 +39,7 @@ children:
   - ./036-zero-hash-smt-model.md
   - ./037-single-party-beacon-and-two-axis-model.md
   - ./038-musig2-key-custody.md
+  - ./039-cohort-condition-model.md
 ---
 
 # Architecture Decision Records
@@ -85,3 +86,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 036 | 2026-06-16 | [Adopt the Zero-Hash SMT Model per algorithms.html](036-zero-hash-smt-model.md) |
 | 037 | 2026-06-19 | [Rename Beacon to SinglePartyBeacon and the Two-Axis Beacon Model](037-single-party-beacon-and-two-axis-model.md) |
 | 038 | 2026-06-20 | [MuSig2 Key Custody: Bounded, Zeroized Secrets at the Participant Boundary](038-musig2-key-custody.md) |
+| 039 | 2026-06-21 | [Cohort Condition Model](039-cohort-condition-model.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.35.0",
+    "version": "0.36.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/aggregation/cohort.ts
+++ b/packages/method/src/core/aggregation/cohort.ts
@@ -91,7 +91,9 @@ export class AggregationCohort {
 
   constructor({ id, minParticipants, serviceDid, network, beaconType }: AggregationCohortParams) {
     this.id = id || crypto.randomUUID();
-    this.minParticipants = minParticipants || 2;
+    // `?? 2` (not `|| 2`) so a deliberately-passed 0 is preserved rather than
+    // silently coerced; the service rejects an invalid count at createCohort.
+    this.minParticipants = minParticipants ?? 2;
     this.serviceDid = serviceDid || '';
     this.network = network;
     this.beaconType = beaconType || 'CASBeacon';

--- a/packages/method/src/core/aggregation/conditions.ts
+++ b/packages/method/src/core/aggregation/conditions.ts
@@ -1,0 +1,116 @@
+/**
+ * Cohort conditions: the constraints an Aggregation Service advertises for a
+ * cohort (did:btcr2 spec, "Step 1: Create Aggregation Cohort"). See ADR 039.
+ *
+ * The spec frames these as an optional menu ("the Aggregation Service can define
+ * conditions such as ..."), so only `beaconType` and `minParticipants` are
+ * required here; every other condition is optional and, when absent, means
+ * unconstrained.
+ *
+ * Enforcement is staged (ADR 039): `beaconType` and the participant bounds are
+ * enforced by the state machine now; DIDs-per-participant, timing/cadence, and
+ * the pending-update trigger are modeled and advertised here but enforced when
+ * the multi-cohort (AGG-4) and non-inclusion (AGG-5) tracks land. The two cost
+ * conditions are advertised metadata only - the protocol performs no payment or
+ * settlement (consistent with ADR 008).
+ */
+
+/** Beacon types that support aggregation (singleton is single-party only, per ADR 037). */
+export const KNOWN_BEACON_TYPES = ['CASBeacon', 'SMTBeacon'] as const;
+
+/**
+ * An advertised price. `unit` is operator-defined (the spec does not specify a
+ * currency); `basis` distinguishes a per-DID from a per-participant charge for
+ * "cost per announcement". Advertised only - never settled by the protocol.
+ */
+export interface CohortCost {
+  amount: number;
+  unit: string;
+  basis?: 'per-did' | 'per-participant';
+}
+
+/** The seven spec cohort conditions. Only beaconType + minParticipants are required. */
+export interface CohortConditions {
+  /** 1. Beacon mechanism: 'CASBeacon' or 'SMTBeacon'. Enforced. */
+  beaconType: string;
+  /** 2. Lower bound on cohort size. Enforced (finalize floor). */
+  minParticipants: number;
+  /** 2. Upper bound on cohort size. Enforced (accept/finalize ceiling). */
+  maxParticipants?: number;
+  /** 3. Lower bound on DIDs a participant may register. Advertised; enforcement staged (AGG-5). */
+  minDidsPerParticipant?: number;
+  /** 3. Upper bound on DIDs a participant may register. Advertised; enforcement staged (AGG-5). */
+  maxDidsPerParticipant?: number;
+  /** 4. One-time enrollment price. Advertised only - no settlement. */
+  costOfEnrollment?: CohortCost;
+  /** 5. Recurring per-announcement price. Advertised only - no settlement. */
+  costPerAnnouncement?: CohortCost;
+  /** 6. Floor on time between announcements (seconds). Advertised; enforcement staged (AGG-4/5). */
+  minSecondsBetweenAnnouncements?: number;
+  /** 6. Ceiling on time between announcements (seconds). Advertised; enforcement staged - generalizes the ADR 027 Cohort TTL. */
+  maxSecondsBetweenAnnouncements?: number;
+  /** 7. Pending-update count that triggers an announcement. Advertised; enforcement staged (AGG-5) - generalizes hasAllUpdates(). */
+  pendingUpdateTrigger?: number;
+}
+
+/** Validate an optional [min, max] integer pair. */
+function checkPair(problems: string[], label: string, min?: number, max?: number): void {
+  if(min !== undefined && (!Number.isInteger(min) || min < 0)) {
+    problems.push(`min${label} must be an integer >= 0`);
+  }
+  if(max !== undefined && (!Number.isInteger(max) || max < 0)) {
+    problems.push(`max${label} must be an integer >= 0`);
+  }
+  if(min !== undefined && max !== undefined && Number.isInteger(min) && Number.isInteger(max) && max < min) {
+    problems.push(`max${label} must be >= min${label}`);
+  }
+}
+
+/** Validate an optional advertised cost. */
+function checkCost(problems: string[], label: string, cost?: CohortCost): void {
+  if(cost === undefined) return;
+  if(typeof cost.amount !== 'number' || !Number.isFinite(cost.amount) || cost.amount < 0) {
+    problems.push(`${label}.amount must be a finite number >= 0`);
+  }
+  if(typeof cost.unit !== 'string' || cost.unit.length === 0) {
+    problems.push(`${label}.unit must be a non-empty string`);
+  }
+  if(cost.basis !== undefined && cost.basis !== 'per-did' && cost.basis !== 'per-participant') {
+    problems.push(`${label}.basis must be 'per-did' or 'per-participant'`);
+  }
+}
+
+/**
+ * Validate a set of cohort conditions. Returns a list of human-readable problems
+ * (empty when valid) so the caller can decide how to surface them. Used by
+ * `createCohort()` to fail fast instead of discovering invalidity at finalize.
+ */
+export function validateCohortConditions(c: CohortConditions): string[] {
+  const problems: string[] = [];
+
+  if(!(KNOWN_BEACON_TYPES as readonly string[]).includes(c.beaconType)) {
+    problems.push(`beaconType must be one of ${KNOWN_BEACON_TYPES.join(', ')}`);
+  }
+  if(!Number.isInteger(c.minParticipants) || c.minParticipants < 1) {
+    problems.push('minParticipants must be an integer >= 1');
+  }
+  if(c.maxParticipants !== undefined) {
+    if(!Number.isInteger(c.maxParticipants) || c.maxParticipants < 1) {
+      problems.push('maxParticipants must be an integer >= 1');
+    } else if(Number.isInteger(c.minParticipants) && c.maxParticipants < c.minParticipants) {
+      problems.push('maxParticipants must be >= minParticipants');
+    }
+  }
+
+  checkPair(problems, 'DidsPerParticipant', c.minDidsPerParticipant, c.maxDidsPerParticipant);
+  checkPair(problems, 'SecondsBetweenAnnouncements', c.minSecondsBetweenAnnouncements, c.maxSecondsBetweenAnnouncements);
+
+  if(c.pendingUpdateTrigger !== undefined && (!Number.isInteger(c.pendingUpdateTrigger) || c.pendingUpdateTrigger < 1)) {
+    problems.push('pendingUpdateTrigger must be an integer >= 1');
+  }
+
+  checkCost(problems, 'costOfEnrollment', c.costOfEnrollment);
+  checkCost(problems, 'costPerAnnouncement', c.costPerAnnouncement);
+
+  return problems;
+}

--- a/packages/method/src/core/aggregation/messages/base.ts
+++ b/packages/method/src/core/aggregation/messages/base.ts
@@ -1,3 +1,5 @@
+import type { CohortConditions } from '../conditions.js';
+
 /**
  * Current on-the-wire protocol version.
  *
@@ -7,9 +9,11 @@
  */
 export const AGGREGATION_WIRE_VERSION = 1;
 
-export type BaseBody = {
+// Cohort conditions (beaconType, minParticipants, maxParticipants, ...) ride on
+// the wire as flat optional body fields, supplied via `Partial<CohortConditions>`
+// below so the bag stays a single source of truth for the advertised conditions.
+export type BaseBody = Partial<CohortConditions> & {
   cohortId: string;
-  cohortSize?: number;
   network?: string;
   participantPk?: Uint8Array;
   beaconAddress?: string;
@@ -23,7 +27,6 @@ export type BaseBody = {
   prevOutScriptHex?: string;
   prevOutValue?: string;
   communicationPk?: Uint8Array;
-  beaconType?: string;
   data?: string;
   signedUpdate?: Record<string, unknown>;
   casAnnouncement?: Record<string, string>;

--- a/packages/method/src/core/aggregation/messages/bodies.ts
+++ b/packages/method/src/core/aggregation/messages/bodies.ts
@@ -12,6 +12,7 @@
  */
 
 import type { SerializedSMTProof } from '@did-btcr2/smt';
+import type { CohortConditions } from '../conditions.js';
 import type { BaseMessage } from './base.js';
 import {
   AGGREGATED_NONCE,
@@ -29,10 +30,8 @@ import {
 
 // ── Cohort formation (Step 1) ─────────────────────────────────────────────
 
-export interface CohortAdvertBody {
+export interface CohortAdvertBody extends CohortConditions {
   cohortId: string;
-  cohortSize: number;
-  beaconType: string;
   network: string;
   communicationPk: Uint8Array;
 }
@@ -135,8 +134,16 @@ export type AggregationMessage =
 
 const hasStr = (b: unknown, k: string): boolean =>
   !!b && typeof (b as Record<string, unknown>)[k] === 'string';
-const hasNum = (b: unknown, k: string): boolean =>
-  !!b && typeof (b as Record<string, unknown>)[k] === 'number';
+/** Present, an integer, and >= min. */
+const hasIntMin = (b: unknown, k: string, min: number): boolean => {
+  const v = b ? (b as Record<string, unknown>)[k] : undefined;
+  return typeof v === 'number' && Number.isInteger(v) && v >= min;
+};
+/** Absent, or present as an integer >= min. */
+const optIntMin = (b: unknown, k: string, min: number): boolean => {
+  const v = b ? (b as Record<string, unknown>)[k] : undefined;
+  return v === undefined || (typeof v === 'number' && Number.isInteger(v) && v >= min);
+};
 const hasBool = (b: unknown, k: string): boolean =>
   !!b && typeof (b as Record<string, unknown>)[k] === 'boolean';
 const hasBytes = (b: unknown, k: string): boolean =>
@@ -147,9 +154,14 @@ const hasBytesArray = (b: unknown, k: string): boolean => {
 };
 
 export function isCohortAdvertMessage(m: BaseMessage): m is CohortAdvertMessage {
+  // Range-check the participant bounds so a malformed advert (missing or
+  // zero/negative minParticipants) is rejected rather than silently accepted as
+  // a zero-floor cohort. The service does the full cross-field validation at
+  // createCohort (see validateCohortConditions); here we guard the wire shape.
   return m.type === COHORT_ADVERT
     && hasStr(m.body, 'cohortId')
-    && hasNum(m.body, 'cohortSize')
+    && hasIntMin(m.body, 'minParticipants', 1)
+    && optIntMin(m.body, 'maxParticipants', 1)
     && hasStr(m.body, 'beaconType')
     && hasStr(m.body, 'network')
     && hasBytes(m.body, 'communicationPk');

--- a/packages/method/src/core/aggregation/messages/factories.ts
+++ b/packages/method/src/core/aggregation/messages/factories.ts
@@ -1,3 +1,4 @@
+import type { CohortConditions } from '../conditions.js';
 import { BaseMessage } from './base.js';
 import {
   AGGREGATED_NONCE,
@@ -18,11 +19,9 @@ import {
  * Factory functions for creating messages related to the cohort formation step, where cohorts are
  * formed and participants opt in to join the cohort.
  */
-type CohortAdvertMessage = {
+type CohortAdvertMessage = CohortConditions & {
   from: string;
   cohortId: string;
-  cohortSize: number;
-  beaconType: string;
   network: string;
   communicationPk: Uint8Array;
 };

--- a/packages/method/src/core/aggregation/participant.ts
+++ b/packages/method/src/core/aggregation/participant.ts
@@ -5,8 +5,10 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from './beacon-strategy.js';
 import { AggregationCohort } from './cohort.js';
+import type { CohortConditions } from './conditions.js';
 import { AggregationParticipantError } from './errors.js';
 import type { BaseMessage } from './messages/base.js';
+import { isCohortAdvertMessage } from './messages/bodies.js';
 import { AGGREGATION_WIRE_VERSION } from './messages/base.js';
 import {
   AGGREGATED_NONCE,
@@ -28,13 +30,15 @@ import { ParticipantCohortPhase } from './phases.js';
 import type { AggregationSigner } from './signer.js';
 import { BeaconSigningSession } from './signing-session.js';
 
-/** Cohort advert as discovered by the participant (UI: list of joinable cohorts). */
-export interface CohortAdvert {
+/**
+ * Cohort advert as discovered by the participant (UI: list of joinable cohorts).
+ * Carries the advertised {@link CohortConditions} (beaconType, minParticipants,
+ * maxParticipants, costs, ...) so a `shouldJoin` decision can inspect them.
+ */
+export interface CohortAdvert extends CohortConditions {
   cohortId: string;
   serviceDid: string;
-  cohortSize: number;
   network: string;
-  beaconType: string;
   serviceCommunicationPk: Uint8Array;
 }
 
@@ -168,17 +172,18 @@ export class AggregationParticipant {
   }
 
   #handleCohortAdvert(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
+    // Validate the wire shape (incl. minParticipants range) before trusting it,
+    // rather than reading fields with `?? 0` fallbacks (see ADR 039).
+    if(!isCohortAdvertMessage(message)) return;
+    const { cohortId, network, communicationPk, ...conditions } = message.body;
     if(this.#cohortStates.has(cohortId)) return;  // Already known
 
     const advert: CohortAdvert = {
       cohortId,
       serviceDid             : message.from,
-      cohortSize             : message.body?.cohortSize ?? 0,
-      network                : message.body?.network ?? '',
-      beaconType             : message.body?.beaconType ?? 'CASBeacon',
-      serviceCommunicationPk : message.body?.communicationPk ?? new Uint8Array(),
+      network,
+      serviceCommunicationPk : communicationPk,
+      ...conditions,
     };
 
     this.#cohortStates.set(cohortId, {
@@ -206,7 +211,7 @@ export class AggregationParticipant {
     const cohort = new AggregationCohort({
       id              : cohortId,
       serviceDid      : state.serviceDid,
-      minParticipants : state.advert!.cohortSize,
+      minParticipants : state.advert!.minParticipants,
       network         : state.advert!.network,
       beaconType      : state.advert!.beaconType,
     });

--- a/packages/method/src/core/aggregation/runner/service-runner.ts
+++ b/packages/method/src/core/aggregation/runner/service-runner.ts
@@ -383,6 +383,15 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       const decision = await this.#onOptInReceived(optIn);
       if(!decision.accepted) return;
 
+      // Don't accept past the advertised maxParticipants: acceptParticipant
+      // would throw COHORT_FULL and fail the run. Silently ignore the surplus
+      // opt-in (the cohort is full).
+      const maxParticipants = this.#config.maxParticipants;
+      const cohortNow = this.session.getCohort(this.#cohortId!);
+      if(maxParticipants !== undefined && cohortNow && cohortNow.participants.length >= maxParticipants) {
+        return;
+      }
+
       await this.#sendAll(this.session.acceptParticipant(this.#cohortId!, msg.from));
       this.emit('participant-accepted', { participantDid: msg.from });
 

--- a/packages/method/src/core/aggregation/service.ts
+++ b/packages/method/src/core/aggregation/service.ts
@@ -6,6 +6,7 @@ import { bytesToHex } from '@noble/hashes/utils';
 import type { Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from './beacon-strategy.js';
 import { AggregationCohort } from './cohort.js';
+import { validateCohortConditions, type CohortConditions } from './conditions.js';
 import { AggregationServiceError } from './errors.js';
 import type { BaseMessage } from './messages/base.js';
 import { AGGREGATION_WIRE_VERSION } from './messages/base.js';
@@ -28,11 +29,14 @@ import type { ServiceCohortPhaseType } from './phases.js';
 import { ServiceCohortPhase } from './phases.js';
 import { BeaconSigningSession } from './signing-session.js';
 
-/** Cohort configuration set by the service operator. */
-export interface CohortConfig {
-  minParticipants: number;
+/**
+ * Cohort configuration set by the service operator: the advertised cohort
+ * {@link CohortConditions} plus the Bitcoin network. `beaconType` and
+ * `minParticipants` are required; the other conditions are optional (absent =
+ * unconstrained). See ADR 039.
+ */
+export interface CohortConfig extends CohortConditions {
   network: string;
-  beaconType: string;
 }
 
 /** Pending opt-in awaiting service operator approval. */
@@ -201,6 +205,14 @@ export class AggregationService {
    * Cohort starts in `Created` phase — call `advertise()` to broadcast.
    */
   createCohort(config: CohortConfig): string {
+    // Fail fast on invalid conditions rather than discovering them at finalize.
+    const problems = validateCohortConditions(config);
+    if(problems.length > 0) {
+      throw new AggregationServiceError(
+        `Invalid cohort conditions: ${problems.join('; ')}`,
+        'INVALID_COHORT_CONDITIONS', { problems }
+      );
+    }
     const cohort = new AggregationCohort({
       serviceDid      : this.did,
       minParticipants : config.minParticipants,
@@ -234,13 +246,15 @@ export class AggregationService {
       );
     }
 
+    // Advertise the full condition set (flat fields, per ADR 039). network is
+    // a separate cohort parameter; everything else in config is a condition.
+    const { network, ...conditions } = state.config;
     const message = createCohortAdvertMessage({
       from            : this.did,
       cohortId,
-      cohortSize      : state.config.minParticipants,
-      beaconType      : state.config.beaconType,
-      network         : state.config.network,
+      network,
       communicationPk : this.publicKey.compressed,
+      ...conditions,
     });
 
     state.phase = ServiceCohortPhase.Advertised;
@@ -310,6 +324,15 @@ export class AggregationService {
         'ALREADY_ACCEPTED', { cohortId, participantDid }
       );
     }
+    // Enforce the maxParticipants condition: a cohort cannot grow past its
+    // advertised ceiling (closes the unbounded-growth path; see ADR 039).
+    const maxParticipants = state.config.maxParticipants;
+    if(maxParticipants !== undefined && state.acceptedParticipants.size >= maxParticipants) {
+      throw new AggregationServiceError(
+        `Cohort ${cohortId} is full: ${maxParticipants} participants already accepted.`,
+        'COHORT_FULL', { cohortId, maxParticipants }
+      );
+    }
 
     state.acceptedParticipants.add(participantDid);
     state.cohort.participants.push(participantDid);
@@ -342,6 +365,15 @@ export class AggregationService {
       throw new AggregationServiceError(
         `Cohort ${cohortId} has only ${state.acceptedParticipants.size} accepted participants, need ${state.config.minParticipants}.`,
         'NOT_ENOUGH_PARTICIPANTS', { cohortId }
+      );
+    }
+    // Ceiling defense: acceptParticipant already rejects past max, so reaching
+    // here over max means state was mutated out-of-band.
+    const maxParticipants = state.config.maxParticipants;
+    if(maxParticipants !== undefined && state.acceptedParticipants.size > maxParticipants) {
+      throw new AggregationServiceError(
+        `Cohort ${cohortId} has ${state.acceptedParticipants.size} accepted participants, exceeds max ${maxParticipants}.`,
+        'TOO_MANY_PARTICIPANTS', { cohortId, maxParticipants }
       );
     }
 

--- a/packages/method/src/index.ts
+++ b/packages/method/src/index.ts
@@ -2,6 +2,7 @@
 export * from './core/aggregation/service.js';
 export * from './core/aggregation/participant.js';
 export * from './core/aggregation/signer.js';
+export * from './core/aggregation/conditions.js';
 export * from './core/aggregation/cohort.js';
 export * from './core/aggregation/signing-session.js';
 export * from './core/aggregation/phases.js';

--- a/packages/method/tests/aggregation-conditions.spec.ts
+++ b/packages/method/tests/aggregation-conditions.spec.ts
@@ -1,0 +1,142 @@
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { expect } from 'chai';
+import {
+  AggregationService,
+  BaseMessage,
+  COHORT_ADVERT,
+  DidBtcr2,
+  createCohortOptInMessage,
+  isCohortAdvertMessage,
+  validateCohortConditions,
+} from '../src/index.js';
+
+/** Executable coverage for ADR 039 (cohort condition model). */
+describe('ADR 039: cohort conditions', () => {
+  const mkService = () => {
+    const keys = SchnorrKeyPair.generate();
+    const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+    return { service: new AggregationService({ did, publicKey: keys.publicKey }), serviceDid: did };
+  };
+  const mkOptIn = (cohortId: string, serviceDid: string) => {
+    const kp = SchnorrKeyPair.generate();
+    const did = DidBtcr2.create(kp.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+    return {
+      did,
+      msg : createCohortOptInMessage({
+        from            : did,
+        to              : serviceDid,
+        cohortId,
+        participantPk   : kp.publicKey.compressed,
+        communicationPk : kp.publicKey.compressed,
+      }),
+    };
+  };
+
+  describe('validateCohortConditions', () => {
+    it('accepts a minimal valid condition set', () => {
+      expect(validateCohortConditions({ beaconType: 'CASBeacon', minParticipants: 1 })).to.deep.equal([]);
+    });
+
+    it('accepts a full set including advertised costs, dids-per-participant, timing and trigger', () => {
+      expect(validateCohortConditions({
+        beaconType                     : 'SMTBeacon',
+        minParticipants                : 2,
+        maxParticipants                : 5,
+        minDidsPerParticipant          : 1,
+        maxDidsPerParticipant          : 10,
+        costOfEnrollment               : { amount: 1000, unit: 'sat' },
+        costPerAnnouncement            : { amount: 100, unit: 'sat', basis: 'per-did' },
+        minSecondsBetweenAnnouncements : 60,
+        maxSecondsBetweenAnnouncements : 3600,
+        pendingUpdateTrigger           : 8,
+      })).to.deep.equal([]);
+    });
+
+    it('rejects minParticipants < 1', () => {
+      expect(validateCohortConditions({ beaconType: 'SMTBeacon', minParticipants: 0 }).join(' ')).to.match(/minParticipants/);
+    });
+
+    it('rejects maxParticipants < minParticipants', () => {
+      expect(validateCohortConditions({ beaconType: 'CASBeacon', minParticipants: 3, maxParticipants: 2 }).join(' '))
+        .to.match(/maxParticipants must be >= minParticipants/);
+    });
+
+    it('rejects an unknown beaconType', () => {
+      expect(validateCohortConditions({ beaconType: 'SingletonBeacon', minParticipants: 1 }).join(' ')).to.match(/beaconType/);
+    });
+
+    it('rejects a malformed advertised cost', () => {
+      expect(validateCohortConditions({
+        beaconType       : 'CASBeacon',
+        minParticipants  : 1,
+        costOfEnrollment : { amount: -5, unit: '' },
+      }).length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('createCohort validation', () => {
+    it('throws INVALID_COHORT_CONDITIONS on a bad config', () => {
+      const { service } = mkService();
+      expect(() => service.createCohort({ beaconType: 'CASBeacon', minParticipants: 0, network: 'mutinynet' }))
+        .to.throw(/INVALID_COHORT_CONDITIONS|Invalid cohort conditions/);
+    });
+
+    it('accepts a valid config', () => {
+      const { service } = mkService();
+      const id = service.createCohort({ beaconType: 'CASBeacon', minParticipants: 1, maxParticipants: 2, network: 'mutinynet' });
+      expect(id).to.be.a('string').and.not.empty;
+    });
+  });
+
+  describe('maxParticipants enforcement', () => {
+    it('rejects acceptParticipant once the cohort is full (COHORT_FULL)', () => {
+      const { service, serviceDid } = mkService();
+      const cohortId = service.createCohort({ beaconType: 'CASBeacon', minParticipants: 1, maxParticipants: 1, network: 'mutinynet' });
+      service.advertise(cohortId);
+
+      const a = mkOptIn(cohortId, serviceDid);
+      const b = mkOptIn(cohortId, serviceDid);
+      service.receive(a.msg);
+      service.receive(b.msg);
+
+      service.acceptParticipant(cohortId, a.did);  // fills the cohort (max 1)
+      expect(() => service.acceptParticipant(cohortId, b.did)).to.throw(/COHORT_FULL|is full/);
+    });
+  });
+
+  describe('advert carries the conditions', () => {
+    it('advertises minParticipants/maxParticipants + advertised costs, and drops cohortSize', () => {
+      const { service } = mkService();
+      const cohortId = service.createCohort({
+        beaconType       : 'SMTBeacon',
+        minParticipants  : 2,
+        maxParticipants  : 4,
+        network          : 'mutinynet',
+        costOfEnrollment : { amount: 500, unit: 'sat' },
+      });
+      const [advert] = service.advertise(cohortId);
+      expect(isCohortAdvertMessage(advert!)).to.equal(true);
+      const body = advert!.body as Record<string, unknown>;
+      expect(body.minParticipants).to.equal(2);
+      expect(body.maxParticipants).to.equal(4);
+      expect(body.costOfEnrollment).to.deep.equal({ amount: 500, unit: 'sat' });
+      expect(body.cohortSize).to.equal(undefined);
+    });
+  });
+
+  describe('advert guard range-checks the wire shape', () => {
+    const advert = (minParticipants: number) => new BaseMessage({
+      type : COHORT_ADVERT,
+      from : 'did:btcr2:svc',
+      body : { cohortId: 'c', minParticipants, beaconType: 'CASBeacon', network: 'mutinynet', communicationPk: new Uint8Array(33) },
+    });
+
+    it('rejects a zero-floor advert', () => {
+      expect(isCohortAdvertMessage(advert(0))).to.equal(false);
+    });
+
+    it('accepts a well-formed advert', () => {
+      expect(isCohortAdvertMessage(advert(2))).to.equal(true);
+    });
+  });
+});

--- a/packages/method/tests/aggregation-security.spec.ts
+++ b/packages/method/tests/aggregation-security.spec.ts
@@ -166,7 +166,7 @@ describe('Aggregation security regressions', () => {
         from    : 'did:btcr2:service',
         body    : {
           cohortId        : 'cohort-x',
-          cohortSize      : 2,
+          minParticipants : 2,
           network         : 'mutinynet',
           beaconType      : 'CASBeacon',
           communicationPk : new Uint8Array(33),


### PR DESCRIPTION
* docs(adr): add ADR 039 cohort condition model (advertise-only economics)
* feat(method)!: model the seven aggregation cohort conditions from the spec
* chore(release): bump method 0.36.0, api 0.9.2, cli 0.10.2