### PR TITLE
generate a keypair by default in the CLI create command

### DIFF
--- a/docs/adr/049-cli-create-default-keygen.md
+++ b/docs/adr/049-cli-create-default-keygen.md
@@ -1,0 +1,70 @@
+---
+title: "ADR 049: Default Keypair Generation in the create Command"
+---
+
+# ADR 049: Default Keypair Generation in the create Command
+
+**Status:** Accepted (implementation pending)
+
+**Date:** 2026-06-25
+
+**Branch / PR:** `feat/cli-create-keygen`
+
+**Implementation status:** This record fixes the design ahead of the change on this branch. At the time of writing the `create` command requires the caller to supply genesis bytes as a flag and is wired to the keystore-free factory; the default generation path, the existing-key path, the optional network, and the additive genesis-document re-export described below are the accepted target, not yet present in the code.
+
+**References:** [ADR 003](003-bech32m-did-encoding.md), [ADR 013](013-cli-per-command-dependency-injection.md), [ADR 018](018-beacon-hierarchy.md), [ADR 024](024-api-facade-lazy-and-layered-config.md), [ADR 047](047-cli-encrypted-keystore.md), [ADR 048](048-cli-config-profile-model.md)
+
+## Context
+
+The `create` command requires the caller to supply genesis bytes as a hex flag: a 33-byte compressed public key for a deterministic (key) identifier, or a 32-byte document hash for an external identifier. There is no way to mint an identifier from nothing. A user must already hold a key in some other tool and paste its public key, which is friction for the most basic first step of using the method.
+
+The tool now holds keys. There is an encrypted keystore with a key-management command group ([ADR 047](047-cli-encrypted-keystore.md)) and a writable configuration and profile model ([ADR 048](048-cli-config-profile-model.md)). Generated keys persist and an active key is tracked across invocations. But `create` is wired to the keystore-free factory and ignores the keystore entirely, so an identifier minted today has no controllable key in the keystore and cannot be updated or deactivated without a separate import step.
+
+The SDK facade already exposes a one-call generate-and-create path: it mints a keypair, imports it into the injected key manager, and returns the identifier together with the key identifier. Under the keystore-backed key manager that import seals and persists the secret. The capability exists; `create` does not use it.
+
+A deterministic (key) identifier needs no genesis document and no sidecar at resolution; it is derived purely from the public key ([ADR 003](003-bech32m-did-encoding.md)), and its initial document, including a single-party beacon service, is reconstructed deterministically ([ADR 018](018-beacon-hierarchy.md)). An external identifier is different: it needs a genesis document constructed, hashed, and retained as sidecar data for resolution.
+
+## Decision
+
+### 1. Generate a keypair by default when no key is supplied
+
+For a deterministic identifier, when the caller gives neither raw genesis bytes nor a key reference, `create` generates a fresh keypair, persists it to the encrypted keystore, sets it as the active key, and prints the identifier. Running the command with no key material is the common path: a user mints a new, immediately-controllable identifier in one step. Sealing the secret requires the keystore passphrase, so this path prompts for it (or reads it from the configured non-interactive source). The two key-supplying paths below do not prompt.
+
+### 2. Three input modes for a deterministic identifier, selected by presence
+
+- **generate** (no key flag): as above.
+- **existing key reference**: the global key-reference flag selects a key already in the keystore by identifier, fingerprint prefix, or name; its public key becomes the genesis bytes. Reading a public key never decrypts a secret, so this path does not prompt for the passphrase.
+- **raw bytes**: the existing flag supplies a 33-byte compressed public key as hex; this path stays keystore-free and offline, unchanged.
+
+The three modes are mutually exclusive. Supplying more than one is a typed error rather than a silent precedence rule, so the caller's intent is never guessed.
+
+### 3. External identifiers stay raw-bytes-only
+
+An external identifier still requires the 32-byte genesis-document hash via the raw-bytes flag. Generation and the key-reference path apply only to deterministic identifiers; requesting either for an external identifier is a clear error. Generating an external identifier (mint a key, build a genesis document, hash it, and retain the sidecar) is deferred: it introduces sidecar-persistence concerns the deterministic path does not have, and the deterministic path delivers the headline capability on its own.
+
+### 4. The network is optional and resolves from configuration
+
+The network flag becomes optional. When omitted, `create` resolves the network from configuration in order: an explicit default network, then an active profile named for a network, then a development fallback. A user who has set a default network or an active profile ([ADR 048](048-cli-config-profile-model.md)) can mint an identifier with no flags at all; an explicit network flag still wins. Generation itself remains offline and needs no Bitcoin connection.
+
+### 5. Output: the identifier on standard output, key provenance alongside
+
+`create` prints the identifier string on standard output in text mode, so it stays scriptable, and reports the generated or selected key identifier on the human side channel. In structured-output mode the result object carries the identifier together with the key identifier and public key, so an automated caller can record which key controls the new identifier. The raw-bytes path, which involves no keystore key, reports only the identifier as before.
+
+### 6. Reuse the existing generate-and-create path; expose the genesis-document builder
+
+The command uses the facade's existing generate-and-create method rather than a new one ([ADR 024](024-api-facade-lazy-and-layered-config.md)); the only behavioral change is that it runs against the keystore-backed key manager so the secret persists. Separately, the genesis-document class, which builds a full genesis document (a verification method and a beacon service) from a public key, is re-exported from the SDK. This closes a documented export gap and is the additive groundwork for a future external-generation path, without building that path now.
+
+## Consequences
+
+- A first-time user mints a controllable identifier with a single command and no external key tooling; the resulting key is active and immediately usable by update and deactivate.
+- `create` gains a passphrase prompt on the generate path only. The raw-bytes path stays fully offline and prompt-free, preserving the air-gapped create workflow.
+- `create` now uses the keystore-backed factory for the generate and existing-key paths, where before it used only the keystore-free factory. The raw-bytes path keeps the keystore-free factory, so `create` does not require a keystore to exist unless the user asks it to generate or reuse a stored key.
+- The network flag is no longer required, a small contract change; invocations that pass it are unaffected.
+- The SDK surface grows by one additive re-export (the genesis-document builder); no existing export changes.
+
+## Rejected alternatives
+
+- **An explicit generate flag instead of generate-by-default.** Explicit is marginally less surprising but defeats the goal of a one-command mint. The default-when-absent rule keeps the raw-bytes and reference paths explicit while making the common case frictionless, and the mutual-exclusivity error removes the ambiguity an explicit flag would otherwise resolve.
+- **A new dedicated generate-and-create method on the SDK.** The facade already has one; adding another would duplicate it. The only SDK change needed is the additive genesis-document re-export.
+- **Building external-identifier generation now.** It requires constructing and persisting a genesis document as sidecar data, a larger surface with its own retention concerns. The deterministic path delivers the headline capability, and re-exporting the genesis-document builder lets the external path follow additively.
+- **Keeping the network flag required.** Simpler, but it blocks the zero-flag mint the configuration model ([ADR 048](048-cli-config-profile-model.md)) already makes possible. Resolving the network from configuration reuses that model rather than inventing a second default.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -49,6 +49,7 @@ children:
   - ./046-extract-aggregation-package.md
   - ./047-cli-encrypted-keystore.md
   - ./048-cli-config-profile-model.md
+  - ./049-cli-create-default-keygen.md
 ---
 
 # Architecture Decision Records
@@ -105,3 +106,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 046 | 2026-06-24 | [Extract the Aggregation Subsystem into @did-btcr2/aggregation](046-extract-aggregation-package.md) |
 | 047 | 2026-06-25 | [CLI Secret-Key Custody via an Encrypted File-Backed Keystore](047-cli-encrypted-keystore.md) |
 | 048 | 2026-06-25 | [CLI Configuration and Profile Model: Writable Config with Identity and Aggregation Profiles](048-cli-config-profile-model.md) |
+| 049 | 2026-06-25 | [Default Keypair Generation in the create Command](049-cli-create-default-keygen.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 // Upstream re-exports
-export { DidDocument, DidDocumentBuilder, Identifier } from '@did-btcr2/method';
+export { DidDocument, DidDocumentBuilder, GenesisDocument, Identifier } from '@did-btcr2/method';
 export { IdentifierTypes } from '@did-btcr2/common';
 export type {
   BlockV3,

--- a/packages/api/tests/create-api.spec.ts
+++ b/packages/api/tests/create-api.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   createApi,
   DidBtcr2Api,
+  GenesisDocument,
 } from '../src/index.js';
 
 /**
@@ -33,5 +34,28 @@ describe('createApi()', () => {
     };
     const api = createApi({ logger });
     expect(api).to.be.instanceOf(DidBtcr2Api);
+  });
+});
+
+/**
+ * GenesisDocument re-export.
+ *
+ * The genesis-document builder lives in @did-btcr2/method; the SDK re-exports it
+ * so callers can construct an external genesis document from a public key without
+ * reaching into the method package directly.
+ */
+describe('GenesisDocument re-export', () => {
+  it('re-exports the GenesisDocument class', () => {
+    expect(GenesisDocument).to.be.a('function');
+  });
+
+  it('builds a genesis document from a generated public key', () => {
+    const api = createApi();
+    const keyId = api.kms.generateKey();
+    const publicKey = api.kms.getPublicKey(keyId);
+    const genesis = GenesisDocument.fromPublicKey(publicKey, 'regtest');
+    expect(genesis).to.be.instanceOf(GenesisDocument);
+    expect(genesis.verificationMethod).to.be.an('array').with.length.greaterThan(0);
+    expect(genesis.service).to.be.an('array').with.length.greaterThan(0);
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,7 +57,7 @@ export class DidBtcr2Cli {
 
     const globals = (): GlobalOptions => this.program.opts() as GlobalOptions;
 
-    registerCreateCommand(this.program, factory, globals);
+    registerCreateCommand(this.program, factory, keystoreFactory, globals);
     registerResolveCommand(this.program, factory, globals);
     registerUpdateCommand(this.program, keystoreFactory, globals);
     registerDeactivateCommand(this.program, keystoreFactory, globals);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,14 +1,12 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import type { Command } from 'commander';
-import type { ApiFactory } from '../config.js';
+import type { ApiFactory, ConnectionOverrides } from '../config.js';
+import { resolveDefaultNetwork } from '../config.js';
 import { CLIError } from '../error.js';
+import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
-import type {
-  CreateCommandOptions,
-  GlobalOptions,
-  NetworkOption} from '../types.js';
-import {
-  SUPPORTED_NETWORKS,
-} from '../types.js';
+import type { CommandResult, GlobalOptions, NetworkOption } from '../types.js';
+import { SUPPORTED_NETWORKS } from '../types.js';
 
 /** Expected byte length per identifier type: compressed secp256k1 = 33, SHA-256 hash = 32. */
 const EXPECTED_BYTES: Record<'k' | 'x', { length: number; label: string }> = {
@@ -16,74 +14,164 @@ const EXPECTED_BYTES: Record<'k' | 'x', { length: number; label: string }> = {
   x : { length: 32, label: 'SHA-256 hash (32 bytes)' },
 };
 
+/**
+ * Registers the `create` command.
+ *
+ * A deterministic (`-t k`) identifier has three mutually-exclusive input modes,
+ * selected by which is present:
+ * - generate (neither `--bytes` nor `--signing-key`): mint a fresh key, persist
+ *   it to the keystore, set it active, and print the identifier. Sealing the
+ *   secret prompts for the keystore passphrase.
+ * - existing (`--signing-key <ref>`): use a stored key's public key as the
+ *   genesis bytes. Reading a public key never decrypts, so this never prompts.
+ * - raw (`--bytes <hex>`): a 33-byte public key as hex. Offline, keystore-free.
+ *
+ * An external (`-t x`) identifier is raw-bytes-only: a 32-byte genesis-document
+ * hash via `--bytes`. Generation and `--signing-key` apply only to `-t k`.
+ *
+ * The keystore-free `factory` serves the raw-bytes path; the keystore-aware
+ * `keystoreFactory` serves the generate and existing-key paths.
+ */
 export function registerCreateCommand(
-  program : Command,
-  factory : ApiFactory,
-  globals : () => GlobalOptions,
+  program         : Command,
+  factory         : ApiFactory,
+  keystoreFactory : ApiFactory,
+  globals         : () => GlobalOptions,
 ): void {
   program
     .command('create')
     .description('Create an identifier and initial DID document')
-    .requiredOption('-t, --type <type>', 'Identifier type <k|x>', 'k')
-    .requiredOption(
+    .option('-t, --type <type>', 'Identifier type <k|x>', 'k')
+    .option(
       '-n, --network <network>',
-      'Identifier bitcoin network <bitcoin|testnet3|testnet4|signet|mutinynet|regtest>'
+      'Identifier bitcoin network <bitcoin|testnet3|testnet4|signet|mutinynet|regtest> '
+      + '(default: config defaults.network, else regtest)'
     )
-    .requiredOption(
+    .option(
       '-b, --bytes <bytes>',
-      'Genesis bytes as a hex string. ' +
-      'If type=k, MUST be secp256k1 public key. ' +
-      'If type=x, MUST be SHA-256 hash of a genesis document'
+      'Genesis bytes as a hex string. '
+      + 'For type=k, a 33-byte secp256k1 public key (omit to generate a key). '
+      + 'For type=x, the 32-byte SHA-256 hash of a genesis document.'
     )
-    .action(async (options: { type: string; network: string; bytes: string }) => {
-      const parsed = validateCreateOptions(options);
-      const api = factory();
-      const type = parsed.type === 'k' ? 'deterministic' : 'external';
-      const genesisBytes = Buffer.from(parsed.bytes, 'hex');
-      const data = api.createDid(type, genesisBytes, { network: parsed.network });
-      const result = { action: 'create' as const, data };
-      console.log(formatResult(result, globals()));
+    .action(async (options: { type: string; network?: string; bytes?: string }) => {
+      const g = globals();
+      if (options.type !== 'k' && options.type !== 'x') {
+        throw new CLIError('Invalid type. Must be "k" or "x".', 'INVALID_ARGUMENT_ERROR', options);
+      }
+
+      const overrides = overridesFromGlobals(g);
+      const network = resolveNetwork(options.network, overrides);
+      const signingKey = g.signingKey;
+
+      /** Prints the result, plus a stderr provenance line in text mode. */
+      const print = (result: CommandResult, note?: string): void => {
+        console.log(formatResult(result, g));
+        if (note && g.output !== 'json') process.stderr.write(`${note}\n`);
+      };
+
+      // External: raw-bytes only.
+      if (options.type === 'x') {
+        if (signingKey) {
+          throw new CLIError(
+            '--signing-key applies only to deterministic identifiers (-t k).',
+            'INVALID_ARGUMENT_ERROR',
+          );
+        }
+        if (options.bytes === undefined) {
+          throw new CLIError(
+            'External identifiers (-t x) require --bytes <hex>, the 32-byte genesis document hash. '
+            + 'Key generation is only available for -t k.',
+            'INVALID_ARGUMENT_ERROR',
+          );
+        }
+        const genesisBytes = parseGenesisBytes(options.bytes, 'x');
+        const did = factory().createDid('external', genesisBytes, { network });
+        print({ action: 'create', data: did });
+        return;
+      }
+
+      // Deterministic (KEY): three mutually-exclusive modes.
+      if (options.bytes !== undefined && signingKey) {
+        throw new CLIError(
+          'Provide at most one of --bytes or --signing-key.',
+          'INVALID_ARGUMENT_ERROR',
+        );
+      }
+
+      // Raw bytes: keystore-free, offline.
+      if (options.bytes !== undefined) {
+        const genesisBytes = parseGenesisBytes(options.bytes, 'k');
+        const did = factory().createDid('deterministic', genesisBytes, { network });
+        print({ action: 'create', data: did });
+        return;
+      }
+
+      // Existing key: read its public key from the keystore (no passphrase prompt).
+      if (signingKey) {
+        const api = keystoreFactory(undefined, overrides);
+        const keyId = resolveKeyRef(api.kms.kms, signingKey);
+        const publicKey = api.kms.getPublicKey(keyId);
+        const did = api.createDid('deterministic', publicKey, { network });
+        print(
+          { action: 'create', data: did, keyId, publicKey: bytesToHex(publicKey) },
+          `Using stored key ${keyId}.`,
+        );
+        return;
+      }
+
+      // Generate: mint a fresh key, persist it, and set it active (passphrase prompt).
+      const api = keystoreFactory(undefined, overrides);
+      const { did, keyId } = api.generateDid({ network, setActive: true });
+      const publicKey = bytesToHex(api.kms.getPublicKey(keyId));
+      print(
+        { action: 'create', data: did, keyId, publicKey },
+        `Generated and stored key ${keyId} (now the active key).`,
+      );
     });
 }
 
-function validateCreateOptions(
-  options: { type: string; network: string; bytes: string }
-): CreateCommandOptions {
-  if (!['k', 'x'].includes(options.type)) {
-    throw new CLIError(
-      'Invalid type. Must be "k" or "x".',
-      'INVALID_ARGUMENT_ERROR',
-      options
-    );
-  }
-  if (!SUPPORTED_NETWORKS.includes(options.network as NetworkOption)) {
+/** Builds the keystore- and config-resolution overrides from the global flags. */
+function overridesFromGlobals(g: GlobalOptions): ConnectionOverrides {
+  return {
+    config         : g.config,
+    profile        : g.profile,
+    keystore       : g.keystore,
+    passphraseFile : g.passphraseFile,
+  };
+}
+
+/** Validates an explicit `--network`, or resolves the default from configuration. */
+function resolveNetwork(explicit: string | undefined, overrides: ConnectionOverrides): NetworkOption {
+  if (!explicit) return resolveDefaultNetwork(overrides);
+  if (!SUPPORTED_NETWORKS.includes(explicit as NetworkOption)) {
     throw new CLIError(
       'Invalid network. Must be one of "bitcoin", "testnet3", "testnet4", "signet", "mutinynet", or "regtest".',
       'INVALID_ARGUMENT_ERROR',
-      options
+      { network: explicit },
     );
   }
+  return explicit as NetworkOption;
+}
 
-  const buf = Buffer.from(options.bytes, 'hex');
-  if (buf.length === 0) {
+/** Parses and length-checks hex genesis bytes for the given identifier type. */
+function parseGenesisBytes(hex: string, type: 'k' | 'x'): Uint8Array {
+  const expected = EXPECTED_BYTES[type];
+  let bytes: Uint8Array;
+  try {
+    bytes = hexToBytes(hex.trim());
+  } catch {
     throw new CLIError(
-      'Invalid bytes. Must be a non-empty hex string.',
+      `Invalid bytes: not valid hex. Expected ${expected.label}.`,
       'INVALID_ARGUMENT_ERROR',
-      options
+      { bytes: hex },
     );
   }
-  const expected = EXPECTED_BYTES[options.type as 'k' | 'x'];
-  if (buf.length !== expected.length) {
+  if (bytes.length !== expected.length) {
     throw new CLIError(
-      `Invalid bytes length for type="${options.type}": expected ${expected.label}, got ${buf.length} bytes.`,
+      `Invalid bytes length for type="${type}": expected ${expected.label}, got ${bytes.length} bytes.`,
       'INVALID_ARGUMENT_ERROR',
-      options
+      { bytes: hex },
     );
   }
-
-  return {
-    type    : options.type as 'k' | 'x',
-    network : options.network as NetworkOption,
-    bytes   : options.bytes,
-  };
+  return bytes;
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -232,6 +232,29 @@ export function profileToOverrides(
 }
 
 /**
+ * Resolves the default Bitcoin network for offline identifier creation when no
+ * `--network` flag is given. Resolution order: the config file's
+ * `defaults.network`, then an active profile named for a network (an explicit
+ * `--profile` flag or `defaults.profile`), then `regtest` as the development
+ * fallback. Generation itself is offline; this only fixes which network the
+ * identifier encodes.
+ */
+export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkOption {
+  const configPath = overrides?.config ?? defaultConfigPath();
+  const file = readConfigFile(configPath);
+
+  const explicit = file?.defaults?.network;
+  if (explicit && SUPPORTED_NETWORKS.includes(explicit)) return explicit;
+
+  const profile = overrides?.profile ?? file?.defaults?.profile;
+  if (profile && SUPPORTED_NETWORKS.includes(profile as NetworkOption)) {
+    return profile as NetworkOption;
+  }
+
+  return 'regtest';
+}
+
+/**
  * Resolves the Bitcoin and CAS connection config for a network by merging,
  * in precedence order, CLI flags, environment variables, and the config-file
  * profile on top of the per-network defaults (handled by `BitcoinConnection`).

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -10,12 +10,6 @@ export const SUPPORTED_NETWORKS: NetworkOption[] = [
   'bitcoin', 'testnet3', 'testnet4', 'signet', 'mutinynet', 'regtest'
 ];
 
-export interface CreateCommandOptions {
-  type    : 'k' | 'x';
-  bytes   : string;
-  network : NetworkOption;
-}
-
 export interface ResolveCommandOptions {
   identifier : string;
   options?   : ResolutionOptions;
@@ -30,7 +24,7 @@ export interface UpdateCommandOptions {
 }
 
 export type CommandResult =
-  | { action: 'create'; data: string }
+  | { action: 'create'; data: string; keyId?: string; publicKey?: string }
   | { action: 'resolve'; data: DidResolutionResult }
   | { action: 'update'; data: SignedBTCR2Update }
   | { action: 'deactivate'; data: SignedBTCR2Update }

--- a/packages/cli/tests/create-commands.spec.ts
+++ b/packages/cli/tests/create-commands.spec.ts
@@ -1,0 +1,139 @@
+import { Identifier } from '@did-btcr2/api';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DidBtcr2Cli } from '../src/cli.js';
+import {
+  createKeystoreTestApiFactory,
+  createTestApiFactory,
+  expect,
+  originalConsoleError,
+  originalConsoleLog,
+} from './helpers.js';
+
+/** A fresh 33-byte compressed public key as hex, for the raw-bytes path. */
+function freshPublicKeyHex(): string {
+  return bytesToHex(SchnorrKeyPair.generate().publicKey.compressed);
+}
+
+describe('create command', () => {
+  let dir: string;
+  let keystore: string;
+  let cfg: string;
+  let out: string[];
+  let err: string[];
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-create-'));
+    keystore = join(dir, 'keystore.json');
+    cfg = join(dir, 'config.json');
+    out = [];
+    err = [];
+    console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };
+    console.error = (m?: unknown) => { if (m !== undefined) err.push(String(m)); };
+    originalStderrWrite = process.stderr.write;
+    process.stderr.write = ((chunk: unknown) => { err.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    // Start each test with a clean exit code so handleError's `??= 1` is observable.
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = 0;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Each call is a fresh CLI invocation sharing the temp keystore and config files.
+  async function run(...args: string[]): Promise<void> {
+    const cli = new DidBtcr2Cli(createTestApiFactory(), createKeystoreTestApiFactory(keystore, 'pw'));
+    await cli.run(['node', 'btcr2', ...args]);
+  }
+
+  function readKeystore(): { active?: string; keys: Record<string, unknown> } {
+    return JSON.parse(readFileSync(keystore, 'utf-8'));
+  }
+
+  it('generate mode mints a DID and stores a key when no key arg is given', async () => {
+    await run('-o', 'json', 'create', '-n', 'regtest');
+    const result = JSON.parse(out[0]);
+    expect(result.action).to.equal('create');
+    expect(result.data).to.match(/^did:btcr2:k1/);
+    expect(result.keyId).to.match(/^urn:kms:secp256k1:[0-9a-f]{32}$/);
+    expect(result.publicKey).to.match(/^[0-9a-f]{66}$/);
+  });
+
+  it('the generated key is persisted and set active', async () => {
+    await run('-o', 'json', 'create', '-n', 'regtest');
+    const { keyId } = JSON.parse(out[0]);
+    const stored = readKeystore();
+    expect(stored.active).to.equal(keyId);
+    expect(stored.keys).to.have.property(keyId);
+  });
+
+  it('existing-key mode reuses a stored key without generating a new one', async () => {
+    await run('-o', 'json', 'create', '-n', 'regtest');
+    const first = JSON.parse(out[0]);
+    out = [];
+    await run('-o', 'json', '--signing-key', first.keyId, 'create', '-n', 'regtest');
+    const second = JSON.parse(out[0]);
+    expect(second.keyId).to.equal(first.keyId);
+    // Same key, same network -> the deterministic identifier is identical.
+    expect(second.data).to.equal(first.data);
+    // No second key was created.
+    expect(Object.keys(readKeystore().keys)).to.have.length(1);
+  });
+
+  it('raw-bytes mode creates a deterministic DID offline (no keystore)', async () => {
+    const pk = freshPublicKeyHex();
+    await run('-o', 'json', 'create', '-t', 'k', '-n', 'signet', '-b', pk);
+    const result = JSON.parse(out[0]);
+    expect(result.data).to.match(/^did:btcr2:k1/);
+    expect(result).to.not.have.property('keyId');
+    expect(Identifier.decode(result.data).network).to.equal('signet');
+  });
+
+  it('defaults the network from config defaults.network when -n is omitted', async () => {
+    writeFileSync(cfg, JSON.stringify({ schemaVersion: 1, defaults: { network: 'mutinynet' } }));
+    const pk = freshPublicKeyHex();
+    await run('-o', 'json', '--config', cfg, 'create', '-b', pk);
+    const result = JSON.parse(out[0]);
+    expect(Identifier.decode(result.data).network).to.equal('mutinynet');
+  });
+
+  it('falls back to regtest when no -n and no config default', async () => {
+    const pk = freshPublicKeyHex();
+    await run('-o', 'json', '--config', cfg, 'create', '-b', pk);
+    const result = JSON.parse(out[0]);
+    expect(Identifier.decode(result.data).network).to.equal('regtest');
+  });
+
+  it('rejects supplying both --bytes and --signing-key', async () => {
+    const pk = freshPublicKeyHex();
+    await run('--signing-key', 'somekey', 'create', '-b', pk);
+    expect(err.join(' ')).to.match(/at most one of --bytes or --signing-key/i);
+    expect(process.exitCode).to.equal(1);
+  });
+
+  it('external type requires --bytes', async () => {
+    await run('create', '-t', 'x', '-n', 'regtest');
+    expect(err.join(' ')).to.match(/external identifiers .* require --bytes/i);
+    expect(process.exitCode).to.equal(1);
+  });
+
+  it('rejects an invalid --bytes length', async () => {
+    await run('create', '-t', 'k', '-n', 'regtest', '-b', 'abcd');
+    expect(err.join(' ')).to.match(/invalid bytes length/i);
+    expect(process.exitCode).to.equal(1);
+  });
+
+  it('text mode prints the DID on stdout and key provenance on stderr', async () => {
+    await run('create', '-n', 'regtest');
+    expect(out[0]).to.match(/^did:btcr2:k1/);
+    expect(err.join(' ')).to.match(/Generated and stored key urn:kms:secp256k1:[0-9a-f]{32} \(now the active key\)/);
+  });
+});


### PR DESCRIPTION
* chore(release): bump api 0.11.0, cli 0.12.0
* feat(cli): default keypair generation and existing-key reuse in create
* feat(api): re-export GenesisDocument for genesis-document construction
* docs(adr): add ADR 049 (CLI default keypair generation in create)