### PR TITLE
fail fast when a DID update is signed with a non-matching key

### DIFF
--- a/docs/adr/051-update-verifies-signing-key.md
+++ b/docs/adr/051-update-verifies-signing-key.md
@@ -1,0 +1,56 @@
+---
+title: "ADR 051: Verify the Signing Key Against the Named Verification Method in Updater.sign"
+---
+
+# ADR 051: Verify the Signing Key Against the Named Verification Method in Updater.sign
+
+**Status:** Accepted
+
+**Date:** 2026-06-26
+
+**Branch / PR:** `fix/update-verifies-signing-key`
+
+**References:** [ADR 002](002-jcs-canonicalization-and-cryptosuite.md), [ADR 012](012-kms-dual-signing-urn-identifiers.md), [ADR 016](016-sans-io-resolver.md), [ADR 025](025-sans-io-updater.md)
+
+## Context
+
+The sign step of a did:btcr2 update builds a multikey from the caller's signer and produces a Data Integrity proof over the unsigned update ([ADR 002](002-jcs-canonicalization-and-cryptosuite.md)). The signer is supplied by the caller: a local secret key, a key-manager-backed signature, or any custom backend ([ADR 012](012-kms-dual-signing-urn-identifiers.md)). The proof records the verification method it claims to satisfy, taken from the document's `capabilityInvocation`.
+
+Nothing checked that the signer's public key is the key that verification method publishes. A caller who supplies the wrong signing key (a different keystore entry, a key mis-derived after rotation, the wrong active key) produces a structurally valid update whose proof is signed by a key the named method does not list. The proof is internally well-formed but cryptographically unverifiable against the document.
+
+That failure was silent at signing time. It surfaced only much later, when a resolver replaying the update verifies the proof against the document's published key and rejects it ([ADR 016](016-sans-io-resolver.md)) - after the update had been funded and broadcast. The cost of the mistake was an irreversible on-chain announcement that anchors an update no one can verify, with no signal at the point where the mistake was made.
+
+The sign step is a single chokepoint. Both the state-machine path (the updater emits a signing-key need; the caller provides a signer) and the direct static path (scripts and the SDK calling `Updater.sign` outside the state machine) route through the same function ([ADR 025](025-sans-io-updater.md)). The SDK and the CLI both drive updates through it. A check placed there covers every write path; a check placed anywhere else has to be duplicated per consumer or is missed.
+
+## Decision
+
+### 1. Verify the signer's public key against the method's published key at the core sign step
+
+`Updater.sign` compares the multibase-encoded public key carried by the signer's multikey against the named verification method's `publicKeyMultibase`. On mismatch it raises a typed update error and produces no proof. Both encodings are the same canonical form the document uses to record the key, so the comparison is a direct string equality of values already computed, not new cryptography.
+
+Because the state-machine path and the direct static path both call `Updater.sign`, the guard protects the builder, the SDK, and the CLI from one place. None of those layers re-derives or re-compares keys; the error propagates through their existing error handling.
+
+### 2. Fail fast, before funding and broadcast
+
+The check runs at signing, the earliest point the mismatch is detectable and the phase before the update is funded or broadcast. A wrong signing key now costs nothing on-chain: the caller gets a clear, typed error that names the verification method, instead of an unverifiable update that is only discovered after an announcement is spent.
+
+### 3. Skip the check only when the method publishes no key
+
+The guard runs whenever the verification method carries a `publicKeyMultibase`, which a well-formed btcr2 Multikey method always does. When the field is absent, the guard does not invent a key to compare against and does not block signing; it is a consistency check between two stated keys, not a second validator of method shape.
+
+### 4. Keep the resolver's verification as defense in depth
+
+The sign-time guard does not replace the resolver's proof verification. A resolver still rejects any update whose proof signature does not match the document's published key, so an update that bypasses this guard (constructed by other means, or signed against a method an attacker controls while claiming the document's method id) is still caught at resolution ([ADR 016](016-sans-io-resolver.md)). The sign-time guard is the fast local fence that saves a wasted broadcast; the resolver is the trustless backstop that does not depend on the writer having run the fence.
+
+## Consequences
+
+- A wrong signing key fails immediately, at signing, with a typed error naming the verification method, rather than producing an update that fails silently and is only detected after an irreversible on-chain announcement.
+- The guard is a string comparison of already-computed public-key encodings: no extra cryptography, no I/O. The sans-I/O contract of the sign step is preserved.
+- Behavior changes for one case: a caller that previously signed with a mismatched key, which always produced a broken update, now receives an error instead of a broken update. This rejects only previously-broken input; it adds no API surface and removes none.
+- The SDK and the CLI inherit the guard with no code change. A caller that points the update at the wrong stored key now gets the clear error in place of a wasted broadcast.
+
+## Rejected alternatives
+
+- **Check in the SDK or the CLI instead of the core sign step.** Each consumer would duplicate the derive-and-compare, and a future consumer could forget it. The core sign step is the one point every write path crosses, so the invariant belongs there.
+- **Rely solely on the resolver's verification.** Correct but late. The mismatch would surface only at resolution, after the update is funded and broadcast, turning a local input error into a wasted irreversible on-chain spend. The resolver stays as the backstop; it is not a substitute for failing fast at the point of the mistake.
+- **Compare raw public-key bytes rather than the multibase encoding.** Equivalent in result, but the verification method records the key as `publicKeyMultibase` and the signer's multikey exposes the same canonical multibase, so comparing the two encodings directly matches how the document states the key and needs no decode step.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -51,6 +51,7 @@ children:
   - ./048-cli-config-profile-model.md
   - ./049-cli-create-default-keygen.md
   - ./050-split-aggregation-packages.md
+  - ./051-update-verifies-signing-key.md
 ---
 
 # Architecture Decision Records
@@ -109,3 +110,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 048 | 2026-06-25 | [CLI Configuration and Profile Model: Writable Config with Identity and Aggregation Profiles](048-cli-config-profile-model.md) |
 | 049 | 2026-06-25 | [Default Keypair Generation in the create Command](049-cli-create-default-keygen.md) |
 | 050 | 2026-06-26 | [Split the Aggregation Package into Core, Participant, and Service Subpath Exports](050-split-aggregation-packages.md) |
+| 051 | 2026-06-26 | [Verify the Signing Key Against the Named Verification Method in Updater.sign](051-update-verifies-signing-key.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/updater.ts
+++ b/packages/method/src/core/updater.ts
@@ -266,6 +266,27 @@ export class Updater {
     const id = verificationMethod.id.slice(hashIdx);
     const multikey = SchnorrMultikey.fromSigner(id, controller, signer);
 
+    // Fail fast if the signer's public key is not the key published in the named
+    // verification method. Signing with the wrong key yields a Data Integrity
+    // proof that cannot verify against the method, so the resulting on-chain
+    // announcement is wasted: a resolver replaying the update rejects it. Catching
+    // it here guards every update path (state machine, builder, api, cli) at a
+    // single chokepoint. The check is skipped when the method carries no
+    // publicKeyMultibase, which a well-formed btcr2 Multikey method never omits.
+    const signerKey = multikey.publicKey.multibase.encoded;
+    if(verificationMethod.publicKeyMultibase && signerKey !== verificationMethod.publicKeyMultibase) {
+      throw new UpdateError(
+        `Signing key does not match verification method "${verificationMethod.id}": the signer's public `
+        + 'key differs from the method\'s published publicKeyMultibase.',
+        INVALID_DID_UPDATE,
+        {
+          verificationMethodId : verificationMethod.id,
+          expected             : verificationMethod.publicKeyMultibase,
+          actual               : signerKey,
+        }
+      );
+    }
+
     const config: DataIntegrityConfig = {
       '@context' : [
         'https://w3id.org/security/v2',

--- a/packages/method/tests/updater.spec.ts
+++ b/packages/method/tests/updater.spec.ts
@@ -227,6 +227,15 @@ describe('Updater', () => {
       expect(() => updater.provide(signingNeed)).to.throw(/Signer/i);
     });
 
+    it('provide(NeedSigningKey) throws when the signer does not match the verification method', () => {
+      // Drives the same guard through the state-machine path the api and cli use.
+      const state = updater.advance();
+      if(state.status !== 'action-required') throw new Error('expected action-required');
+      const wrongSigner = new LocalSigner(new Uint8Array(32).fill(0x42));
+      expect(() => updater.provide(state.needs[0] as NeedSigningKey, wrongSigner))
+        .to.throw(/does not match verification method/i);
+    });
+
     it('provide(NeedFunding) throws if called before signing is done', () => {
       const bogusFunding: NeedFunding = {
         kind          : 'NeedFunding',
@@ -286,20 +295,38 @@ describe('Updater', () => {
       expect(result.verified).to.be.true;
     });
 
-    it('verification fails when proof is signed by a different key', () => {
+    it('Updater.sign throws when the signer does not match the verification method', () => {
       const unsigned = Updater.construct(sourceDocument, [], 1);
       const vm = sourceDocument.verificationMethod![0]!;
 
-      // Sign with a key that does NOT match the verification method.
-      const wrongKey = new Uint8Array(32).fill(0x42);
-      const wrongSigner = new LocalSigner(wrongKey);
-      const signed = Updater.sign(sourceDocument.id, unsigned, vm, wrongSigner);
+      // Sign with a key that does NOT match the method's published publicKeyMultibase.
+      // The guard fails fast here, before an unverifiable proof is produced and an
+      // on-chain announcement wasted.
+      const wrongSigner = new LocalSigner(new Uint8Array(32).fill(0x42));
+      expect(() => Updater.sign(sourceDocument.id, unsigned, vm, wrongSigner))
+        .to.throw(/does not match verification method/i);
+    });
 
-      const verifierMultikey = SchnorrMultikey.fromVerificationMethod(vm);
-      const cryptosuite = verifierMultikey.toCryptosuite();
-      const result = cryptosuite.verifyProof(signed);
+    it('verifier still rejects a self-consistent proof made by a key other than the document\'s', () => {
+      // Defense in depth: even when a proof is internally consistent (the signer's
+      // key matches the method it was signed against), a resolver verifying against
+      // the document's actual published key rejects a proof an attacker signed with
+      // their own key while claiming the document's verification method id.
+      const unsigned = Updater.construct(sourceDocument, [], 1);
+      const realVm = sourceDocument.verificationMethod![0]!;
+      const fragment = realVm.id.slice(realVm.id.indexOf('#'));
 
-      expect(result.verified).to.be.false;
+      const wrongSigner = new LocalSigner(new Uint8Array(32).fill(0x42));
+      const attackerKey = SchnorrMultikey
+        .fromSigner(fragment, realVm.controller, wrongSigner)
+        .publicKey.multibase.encoded;
+      // A method that legitimately matches the attacker's key, so the sign guard passes.
+      const attackerVm = { ...realVm, publicKeyMultibase: attackerKey };
+      const signed = Updater.sign(sourceDocument.id, unsigned, attackerVm, wrongSigner);
+
+      // The resolver checks against the document's REAL published key, which rejects it.
+      const verifier = SchnorrMultikey.fromVerificationMethod(realVm).toCryptosuite();
+      expect(verifier.verifyProof(signed).verified).to.be.false;
     });
 
     it('cross-signer parity: LocalSigner and inline literal Signer both produce verifiable proofs', () => {


### PR DESCRIPTION
* chore(release): bump method 0.40.1, api 0.11.1, cli 0.12.2
* fix(method): verify the signing key matches the named verification method in Updater.sign
* docs(adr): add ADR 051 (verify signing key matches verification method in Updater.sign)