### PR TITLE
opt-in beacon change addresses and dynamic aggregation fees

### DIFF
--- a/docs/adr/044-beacon-change-output-address.md
+++ b/docs/adr/044-beacon-change-output-address.md
@@ -1,0 +1,65 @@
+---
+title: "ADR 044: Beacon Change Output - Caller-Supplied Address to End Beacon-Address Reuse"
+---
+
+# ADR 044: Beacon Change Output - Caller-Supplied Address to End Beacon-Address Reuse
+
+**Status:** Accepted (implementation pending)
+
+**Date:** 2026-06-24
+
+**Branch / PR:** `feat/aggregation-privacy-fees`
+
+**Implementation status:** This record fixes the design ahead of the change on this branch. At the time of writing the builders still return change to the beacon address unconditionally; the `changeAddress` parameter described below is the accepted target, not yet present in the code.
+
+**References:** [ADR 037](037-single-party-beacon-and-two-axis-model.md), [ADR 038](038-musig2-key-custody.md), [ADR 039](039-cohort-condition-model.md), [ADR 040](040-multi-cohort-service-runner.md), [ADR 042](042-fault-tolerant-beacon-output.md), [ADR 043](043-k-of-n-fallback-protocol.md)
+
+## Context
+
+Every beacon broadcast spends a UTXO from the beacon address and returns its change to that **same** address. This is true of all four beacon paths: the single-party singleton, CAS, and SMT beacons (which share `SinglePartyBeacon.buildSignAndBroadcast`) and the multi-party aggregation builder (`buildAggregationBeaconTx`). Each builder adds the change output first, then a trailing `OP_RETURN` carrying the 32-byte signal, and the change output's recipient is hard-coded to the address the transaction just spent from.
+
+Reusing the beacon address for change links a beacon's entire announcement history into a single walkable UTXO chain: the change of one signal becomes the input of the next, all at one address. An observer needs no off-chain data to enumerate every past and future signal of a beacon, to cluster all of a controller's (single-party) or a cohort's (aggregation) announcements under one persistent on-chain identity, and to read the announcement cadence as an activity side channel. For a method whose value proposition is censorship resistance, a permanent self-advertising on-chain address is a censorship target (a miner or relay can blacklist or watch the address) and a deanonymization vector. This is the load-bearing privacy weakness in the broadcast path.
+
+The did:btcr2 specification fixes the beacon transaction's spend source (the beacon address) and its signal output (an `OP_RETURN` carrying the update or aggregator hash, which the spec requires to be the **last** transaction output, the output resolution reads the signal bytes from), but it is silent on the change output and silent on transaction fees. Where the spec is silent the implementation decides, and improving the change output does not violate any normative requirement as long as the signal stays the last output.
+
+Two structural facts constrain how far this decision can go:
+
+- **Single-party.** The signer's public key *is* the beacon address (enforced by the `SIGNER_KEY_MISMATCH` guard), so the transaction's input address cannot move per broadcast. The three deterministic singleton beacons of a `did:btcr2:k...` document are additionally locked to the genesis public key, and resolution depends on signals appearing at exactly those addresses. Input-address rotation is therefore not a property of the broadcast builder; it is achieved at the document layer, by adding new singleton beacon services backed by other keypairs the controller manages in a wallet, and the encouraged cost-and-privacy path is to move to aggregate beacons.
+- **Aggregation.** The input is the cohort's MuSig2 address, not tied to any one party, so the cohort *could* send change elsewhere, but "who owns the change" is the advertise-only economics question that [ADR 039](039-cohort-condition-model.md) deliberately leaves to the funder. A transient n-of-n cohort that may dissolve after one round also cannot safely lock change to anything that requires all n signers to reconvene.
+
+## Decision
+
+### 1. The change destination becomes a caller-supplied address, defaulting to the beacon address
+
+Both builders gain an optional change address: a `changeAddress` field on the single-party `BroadcastOptions` and on the `buildAggregationBeaconTx` options. When omitted, change goes to the beacon address exactly as today, so every existing caller, test, and vector is unchanged. A privacy-conscious caller supplies a fresh address it controls, and the change-chain re-link is broken at the source.
+
+### 2. Privacy is a caller-pulled policy lever, not an automatic guarantee
+
+The default still reuses the beacon address. This decision exposes a lever; it does not flip privacy on for everyone. The reason is deliberate: the only designs that make privacy automatic require the builder itself to hold or derive a spendable change key, which collides with three established constraints. The builders are sans-I/O and hold no I/O or key material of their own; the single-party `Signer` abstraction exposes no derivation surface; and the aggregation coordinator holds only public key material, never a secret (the custody model of [ADR 038](038-musig2-key-custody.md)). The wallet, which already manages keys beyond the beacon key in order to add non-deterministic beacons, is the correct layer to mint a fresh change address and hand it in. Pushing key custody into the builder to win an automatic default would be a worse architecture than letting the caller name where change goes.
+
+### 3. The scope is the change output only; input-address rotation lives elsewhere
+
+This decision changes where change goes, nothing else. For the single-party path it does not, and cannot, rotate the beacon input address: that is a document-update concern (adding new beacon services backed by wallet-managed keys) and a deployment choice (preferring aggregate beacons), both outside the broadcast builder. Single-party privacy from this decision is therefore partial by construction: it stops the change-chain re-link but the beacon input addresses themselves remain visible. The decision states that plainly rather than implying a stronger guarantee.
+
+### 4. The signal output stays last; change is placed before it
+
+The spec requires the signal to be the last output of the beacon transaction (resolution reads the signal bytes from the last output), so the `OP_RETURN` signal output remains final and the change output is placed before it. Changing the change recipient never reorders the outputs, leaving signal discovery and the spec's last-output requirement unaffected.
+
+### 5. Aggregation change ownership tracks the advertised funding model
+
+For an operator-funded cohort, the operator funded the input and the caller supplies the operator's funding-wallet address as the change destination, so ownership is explicit and external to the protocol, matching the advertise-only stance of [ADR 039](039-cohort-condition-model.md). The reserved participant-funded model (which would imply per-participant refunds across multiple change outputs) stays out of scope: a single change output, owned by whoever the caller names.
+
+## Consequences
+
+- **Backward-compatible by default.** Omitting the change address reproduces today's behavior exactly, so no existing test or test vector changes. Privacy is opt-in.
+- **Privacy is deployment-tunable.** The wallet (single-party) or the operator (aggregation) decides whether to rotate change, and to where, without any change to the builders' custody posture.
+- **Single-party privacy is partial.** This decision breaks the change-chain re-link but leaves the beacon input addresses visible; full single-party unlinkability is reached by adding new beacon services or moving to aggregate beacons, which this decision documents but does not implement.
+- **The change-output script kind is now variable.** A caller-supplied change address may be a different script type than the beacon address, which changes the transaction vsize the fee is computed over. The fee decision that follows ([ADR 045](045-analytical-vsize-aggregation-fees.md)) is sized over this variable change output, which is why the change-output decision is settled first.
+- **The "change equals beacon address" assumption is generalized.** The transaction plan that previously documented its change recipient as identical to the beacon address now records the actual change recipient, since the two can differ.
+
+## Rejected alternatives
+
+- **Builder-derived fresh change address (a BIP-32 child minted inside the builder).** This wins an automatic default but forces secret-key custody and derivation into a sans-I/O builder, breaking the single-party `Signer` abstraction and the coordinator-holds-only-public-key model of [ADR 038](038-musig2-key-custody.md). The wallet is the correct layer to derive change keys.
+- **Rotating, per-cohort or per-announcement deterministic change address.** Best on paper for never reusing an address, but it carries the same custody problem and adds a liveness hazard for aggregation: a transient n-of-n cohort cannot reconvene to spend change locked to a rotated cohort key.
+- **Hard cutover (require an explicit change address, no default).** Maximizes default privacy but breaks every existing caller, test, and vector for a property that is a deployment choice. Defaulting to the beacon address keeps adoption frictionless while still offering the lever.
+- **Folding single-party input-address rotation into this decision.** Rotating the beacon input address is a document-update concern (adding beacon services backed by wallet-managed keys), not a property of the broadcast builder; bundling it here would conflate the write path with beacon transaction construction and pull in a much larger change for partial benefit.

--- a/docs/adr/045-analytical-vsize-aggregation-fees.md
+++ b/docs/adr/045-analytical-vsize-aggregation-fees.md
@@ -1,0 +1,56 @@
+---
+title: "ADR 045: Analytical-vsize Dynamic Fees for the Aggregation Beacon Broadcast"
+---
+
+# ADR 045: Analytical-vsize Dynamic Fees for the Aggregation Beacon Broadcast
+
+**Status:** Accepted (implementation pending)
+
+**Date:** 2026-06-24
+
+**Branch / PR:** `feat/aggregation-privacy-fees`
+
+**Implementation status:** This record fixes the design ahead of the change on this branch. At the time of writing the aggregation builder still sizes the fee from a single fixed constant, and the service runner exposes no `FeeEstimator` injection point; the analytical vsize and the runner-level estimator described below are the accepted target, not yet present in the code.
+
+**References:** [ADR 040](040-multi-cohort-service-runner.md), [ADR 042](042-fault-tolerant-beacon-output.md), [ADR 043](043-k-of-n-fallback-protocol.md), [ADR 044](044-beacon-change-output-address.md)
+
+## Context
+
+Both beacon builders compute the fee as the estimator's rate applied to a fixed vsize constant, with no probe-sign. The single-party builder uses a per-kind constant (it holds the secret but chooses a constant for determinism); the aggregation builder uses a single P2TR constant because at construction time it has no secret at all. The aggregation signature is produced downstream by a MuSig2 nonce-then-partial-signature round, so when the transaction is built there is nothing to sign with and nothing to measure. The constant of roughly 160 vbytes is the standing workaround, with an in-code comment recording exactly that reason.
+
+The `FeeEstimator` interface already separates the two concerns a fee needs: the estimator supplies the **rate** (sat/vB) and the caller supplies the **size** (vsize). A "dynamic fee" in this context means responding to a live rate, for example a mempool or Bitcoin Core estimate, rather than a hard-coded rate. It does not mean measuring the size by signing, which the aggregation path still cannot do. The size must instead be computed analytically from public parameters, all of which are known at construction time: the spend is a P2TR key-path, the output set is one change output plus one `OP_RETURN` carrying the 32-byte signal, and the witness is a single 64-byte BIP-340 signature.
+
+[ADR 044](044-beacon-change-output-address.md) makes the change output's script kind variable (a caller may send change to an address whose type differs from the beacon address). The single constant baked in "one P2TR change output," so it no longer describes every aggregation transaction. The vsize must be parameterized over the change-output kind, which is why the change-output decision is settled first.
+
+## Decision
+
+### 1. The aggregation key-path fee uses an analytical vsize, not a single constant
+
+The fee for the optimistic key-path spend is the estimator's rate applied to a vsize computed from public parameters: the stripped base for a one-input P2TR key-path transaction with a trailing `OP_RETURN(32)` output, plus the change output's bytes for its actual script kind (derived from the [ADR 044](044-beacon-change-output-address.md) change address), plus the witness-weighted cost of one 64-byte BIP-340 signature. No secret is required, and no probe-sign round is performed; the number is derived, not measured. The previous P2TR constant is retained as the default change-output case, so a transaction whose change returns to the (P2TR) beacon address sizes exactly as before.
+
+### 2. The scope is the optimistic key-path spend only
+
+This decision sizes the fee for the key-path spend that the service constructs and signs first. The k-of-n fallback spend of [ADR 043](043-k-of-n-fallback-protocol.md) and the CSV recovery spend of [ADR 042](042-fault-tolerant-beacon-output.md) are heavier (their witnesses carry multiple signatures or a control block and leaf script), and they are built and broadcast by different actors at different times. They size their own fee from their own witness shape; the single fee the key-path builder returns does not cover them. This decision names that boundary rather than implying the key-path fee covers every spend of the funded output.
+
+### 3. A FeeEstimator is threaded through the service runner's transaction-data boundary
+
+Today the aggregation builder accepts an optional estimator, but the service runner's transaction-data callback (the hook a caller fills to return the unsigned transaction and its sighash inputs) has no channel to receive one, so an integrator wanting a live rate must hard-code it inside the callback. This decision surfaces a `FeeEstimator` as a runner option and passes it into the callback's input, giving production callers a single standard injection point for a dynamic (mempool or Bitcoin Core) estimator. The default remains the static 5 sat/vB estimator, preserving current behavior.
+
+### 4. The analytical vsize is locked by a finalized-witness test
+
+The vsize formula is guarded by a unit test that builds a finalized key-path witness with a dummy 64-byte signature and asserts the actual vsize is no greater than the formula and within a small slack, extending the existing beacon vsize lock-in test. This catches a formula that ever under-sizes the real transaction (which would under-pay the fee) without coupling the test to a live signing round.
+
+## Consequences
+
+- **Aggregation broadcasts can follow the fee market.** A caller can inject a live-rate estimator at a documented point, instead of being limited to the static default, without needing a probe-sign the MuSig2 round cannot provide.
+- **The fee tracks the change-output choice.** Because the vsize includes the actual change output, a cheaper change kind (for example P2WPKH change on a P2TR beacon) lowers the fee correctly rather than over-paying against a P2TR assumption.
+- **The estimator injection point is explicit.** Fee-rate selection moves from buried callback code to a named runner option, so every integrator solves it the same way.
+- **The constant becomes a named default case.** The prior single constant survives as the default-change (P2TR) value, and the lock-in test guards against under-paying as output shapes vary.
+- **Fallback and recovery fee sizing is deferred, not dropped.** Those spends keep their own sizing and are named as future work, to be standardized when they gain a dedicated fee path.
+
+## Rejected alternatives
+
+- **Probe-sign the aggregation transaction to measure its vsize.** Impossible at construction time: there is no secret until the downstream MuSig2 round completes. The absence of a secret is the entire reason an analytical vsize is required.
+- **Keep a single hard-coded vsize constant.** It bakes in one P2TR change output, which [ADR 044](044-beacon-change-output-address.md) can overturn, and it cannot reflect a different change kind. It over-pays or under-pays as the output set varies.
+- **Select the estimator only inside the operator's transaction-data callback.** It works but offers no standard injection point and forces every integrator to re-solve fee wiring; a runner option centralizes it and keeps the callback focused on transaction construction.
+- **Standardize the fallback and recovery fees in this same decision.** Those spends have different witness shapes, different broadcasters, and a different timing; bundling them would couple unrelated fee paths and broaden the change surface with no current caller needing it.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -44,6 +44,8 @@ children:
   - ./041-cooperative-non-inclusion-signaling.md
   - ./042-fault-tolerant-beacon-output.md
   - ./043-k-of-n-fallback-protocol.md
+  - ./044-beacon-change-output-address.md
+  - ./045-analytical-vsize-aggregation-fees.md
 ---
 
 # Architecture Decision Records
@@ -95,3 +97,5 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 041 | 2026-06-23 | [Cooperative Non-Inclusion Signaling for Aggregate Beacons](041-cooperative-non-inclusion-signaling.md) (superseded by 042) |
 | 042 | 2026-06-23 | [Fault-Tolerant Aggregate Beacon Output (Hybrid Taproot)](042-fault-tolerant-beacon-output.md) |
 | 043 | 2026-06-24 | [k-of-n Fallback Signing Protocol for Aggregate Beacons](043-k-of-n-fallback-protocol.md) |
+| 044 | 2026-06-24 | [Beacon Change Output - Caller-Supplied Address to End Beacon-Address Reuse](044-beacon-change-output-address.md) |
+| 045 | 2026-06-24 | [Analytical-vsize Dynamic Fees for the Aggregation Beacon Broadcast](045-analytical-vsize-aggregation-fees.md) |

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.37.0",
+    "version": "0.38.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/aggregation/runner/aggregation-runner.ts
+++ b/packages/method/src/core/aggregation/runner/aggregation-runner.ts
@@ -7,6 +7,7 @@ import { AggregationParticipantRunner } from './participant-runner.js';
 import type { OnProvideUpdate } from './participant-runner.js';
 import { AggregationServiceRunner } from './service-runner.js';
 import type { OnProvideTxData } from './service-runner.js';
+import type { FeeEstimator } from '../../beacon/fee-estimator.js';
 
 /** Identity (DID + keys) for one actor in an {@link AggregationRunner.solo} run. */
 export interface SoloActor {
@@ -39,6 +40,11 @@ export interface SoloCohortOptions {
   onProvideUpdate: OnProvideUpdate;
   /** Provide the Bitcoin transaction data the cohort signs. */
   onProvideTxData: OnProvideTxData;
+  /**
+   * Fee estimator forwarded to {@link onProvideTxData} so the cohort transaction is
+   * sized at a chosen rate. Defaults to a static 5 sat/vB estimator (ADR 045).
+   */
+  feeEstimator?: FeeEstimator;
   /** Optional overall wall-clock budget for the run (ms). */
   cohortTtlMs?: number;
   /** Optional per-phase stall timeout (ms). */
@@ -92,6 +98,7 @@ export class AggregationRunner {
       keys                   : options.service.keys,
       config                 : { minParticipants: 1, network: options.config.network, beaconType: options.config.beaconType, recoveryKey, recoverySequence, fundingModel: DEFAULT_FUNDING_MODEL },
       onProvideTxData        : options.onProvideTxData,
+      feeEstimator           : options.feeEstimator,
       cohortTtlMs            : options.cohortTtlMs,
       phaseTimeoutMs         : options.phaseTimeoutMs,
       // In-process bus with the participant already listening: a single advert

--- a/packages/method/src/core/aggregation/runner/service-runner.ts
+++ b/packages/method/src/core/aggregation/runner/service-runner.ts
@@ -21,6 +21,8 @@ import {
   AggregationService
 } from '../service.js';
 import type { Transport } from '../transport/transport.js';
+import { DEFAULT_FEE_ESTIMATOR } from '../../beacon/fee-estimator.js';
+import type { FeeEstimator } from '../../beacon/fee-estimator.js';
 import type { AggregationServiceEvents } from './events.js';
 import { TypedEventEmitter } from './typed-emitter.js';
 
@@ -38,6 +40,13 @@ export type OnProvideTxData = (info: {
   cohortId: string;
   beaconAddress: string;
   signalBytes: Uint8Array;
+  /**
+   * Fee estimator the runner is configured with (the runner's `feeEstimator`
+   * option, or a static 5 sat/vB default). Forward it to the beacon transaction
+   * builder so a dynamic rate injected at the runner is honored, rather than
+   * hard-coding a rate inside this callback (ADR 045).
+   */
+  feeEstimator: FeeEstimator;
 }) => Promise<SigningTxData>;
 
 export interface AggregationServiceRunnerOptions {
@@ -74,6 +83,15 @@ export interface AggregationServiceRunnerOptions {
    * REQUIRED - no sensible default.
    */
   onProvideTxData: OnProvideTxData;
+
+  /**
+   * Fee estimator passed to {@link OnProvideTxData} so the beacon transaction the
+   * callback builds is sized at a chosen rate. Inject a dynamic estimator (a mempool
+   * API or Bitcoin Core `estimatesmartfee`) here as the single standard point for
+   * fee-rate selection, instead of hard-coding a rate inside the callback (ADR 045).
+   * Defaults to a static 5 sat/vB estimator.
+   */
+  feeEstimator?: FeeEstimator;
 
   /**
    * Maximum canonicalized byte-length of a signed update body. Submissions
@@ -192,8 +210,9 @@ interface RunContext {
  *   transport,
  *   did: serviceDid,
  *   keys: serviceKeys,
- *   onProvideTxData: async ({ cohortId, beaconAddress, signalBytes }) => {
- *     return await buildBeaconTransaction(beaconAddress, signalBytes, bitcoin);
+ *   onProvideTxData: async ({ beaconAddress, signalBytes, feeEstimator }) => {
+ *     // Forward feeEstimator so a dynamic rate injected at the runner is honored.
+ *     return await buildBeaconTransaction(beaconAddress, signalBytes, bitcoin, feeEstimator);
  *   },
  * });
  *
@@ -225,6 +244,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
   readonly #onOptInReceived: OnOptInReceived;
   readonly #onReadyToFinalize: OnReadyToFinalize;
   readonly #onProvideTxData: OnProvideTxData;
+  readonly #feeEstimator: FeeEstimator;
   readonly #cohortTtlMs?: number;
   readonly #phaseTimeoutMs?: number;
   readonly #advertRepeatIntervalMs: number;
@@ -252,6 +272,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       finalize : acceptedCount >= minRequired,
     }));
     this.#onProvideTxData = options.onProvideTxData;
+    this.#feeEstimator = options.feeEstimator ?? DEFAULT_FEE_ESTIMATOR;
     this.#cohortTtlMs = options.cohortTtlMs;
     this.#phaseTimeoutMs = options.phaseTimeoutMs;
     this.#advertRepeatIntervalMs = options.advertRepeatIntervalMs ?? DEFAULT_ADVERT_REPEAT_INTERVAL_MS;
@@ -760,6 +781,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
           cohortId      : ctx.cohortId,
           beaconAddress : cohort.beaconAddress,
           signalBytes   : cohort.signalBytes!,
+          feeEstimator  : this.#feeEstimator,
         });
         const authMsgs = this.session.startSigning(ctx.cohortId, txData);
         const sessionId = this.session.getSigningSessionId(ctx.cohortId) ?? '';

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -7,12 +7,9 @@ import { Address, OutScript, p2pkh, p2tr, p2wpkh, Script, SigHash, Transaction }
 import type { BeaconProcessResult } from '../resolver.js';
 import type { SidecarData } from '../types.js';
 import { BeaconError } from './error.js';
-import { StaticFeeEstimator } from './fee-estimator.js';
+import { DEFAULT_FEE_ESTIMATOR } from './fee-estimator.js';
 import type { FeeEstimator } from './fee-estimator.js';
 import type { BeaconService, BeaconSignal } from './interfaces.js';
-
-/** Default fee estimator used when none is supplied. ~5 sat/vB static rate. */
-const DEFAULT_FEE_ESTIMATOR: FeeEstimator = new StaticFeeEstimator(5);
 
 /**
  * Singleton beacon script kinds. Per the did:btcr2 spec, deterministic DID documents
@@ -52,6 +49,54 @@ export const SINGLETON_BEACON_TX_VSIZE: Readonly<Record<SingletonScriptKind, num
 };
 
 /**
+ * Serialized size (vbytes) of a single change output, by script kind:
+ * 8 (value) + 1 (scriptPubKey length) + scriptPubKey bytes. P2PKH 25, P2WPKH 22,
+ * P2TR 34. These are non-witness bytes, so each contributes its full byte count to
+ * the transaction vsize. The {@link SINGLETON_BEACON_TX_VSIZE} constants bake in a
+ * same-kind change output; {@link beaconTxVsize} uses these deltas to re-size the
+ * fee when a caller routes change to an address of a different kind (ADR 044).
+ */
+export const CHANGE_OUTPUT_VBYTES: Readonly<Record<SingletonScriptKind, number>> = {
+  p2pkh  : 34,
+  p2wpkh : 31,
+  p2tr   : 43,
+};
+
+/**
+ * Dust threshold (sats) below which a change output is not worth creating, by script
+ * kind (the standard Bitcoin Core dust relay thresholds at the default 3 sat/vB dust
+ * rate). When the change after fees falls below this, the builders omit the change
+ * output and let the remainder fall into the fee rather than emit an unspendable,
+ * relay-rejected dust output (ADR 044).
+ */
+export const DUST_LIMIT_SATS: Readonly<Record<SingletonScriptKind, number>> = {
+  p2pkh  : 546,
+  p2wpkh : 294,
+  p2tr   : 330,
+};
+
+/**
+ * vsize (vbytes) for a beacon transaction that spends one input of `beaconKind`
+ * and returns change to an output of `changeKind`, plus the OP_RETURN(32) signal.
+ *
+ * When `changeKind === beaconKind` (the default, change to the beacon address) this
+ * returns the per-kind {@link SINGLETON_BEACON_TX_VSIZE} constant unchanged, so the
+ * default path and the constants' lock-in tests are byte-identical. A differing
+ * `changeKind` swaps the assumed same-kind change output for the actual one, keeping
+ * the result a valid upper bound. The aggregation key-path spend is the
+ * `beaconKind: 'p2tr'` case (its input is always the cohort's P2TR key path; only the
+ * change output varies), the analytical sizing ADR 045 calls for, computed without a
+ * secret.
+ */
+export function beaconTxVsize(
+  beaconKind: SingletonScriptKind,
+  changeKind: SingletonScriptKind,
+): number {
+  const base = SINGLETON_BEACON_TX_VSIZE[beaconKind] - CHANGE_OUTPUT_VBYTES[beaconKind];
+  return base + CHANGE_OUTPUT_VBYTES[changeKind];
+}
+
+/**
  * Detect the singleton script kind of a Bitcoin address (P2PKH / P2WPKH / P2TR).
  * The deterministic-DID document emits all three kinds; the broadcast path needs
  * to know which is in use to construct the input and dispatch the signing primitive.
@@ -89,11 +134,55 @@ export function deriveSingletonAddress(
 }
 
 /**
+ * Resolve the change-output recipient for a beacon transaction. Returns the beacon
+ * address when no change address is supplied (preserving the prior behavior of
+ * returning change to the spent address), otherwise validates the caller-supplied
+ * address against the network and returns it. Validating here fails fast rather than
+ * burning a real UTXO on a transaction that breaks at broadcast (ADR 044).
+ */
+export function resolveChangeAddress(
+  beaconAddress: string,
+  network: BTCNetwork,
+  changeAddress?: string,
+): string {
+  if(!changeAddress || changeAddress === beaconAddress) return beaconAddress;
+  try {
+    Address(network).decode(changeAddress);
+  } catch {
+    throw new BeaconError(
+      `Invalid change address "${changeAddress}" for network "${network}".`,
+      'INVALID_CHANGE_ADDRESS',
+      { changeAddress, network }
+    );
+  }
+  return changeAddress;
+}
+
+/**
+ * Detect the change output's script kind for fee sizing. A change address that is not
+ * one of the three singleton kinds (for example P2SH or P2WSH) is sized as P2TR, the
+ * largest standard change output, so the estimated fee stays a valid upper bound.
+ */
+function changeOutputKind(changeAddress: string, network: BTCNetwork): SingletonScriptKind {
+  try {
+    return detectSingletonScriptKind(changeAddress, network);
+  } catch {
+    return 'p2tr';
+  }
+}
+
+/**
  * Options accepted by {@link SinglePartyBeacon.buildSignAndBroadcast} and related helpers.
  */
 export interface BroadcastOptions {
   /** Fee estimator for computing the transaction fee. Defaults to {@link DEFAULT_FEE_ESTIMATOR}. */
   feeEstimator?: FeeEstimator;
+  /**
+   * Address to send change to. Defaults to the beacon address (reuses the spent
+   * address, the prior behavior). Supply a fresh address the controller owns to
+   * stop linking the beacon's announcements into one on-chain chain (ADR 044).
+   */
+  changeAddress?: string;
 }
 
 /**
@@ -107,8 +196,10 @@ export interface BeaconTxPlan {
   prevOutScripts: Uint8Array[];
   /** Amounts (sats) of the consumed previous outputs. */
   prevOutValues: bigint[];
-  /** Address change was sent back to (same as the beacon address). */
+  /** The beacon address this tx spends from. */
   beaconAddress: string;
+  /** Address the change output was sent to (the beacon address unless a change address was supplied). */
+  changeAddress: string;
   /** The UTXO this tx consumes. */
   utxo: AddressUtxo;
   /** The fee (sats) already deducted from the change output. */
@@ -188,9 +279,17 @@ export async function buildAggregationBeaconTx(opts: {
   network: BTCNetwork;
   /** Optional fee estimator (defaults to 5 sat/vB). */
   feeEstimator?: FeeEstimator;
+  /**
+   * Address to send change to. Defaults to the beacon (cohort) address. Supply the
+   * funder's address (an operator-funded cohort's funding wallet) to stop reusing the
+   * cohort address for change (ADR 044). Change ownership is the funder's call, which
+   * the cohort-condition model leaves to the caller (ADR 039).
+   */
+  changeAddress?: string;
 }): Promise<BeaconTxPlan> {
   const feeEstimator = opts.feeEstimator ?? DEFAULT_FEE_ESTIMATOR;
   const { utxo, prevTxBytes } = await fetchSpendableUtxo(opts.beaconAddress, opts.bitcoin);
+  const changeAddress = resolveChangeAddress(opts.beaconAddress, opts.network, opts.changeAddress);
 
   // The funded beacon output is a Taproot script-tree output: key path is the
   // MuSig2 aggregate, script path is the k-of-n fallback + CSV recovery leaves
@@ -200,8 +299,11 @@ export async function buildAggregationBeaconTx(opts: {
   // key-path sighash and the fallback script-path sighash.
   const witnessScript = OutScript.encode(Address(opts.network).decode(opts.beaconAddress));
 
-  // Fee cannot be probe-measured (no secret key for MuSig2 round). Use fixed P2TR vsize.
-  const feeSats = await feeEstimator.estimateFee(P2TR_BEACON_TX_VSIZE);
+  // The fee cannot be probe-measured (no secret key until the downstream MuSig2
+  // round), so size it analytically. The input is the cohort's P2TR key path; only
+  // the change output's kind varies, so the vsize follows the change address (ADR 045).
+  const changeKind = changeOutputKind(changeAddress, opts.network);
+  const feeSats = await feeEstimator.estimateFee(beaconTxVsize('p2tr', changeKind));
   if(BigInt(utxo.value) <= feeSats) {
     throw new BeaconError(
       `UTXO value (${utxo.value}) insufficient to cover fee (${feeSats}).`,
@@ -221,7 +323,12 @@ export async function buildAggregationBeaconTx(opts: {
     witnessUtxo    : { amount: BigInt(utxo.value), script: witnessScript },
     tapInternalKey : opts.internalPubkey,
   });
-  tx.addOutputAddress(opts.beaconAddress, BigInt(utxo.value) - feeSats, opts.network);
+  // Change first (omitted when it would be dust, sweeping the remainder into the
+  // fee), then the OP_RETURN signal, which the spec requires to be the last output.
+  const changeValue = BigInt(utxo.value) - feeSats;
+  if(changeValue >= BigInt(DUST_LIMIT_SATS[changeKind])) {
+    tx.addOutputAddress(changeAddress, changeValue, opts.network);
+  }
   tx.addOutput({ script: opReturnScript(opts.signalBytes), amount: 0n });
 
   return {
@@ -229,6 +336,7 @@ export async function buildAggregationBeaconTx(opts: {
     prevOutScripts : [witnessScript],
     prevOutValues  : [BigInt(utxo.value)],
     beaconAddress  : opts.beaconAddress,
+    changeAddress,
     utxo,
     feeSats,
     scriptKind     : 'p2tr',
@@ -404,6 +512,7 @@ export abstract class SinglePartyBeacon {
     const { utxo, prevTxBytes } = await fetchSpendableUtxo(beaconAddress, bitcoin);
     const plan = await this.buildSinglePartyTx({
       signalBytes, beaconAddress, utxo, prevTxBytes, signer, bitcoin, feeEstimator,
+      changeAddress : options?.changeAddress,
     });
     const signedHex = await this.signSinglePartyTx(plan, signer);
     return this.broadcastRawTx(bitcoin, signedHex);
@@ -416,8 +525,9 @@ export abstract class SinglePartyBeacon {
    * the input accordingly. Validates that the signer's pubkey produces the beacon
    * address under that script kind: without this check, a misconfigured caller
    * would burn a real UTXO on a tx that fails at broadcast. Fees are computed from
-   * the per-kind {@link SINGLETON_BEACON_TX_VSIZE} constant, avoiding any probe-sign
-   * round-trip.
+   * the per-kind {@link SINGLETON_BEACON_TX_VSIZE} constant (via {@link beaconTxVsize}),
+   * avoiding any probe-sign round-trip; a change address of a different kind re-sizes
+   * the fee by the change output's size delta so it stays a valid upper bound.
    */
   protected async buildSinglePartyTx(opts: {
     signalBytes: Uint8Array;
@@ -427,10 +537,12 @@ export abstract class SinglePartyBeacon {
     signer: Signer;
     bitcoin: BitcoinConnection;
     feeEstimator: FeeEstimator;
+    changeAddress?: string;
   }): Promise<BeaconTxPlan> {
     const network = opts.bitcoin.data;
     const pubkey = opts.signer.publicKey;
     const kind = detectSingletonScriptKind(opts.beaconAddress, network);
+    const changeAddress = resolveChangeAddress(opts.beaconAddress, network, opts.changeAddress);
 
     const derivedAddress = deriveSingletonAddress(kind, pubkey, network);
     if(derivedAddress !== opts.beaconAddress) {
@@ -441,7 +553,8 @@ export abstract class SinglePartyBeacon {
       );
     }
 
-    const feeSats = await opts.feeEstimator.estimateFee(SINGLETON_BEACON_TX_VSIZE[kind]);
+    const changeKind = changeOutputKind(changeAddress, network);
+    const feeSats = await opts.feeEstimator.estimateFee(beaconTxVsize(kind, changeKind));
     const amount = BigInt(opts.utxo.value);
     if(amount <= feeSats) {
       throw new BeaconError(
@@ -487,7 +600,12 @@ export abstract class SinglePartyBeacon {
       });
     }
 
-    tx.addOutputAddress(opts.beaconAddress, amount - feeSats, network);
+    // Change first (omitted when it would be dust, sweeping the remainder into the
+    // fee), then the OP_RETURN signal, which the spec requires to be the last output.
+    const changeValue = amount - feeSats;
+    if(changeValue >= BigInt(DUST_LIMIT_SATS[changeKind])) {
+      tx.addOutputAddress(changeAddress, changeValue, network);
+    }
     tx.addOutput({ script: opReturnScript(opts.signalBytes), amount: 0n });
 
     return {
@@ -495,6 +613,7 @@ export abstract class SinglePartyBeacon {
       prevOutScripts : [prevOutScript],
       prevOutValues  : [amount],
       beaconAddress  : opts.beaconAddress,
+      changeAddress,
       utxo           : opts.utxo,
       feeSats,
       scriptKind     : kind,

--- a/packages/method/src/core/beacon/fee-estimator.ts
+++ b/packages/method/src/core/beacon/fee-estimator.ts
@@ -50,3 +50,12 @@ export class StaticFeeEstimator implements FeeEstimator {
     return BigInt(Math.ceil(vsize * this.satsPerVbyte));
   }
 }
+
+/**
+ * Default fee estimator used when a caller supplies none: a static 5 sat/vB rate.
+ * Suitable for tests and regtest. Production callers should inject a dynamic
+ * estimator (a mempool API, or Bitcoin Core `estimatesmartfee`) at the point the
+ * beacon transaction is built (single-party broadcast options, or the aggregation
+ * service runner's fee estimator).
+ */
+export const DEFAULT_FEE_ESTIMATOR: FeeEstimator = new StaticFeeEstimator(5);

--- a/packages/method/tests/aggregation-solo.spec.ts
+++ b/packages/method/tests/aggregation-solo.spec.ts
@@ -3,7 +3,8 @@ import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { Address, OutScript, Script, SigHash, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
-import { AggregationRunner, DidBtcr2, Resolver, Updater } from '../src/index.js';
+import { AggregationRunner, DidBtcr2, Resolver, StaticFeeEstimator, Updater } from '../src/index.js';
+import type { FeeEstimator } from '../src/index.js';
 
 describe('AggregationRunner.solo (cohort of one)', () => {
   it('drives a single-participant SMT cohort to a verifiable MuSig2 signature', async function() {
@@ -41,16 +42,22 @@ describe('AggregationRunner.solo (cohort of one)', () => {
     let capturedSighash: Uint8Array | undefined;
     let capturedTweakedPk: Uint8Array | undefined;
     let capturedBeaconAddress: string | undefined;
+    let capturedFeeEstimator: FeeEstimator | undefined;
+
+    // A distinct estimator instance so we can assert the runner forwards it (ADR 045).
+    const feeEstimator = new StaticFeeEstimator(7);
 
     const result = await AggregationRunner.solo({
       service        : { did: serviceDid, keys: serviceKeys },
       participant    : { did: participantDid, keys: participantKeys },
       config         : { network: 'mutinynet', beaconType: 'SMTBeacon' },
       phaseTimeoutMs : 10_000,
+      feeEstimator,
 
       onProvideUpdate : async ({ beaconAddress }) => buildSignedUpdate(beaconAddress),
 
-      onProvideTxData : async ({ beaconAddress, signalBytes }) => {
+      onProvideTxData : async ({ beaconAddress, signalBytes, feeEstimator: provided }) => {
+        capturedFeeEstimator = provided;
         // The cohort beacon address is a P2TR key-path output of the aggregated
         // cohort key. AggregationCohort.computeBeaconAddress() derives it for the
         // cohort's network (here mutinynet to tb1p), so decode it with the same
@@ -86,6 +93,8 @@ describe('AggregationRunner.solo (cohort of one)', () => {
     expect(capturedSighash, 'onProvideTxData ran').to.not.be.undefined;
     expect(capturedTweakedPk, 'tweaked key captured').to.not.be.undefined;
     expect(capturedBeaconAddress, 'beacon address captured').to.be.a('string');
+    // The runner forwarded the configured estimator into the tx-data callback.
+    expect(capturedFeeEstimator, 'runner forwarded its feeEstimator').to.equal(feeEstimator);
 
     // The aggregated MuSig2 signature must verify against the Taproot-tweaked
     // output key + BIP-341 sighash - the ground truth a broadcast relies on.

--- a/packages/method/tests/beacon-change-output.spec.ts
+++ b/packages/method/tests/beacon-change-output.spec.ts
@@ -1,0 +1,142 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
+import type { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
+import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { Address, OutScript, p2tr, p2wpkh, Transaction } from '@scure/btc-signer';
+import { expect } from 'chai';
+import {
+  beaconTxVsize,
+  buildAggregationBeaconTx,
+  CHANGE_OUTPUT_VBYTES,
+  opReturnScript,
+  resolveChangeAddress,
+  SINGLETON_BEACON_TX_VSIZE,
+} from '../src/core/beacon/beacon.js';
+
+const network = getNetwork('regtest');
+const FEE_RATE = 5; // DEFAULT_FEE_ESTIMATOR is StaticFeeEstimator(5)
+
+/** A throwaway 33-byte-compressed key, used to mint distinct change addresses. */
+const freshKey = (): Uint8Array => new LocalSigner(SchnorrKeyPair.generate().secretKey.bytes).publicKey;
+
+/**
+ * Minimal BitcoinConnection that funds `beaconAddress` with a single confirmed UTXO
+ * of `value` sats. Builds a real prev tx whose output 0 pays the beacon address so
+ * scure's nonWitnessUtxo hash check passes when the builder spends it.
+ */
+function mockBitcoin(beaconAddress: string, value: number): BitcoinConnection {
+  const beaconScript = OutScript.encode(Address(network).decode(beaconAddress));
+  const prevTx = new Transaction({ allowUnknownOutputs: true });
+  prevTx.addOutput({ amount: BigInt(value), script: beaconScript });
+  prevTx.addInput({ txid: new Uint8Array(32), index: 0xffffffff, finalScriptSig: new Uint8Array([0x00]) });
+  const prevTxBytes = prevTx.toBytes();
+  const utxo: AddressUtxo = { txid: prevTx.id, vout: 0, value, status: { block_height: 100 } as never };
+  return {
+    data : network,
+    rest : {
+      address     : { getUtxos: async () => [utxo] },
+      transaction : { getHex: async () => bytesToHex(prevTxBytes) },
+    },
+  } as unknown as BitcoinConnection;
+}
+
+describe('beacon change output (ADR 044)', () => {
+  describe('resolveChangeAddress', () => {
+    const beaconAddress = p2tr(SchnorrKeyPair.generate().publicKey.x, undefined, network).address!;
+
+    it('defaults to the beacon address when no change address is supplied', () => {
+      expect(resolveChangeAddress(beaconAddress, network)).to.equal(beaconAddress);
+      expect(resolveChangeAddress(beaconAddress, network, beaconAddress)).to.equal(beaconAddress);
+    });
+
+    it('passes through a valid, distinct change address', () => {
+      const change = p2wpkh(freshKey(), network).address!;
+      expect(resolveChangeAddress(beaconAddress, network, change)).to.equal(change);
+    });
+
+    it('rejects an invalid change address with INVALID_CHANGE_ADDRESS', () => {
+      expect(() => resolveChangeAddress(beaconAddress, network, 'not-a-bitcoin-address'))
+        .to.throw(/Invalid change address/);
+    });
+  });
+
+  describe('beaconTxVsize', () => {
+    it('reproduces the per-kind singleton constant when change kind equals beacon kind', () => {
+      for(const kind of ['p2pkh', 'p2wpkh', 'p2tr'] as const) {
+        expect(beaconTxVsize(kind, kind)).to.equal(SINGLETON_BEACON_TX_VSIZE[kind]);
+      }
+    });
+
+    it('adjusts by the exact change-output size delta for a differing change kind', () => {
+      expect(beaconTxVsize('p2tr', 'p2wpkh'))
+        .to.equal(SINGLETON_BEACON_TX_VSIZE.p2tr - CHANGE_OUTPUT_VBYTES.p2tr + CHANGE_OUTPUT_VBYTES.p2wpkh);
+      // A larger-kind change on a smaller-kind input grows the vsize (P2PKH input, P2TR change).
+      expect(beaconTxVsize('p2pkh', 'p2tr')).to.be.greaterThan(SINGLETON_BEACON_TX_VSIZE.p2pkh);
+    });
+  });
+
+  describe('buildAggregationBeaconTx', () => {
+    const internalKey = SchnorrKeyPair.generate().publicKey.x;
+    const beaconAddress = p2tr(internalKey, undefined, network).address!;
+    const opReturn = bytesToHex(opReturnScript(new Uint8Array(32)));
+
+    it('reuses the beacon address for change by default, with the signal as the last output', async () => {
+      const bitcoin = mockBitcoin(beaconAddress, 100_000);
+      const plan = await buildAggregationBeaconTx({
+        beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
+      });
+
+      expect(plan.changeAddress).to.equal(beaconAddress);
+      expect(plan.tx.outputsLength).to.equal(2);
+      expect(plan.tx.getOutputAddress(0, network)).to.equal(beaconAddress);
+      expect(bytesToHex(plan.tx.getOutput(1).script!)).to.equal(opReturn);
+      // Default change kind is the P2TR beacon address: fee sized for P2TR change.
+      expect(plan.feeSats).to.equal(BigInt(FEE_RATE * beaconTxVsize('p2tr', 'p2tr')));
+    });
+
+    it('routes change to a supplied address and sizes the fee for that change kind', async () => {
+      const changeAddress = p2wpkh(freshKey(), network).address!;
+      const bitcoin = mockBitcoin(beaconAddress, 100_000);
+      const plan = await buildAggregationBeaconTx({
+        beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
+        changeAddress,
+      });
+
+      expect(plan.changeAddress).to.equal(changeAddress);
+      expect(plan.tx.getOutputAddress(0, network)).to.equal(changeAddress);
+      // OP_RETURN stays last even with a rotated change output.
+      expect(bytesToHex(plan.tx.getOutput(1).script!)).to.equal(opReturn);
+      // A P2WPKH change output is cheaper than the default P2TR change: the fee follows.
+      expect(plan.feeSats).to.equal(BigInt(FEE_RATE * beaconTxVsize('p2tr', 'p2wpkh')));
+      expect(Number(plan.feeSats)).to.be.lessThan(FEE_RATE * beaconTxVsize('p2tr', 'p2tr'));
+    });
+
+    it('omits a dust change output, leaving the signal as the sole output', async () => {
+      // Fund just above the fee, so the change after fees is below the dust limit.
+      const feeSats = FEE_RATE * beaconTxVsize('p2tr', 'p2tr');
+      const bitcoin = mockBitcoin(beaconAddress, feeSats + 50); // 50-sat change < 330 dust
+      const plan = await buildAggregationBeaconTx({
+        beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
+      });
+
+      // Change is swept into the fee: the only output is the OP_RETURN signal.
+      expect(plan.tx.outputsLength).to.equal(1);
+      expect(bytesToHex(plan.tx.getOutput(0).script!)).to.equal(opReturn);
+    });
+
+    it('rejects an invalid change address before spending the UTXO', async () => {
+      const bitcoin = mockBitcoin(beaconAddress, 100_000);
+      let threw = false;
+      try {
+        await buildAggregationBeaconTx({
+          beaconAddress, internalPubkey : internalKey, signalBytes    : new Uint8Array(32), bitcoin, network,
+          changeAddress  : 'not-a-bitcoin-address',
+        });
+      } catch(err) {
+        threw = true;
+        expect((err as Error).message).to.match(/Invalid change address/);
+      }
+      expect(threw, 'expected an invalid change address to throw').to.equal(true);
+    });
+  });
+});

--- a/packages/method/tests/beacon-vsize.spec.ts
+++ b/packages/method/tests/beacon-vsize.spec.ts
@@ -6,6 +6,7 @@ import { concatBytes } from '@noble/hashes/utils.js';
 import { OutScript, p2pkh, p2tr, p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 import {
+  beaconTxVsize,
   opReturnScript,
   P2PKH_BEACON_TX_VSIZE,
   P2TR_BEACON_TX_VSIZE,
@@ -120,5 +121,76 @@ describe('beacon vsize constants', () => {
     const actual = tx.vsize;
     expect(actual).to.be.at.most(P2TR_BEACON_TX_VSIZE);
     expect(actual).to.be.at.least(P2TR_BEACON_TX_VSIZE - SLACK);
+  });
+});
+
+/**
+ * Lock in {@link beaconTxVsize} for a change output whose script kind differs from
+ * the beacon (input) kind (ADR 044): the analytical vsize must stay a tight upper
+ * bound for the real finalized transaction so the fee is never under-paid. Covers
+ * the aggregation P2TR key path with a cheaper change kind, and the risky combination
+ * of a small-kind input with the largest (P2TR) change output.
+ */
+describe('beacon vsize by change-output kind', () => {
+  it('P2TR input with P2WPKH change (aggregation key path, cheaper change)', () => {
+    const kp = SchnorrKeyPair.generate();
+    const internalKey = kp.publicKey.x;
+    const tapOut = p2tr(internalKey, undefined, network);
+    const changeOut = p2wpkh(SchnorrKeyPair.generate().publicKey.compressed, network);
+
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addInput({
+      txid           : new Uint8Array(32),
+      index          : 0,
+      witnessUtxo    : { amount: 100000n, script: tapOut.script },
+      tapInternalKey : internalKey,
+    });
+    tx.addOutputAddress(changeOut.address!, 99000n, network);
+    tx.addOutput({ script: opReturnScript(new Uint8Array(32)), amount: 0n });
+    tx.updateInput(0, { tapKeySig: new Uint8Array(64) });
+    tx.finalize();
+
+    const bound = beaconTxVsize('p2tr', 'p2wpkh');
+    expect(tx.vsize).to.be.at.most(bound);
+    expect(tx.vsize).to.be.at.least(bound - SLACK);
+  });
+
+  it('P2PKH input with P2TR change (larger change than the input kind assumes)', () => {
+    const kp = SchnorrKeyPair.generate();
+    const signer = new LocalSigner(kp.secretKey.bytes);
+    const pubkey = signer.publicKey;
+    const pkOut = p2pkh(pubkey, network);
+    const changeOut = p2tr(SchnorrKeyPair.generate().publicKey.x, undefined, network);
+
+    const prevTx = new Transaction();
+    prevTx.addOutput({ amount: 100000n, script: pkOut.script });
+    prevTx.addInput({
+      txid           : new Uint8Array(32),
+      index          : 0xffffffff,
+      finalScriptSig : new Uint8Array([0x00]),
+    });
+    const prevTxBytes = prevTx.toBytes();
+
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addInput({
+      txid           : sha256(sha256(prevTxBytes)).reverse(),
+      index          : 0,
+      nonWitnessUtxo : prevTxBytes,
+    });
+    tx.addOutputAddress(changeOut.address!, 99000n, network);
+    tx.addOutput({ script: opReturnScript(new Uint8Array(32)), amount: 0n });
+
+    const sighashType = SigHash.ALL;
+    const sighash = (tx as unknown as {
+      preimageLegacy: (idx: number, prevScript: Uint8Array, hashType: number) => Uint8Array;
+    }).preimageLegacy(0, pkOut.script, sighashType);
+    const sig = signer.sign(sighash, 'ecdsa');
+    const sigWithType = concatBytes(sig, new Uint8Array([sighashType]));
+    tx.updateInput(0, { partialSig: [[pubkey, sigWithType]] }, true);
+    tx.finalize();
+
+    const bound = beaconTxVsize('p2pkh', 'p2tr');
+    expect(tx.vsize).to.be.at.most(bound);
+    expect(tx.vsize).to.be.at.least(bound - SLACK);
   });
 });


### PR DESCRIPTION
* chore(release): bump method 0.38.0
* feat(method): caller-supplied beacon change address and analytical aggregation fees
* docs(adr): add ADR 044 (beacon change output) and 045 (analytical-vsize aggregation fees)