### PR TITLE
lock the CLI keystore across processes to prevent lost-update key loss

### DIFF
--- a/docs/adr/052-cli-keystore-file-locking.md
+++ b/docs/adr/052-cli-keystore-file-locking.md
@@ -1,0 +1,63 @@
+---
+title: "ADR 052: Cross-Process File Locking for the CLI Keystore"
+---
+
+# ADR 052: Cross-Process File Locking for the CLI Keystore
+
+**Status:** Accepted
+
+**Date:** 2026-06-26
+
+**Branch / PR:** `fix/cli-keystore-file-locking`
+
+**References:** [ADR 013](013-cli-per-command-dependency-injection.md), [ADR 047](047-cli-encrypted-keystore.md), [ADR 048](048-cli-config-profile-model.md)
+
+## Context
+
+The CLI keystore ([ADR 047](047-cli-encrypted-keystore.md)) is a file-backed key-value store. The store loads the whole encrypted file into memory once, at construction, and rewrites the whole file on every mutation (adding or importing a key, removing one, clearing, or moving the active-key pointer). The write is atomic: it serializes to a sibling temporary file and renames it over the target, so a reader, or a crash mid-write, can never observe a torn or half-written file.
+
+Atomicity of a single write is not isolation between writers. Every `btcr2` invocation is a separate process that loads the file once and never reloads it. Two invocations whose lifetimes overlap, two parallel key generations, or a generate in one shell while another shell removes a key, each hold a snapshot taken at their own load. Whichever process flushes last writes its snapshot over the other's change, and the other change is silently gone. This is the classic lost-update read-modify-write race. Because the asset at stake is secret key material, a dropped key is data loss: a key the user believes they generated, with a controllable identifier minted against it, can vanish with no error.
+
+The atomic rename closes the torn-file window. It does nothing for the lost-update window, which is the actual defect.
+
+## Decision
+
+### 1. Serialize mutations with an exclusive cross-process lock
+
+Each of the four mutating store operations runs while holding an exclusive lock, so at most one process mutates the keystore at a time. The lock is the missing isolation the atomic write cannot provide on its own.
+
+### 2. Reload inside the lock, then apply and flush
+
+The lock alone is insufficient: a process that loaded a stale snapshot before acquiring the lock would still flush that stale state over a newer one. So every mutation, while holding the lock, re-reads the file from disk, applies its change on top of that fresh state, and flushes the result. Concurrent additions and deletions now merge instead of clobbering: both added keys survive, and a key one process deleted is not resurrected by another's stale snapshot.
+
+### 3. A hand-rolled O_EXCL lockfile, no dependency
+
+The lock is a sibling lockfile created with `O_CREAT | O_EXCL`: the create fails when the file already exists, and that failure is the mutual-exclusion primitive. We did not take a dependency for this. A general locking library is async and callback-oriented, which fights the synchronous store contract; the logic here is a few dozen lines of well-understood filesystem calls; and the monorepo keeps its dependency surface small. File locking is not a cryptographic primitive, so this is a dependency-minimization call, not the no-external-crypto rule.
+
+### 4. Wait synchronously
+
+The store's key-value contract is synchronous, so the lock acquisition waits with a blocking, non-spinning sleep rather than yielding a promise. The wait blocks the thread for the retry interval instead of busy-looping. The keystore is already a Node-only component, so a synchronous, Node-only wait carries no browser-compatibility cost.
+
+### 5. Break abandoned locks
+
+A process that crashes while holding the lock must not wedge every future invocation. A held lock is broken when its writer process is no longer running (probed with a no-op signal) or when it has aged past a stale threshold. The lockfile records a per-acquisition token, and a holder only ever deletes a lockfile that still carries its own token, so a lock another process legitimately broke as stale is never removed out from under the process that re-took it.
+
+### 6. Reads stay lock-free
+
+Only the four mutations lock. Reads (get, has, list, entries, the active-key lookup) and store construction do not, because the atomic rename already guarantees a reader sees a complete file, old or new. The common commands (resolve, sign, list) pay nothing for the lock. The expensive secret-sealing key derivation also runs before the lock is taken, so the locked critical section is just the reload and flush, keeping the contention window small.
+
+## Consequences
+
+- Two overlapping invocations compose instead of corrupting: both generated keys are kept, and a delete in one process does not undo a delete in another. The silent data-loss window is closed.
+- A crashed writer self-heals. The next invocation breaks the stale lock, immediately when the prior holder's process is gone, or after the stale threshold otherwise, rather than failing forever.
+- A new, visible failure mode replaces silent corruption: under sustained contention a mutation times out with a clear error stating another process holds the lock and how to recover. A loud, recoverable error is the correct outcome.
+- The lock is a transient sibling file, always removed on release, so the existing on-disk invariants (file mode, no leftover temporary files) are unaffected.
+- Windows is covered: both the exclusive-create and the process-liveness probe work there; the keystore already warns separately that POSIX permission bits are not enforced on Windows.
+
+## Rejected alternatives
+
+- **Keep the atomic rename alone.** It prevents torn files but not lost updates, which is the entire bug. Rejected as the status quo being fixed.
+- **Depend on a file-locking library.** More built-in features (retry policies, lock-file mtime refresh) but async and callback-oriented against a synchronous store, and another dependency for logic that is short and well understood here.
+- **Use `flock`-style advisory OS locks.** Node's filesystem API does not expose `flock` without a native addon. An `O_EXCL` lockfile is portable across POSIX and Windows with no addon.
+- **Lock reads as well.** Unnecessary: the atomic rename already gives readers a consistent file, so locking the read path would only slow the common resolve, sign, and list commands for no correctness gain.
+- **Hold one long-lived lock for the whole process.** A larger blast radius and a worse abandoned-lock story. Per-mutation locks keep the held window to a single reload-and-flush.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -52,6 +52,7 @@ children:
   - ./049-cli-create-default-keygen.md
   - ./050-split-aggregation-packages.md
   - ./051-update-verifies-signing-key.md
+  - ./052-cli-keystore-file-locking.md
 ---
 
 # Architecture Decision Records
@@ -111,3 +112,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 049 | 2026-06-25 | [Default Keypair Generation in the create Command](049-cli-create-default-keygen.md) |
 | 050 | 2026-06-26 | [Split the Aggregation Package into Core, Participant, and Service Subpath Exports](050-split-aggregation-packages.md) |
 | 051 | 2026-06-26 | [Verify the Signing Key Against the Named Verification Method in Updater.sign](051-update-verifies-signing-key.md) |
+| 052 | 2026-06-26 | [Cross-Process File Locking for the CLI Keystore](052-cli-keystore-file-locking.md) |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/keystore/file-key-store.ts
+++ b/packages/cli/src/keystore/file-key-store.ts
@@ -6,6 +6,7 @@ import { assertSecurePerms, ensureDir, writeFileAtomic } from './atomic.js';
 import { DEFAULT_ARGON_PARAMS, decryptSecret, encryptSecret } from './envelope.js';
 import type { ArgonParams, SecretEnvelope } from './envelope.js';
 import { KeyStoreError } from './error.js';
+import { withFileLock, type LockOptions } from './lock.js';
 import { defaultKeystorePath } from './paths.js';
 
 /** Current on-disk keystore file format version. */
@@ -41,6 +42,8 @@ export type FileKeyStoreOptions = {
   getPassphrase: () => string;
   /** argon2id cost parameters used when sealing new secrets. Defaults to {@link DEFAULT_ARGON_PARAMS}. */
   argonParams?: ArgonParams;
+  /** Tuning for the cross-process write lock. Defaults documented on {@link LockOptions}. */
+  lock?: LockOptions;
 };
 
 /**
@@ -49,6 +52,15 @@ export type FileKeyStoreOptions = {
  * in memory at construction and flushing the whole file atomically on every
  * mutation.
  *
+ * Every mutation runs under an exclusive cross-process lock and, inside that
+ * lock, reloads the file from disk before applying its change and flushing.
+ * Caching at construction and flushing the whole file is otherwise a lost-update
+ * race: two `btcr2` processes that each load, then each write, would have the
+ * second overwrite the first. The lock serializes the writers and the reload
+ * merges any change the other made, so concurrent invocations compose instead of
+ * clobbering. Reads stay lock-free: an atomic rename means a concurrent reader
+ * always sees a complete file, old or new.
+ *
  * Secrets are materialized only through {@link FileKeyStore.get}. The
  * {@link FileKeyStore.list} and {@link FileKeyStore.entries} projections omit
  * secret keys and never decrypt, so enumerating the store never triggers a
@@ -56,6 +68,8 @@ export type FileKeyStoreOptions = {
  */
 export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
   readonly #path: string;
+  readonly #lockPath: string;
+  readonly #lockOptions: LockOptions;
   readonly #getPassphrase: () => string;
   readonly #argonParams: ArgonParams;
   readonly #cache: Map<KeyIdentifier, CacheEntry> = new Map();
@@ -63,13 +77,15 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
 
   constructor(options: FileKeyStoreOptions) {
     this.#path = options.path ?? defaultKeystorePath();
+    this.#lockPath = `${this.#path}.lock`;
+    this.#lockOptions = options.lock ?? {};
     this.#getPassphrase = options.getPassphrase;
     this.#argonParams = options.argonParams ?? DEFAULT_ARGON_PARAMS;
     ensureDir(dirname(this.#path), 0o700);
-    this.#load();
+    this.#loadFromDisk();
   }
 
-  #load(): void {
+  #loadFromDisk(): void {
     if (!existsSync(this.#path)) return;
     assertSecurePerms(this.#path);
     let parsed: KeystoreFile;
@@ -134,6 +150,44 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
     writeFileAtomic(this.#path, `${JSON.stringify(file, null, 2)}\n`, 0o600);
   }
 
+  /**
+   * Re-reads the file into the cache, discarding the prior in-memory view so a
+   * mutation applies on top of whatever other processes have written. Secrets
+   * already decrypted this session are carried over for entries whose sealed
+   * envelope is byte-identical on disk, so a mid-session write does not force a
+   * re-prompt for keys it did not touch.
+   */
+  #reload(): void {
+    const carried = new Map<KeyIdentifier, { secret: SecretEnvelope; decrypted: Uint8Array }>();
+    for (const [ id, entry ] of this.#cache) {
+      if (entry.secret && entry.decrypted) carried.set(id, { secret: entry.secret, decrypted: entry.decrypted });
+    }
+    this.#cache.clear();
+    this.#active = undefined;
+    this.#loadFromDisk();
+    for (const [ id, prior ] of carried) {
+      const entry = this.#cache.get(id);
+      if (entry?.secret && JSON.stringify(entry.secret) === JSON.stringify(prior.secret)) {
+        entry.decrypted = prior.decrypted;
+      }
+    }
+  }
+
+  /**
+   * Runs a cache mutation under the exclusive write lock, reloading the file
+   * first so the change merges with any concurrent writer's change rather than
+   * overwriting it, then flushing the result atomically. Callers must do any
+   * expensive work (such as sealing a secret with argon2id) before calling this,
+   * so the locked critical section stays short.
+   */
+  #mutate(apply: () => void): void {
+    withFileLock(this.#lockPath, () => {
+      this.#reload();
+      apply();
+      this.#flush();
+    }, this.#lockOptions);
+  }
+
   get(id: KeyIdentifier): KeyEntry | undefined {
     const entry = this.#cache.get(id);
     if (!entry) return undefined;
@@ -165,31 +219,37 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
   }
 
   set(id: KeyIdentifier, value: KeyEntry): void {
+    // Seal the secret before taking the lock: argon2id is deliberately slow and
+    // must not extend the critical section that blocks other processes.
     const secret = value.secretKey
       ? encryptSecret(value.secretKey, this.#getPassphrase(), this.#argonParams)
       : undefined;
-    this.#cache.set(id, {
-      publicKey : value.publicKey,
-      ...(value.tags && { tags: value.tags }),
-      ...(secret && { secret }),
-      ...(value.secretKey && { decrypted: value.secretKey }),
+    this.#mutate(() => {
+      this.#cache.set(id, {
+        publicKey : value.publicKey,
+        ...(value.tags && { tags: value.tags }),
+        ...(secret && { secret }),
+        ...(value.secretKey && { decrypted: value.secretKey }),
+      });
     });
-    this.#flush();
   }
 
   delete(id: KeyIdentifier): boolean {
-    const existed = this.#cache.delete(id);
-    if (existed) {
-      if (this.#active === id) this.#active = undefined;
-      this.#flush();
-    }
+    // `existed` reflects the freshly-reloaded state inside the lock, so a key a
+    // concurrent process already removed reads as absent rather than resurrected.
+    let existed = false;
+    this.#mutate(() => {
+      existed = this.#cache.delete(id);
+      if (existed && this.#active === id) this.#active = undefined;
+    });
     return existed;
   }
 
   clear(): void {
-    this.#cache.clear();
-    this.#active = undefined;
-    this.#flush();
+    this.#mutate(() => {
+      this.#cache.clear();
+      this.#active = undefined;
+    });
   }
 
   /** All stored values with secret keys omitted. Never decrypts, never prompts. */
@@ -233,10 +293,13 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
    * clears it. Throws if the identifier is not a known key.
    */
   setActive(id: KeyIdentifier | undefined): void {
-    if (id !== undefined && !this.#cache.has(id)) {
-      throw new KeyStoreError(`Cannot set unknown key as active: ${id}.`, 'KEY_NOT_FOUND_ERROR', { keyId: id });
-    }
-    this.#active = id;
-    this.#flush();
+    this.#mutate(() => {
+      // The existence check runs against the reloaded state, so a key another
+      // process added in the meantime is a valid active target.
+      if (id !== undefined && !this.#cache.has(id)) {
+        throw new KeyStoreError(`Cannot set unknown key as active: ${id}.`, 'KEY_NOT_FOUND_ERROR', { keyId: id });
+      }
+      this.#active = id;
+    });
   }
 }

--- a/packages/cli/src/keystore/lock.ts
+++ b/packages/cli/src/keystore/lock.ts
@@ -1,0 +1,143 @@
+import { closeSync, openSync, readFileSync, rmSync, statSync, writeSync } from 'node:fs';
+import { KeyStoreError } from './error.js';
+
+/** Tuning for {@link withFileLock}; all values are milliseconds. */
+export interface LockOptions {
+  /** Maximum total time to wait to acquire the lock before failing. Default 10000. */
+  timeoutMs?: number;
+  /** A held lock older than this, or whose writer process is gone, is treated as abandoned and broken. Default 30000. */
+  staleMs?: number;
+  /** Poll interval between acquisition attempts while the lock is held. Default 50. */
+  retryMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_RETRY_MS = 50;
+
+// A per-process counter so a lock token is unambiguous even when one process
+// runs several stores over the same path (as the tests do): the pid alone would
+// collide, the pid plus counter never does.
+let tokenCounter = 0;
+
+/**
+ * Sleeps synchronously for `ms` without spinning the CPU. The keystore store is
+ * a synchronous interface, so the wait must block the thread rather than yield a
+ * promise. `Atomics.wait` on a private buffer no other thread can notify always
+ * runs the full duration. Node-only, which the keystore already is.
+ */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Reports whether a process is still running. `process.kill(pid, 0)` sends no
+ * signal but performs the existence/permission check: ESRCH means the process
+ * is gone, EPERM means it exists under another user (still alive).
+ */
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as { code?: string }).code === 'EPERM';
+  }
+}
+
+/**
+ * Removes the lock if its writer process is gone or it has aged past `staleMs`,
+ * so a process that crashed mid-mutation cannot wedge the keystore permanently.
+ * Returns true when the lock was broken or had already vanished (caller should
+ * retry the create immediately), false when a live, fresh holder still owns it.
+ */
+function breakIfStale(lockPath: string, staleMs: number): boolean {
+  let ageMs: number;
+  let pid: number;
+  try {
+    const stat = statSync(lockPath);
+    ageMs = Date.now() - stat.mtimeMs;
+    pid = Number.parseInt(readFileSync(lockPath, 'utf-8').split('.')[0] ?? '', 10);
+  } catch {
+    // The lock disappeared between our failed create and this inspection; the
+    // caller can race for it again straight away.
+    return true;
+  }
+  if (ageMs > staleMs || !isProcessAlive(pid)) {
+    try {
+      rmSync(lockPath, { force: true });
+    } catch {
+      // Another waiter broke it first; either way it is gone, so retry.
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Releases the lock only while it still holds our token, never one broken from us as stale. */
+function releaseIfOwner(lockPath: string, token: string): void {
+  try {
+    if (readFileSync(lockPath, 'utf-8') === token) rmSync(lockPath, { force: true });
+  } catch {
+    // Already removed (broken as stale, or never created); nothing to release.
+  }
+}
+
+/**
+ * Runs `fn` while holding an exclusive, cross-process advisory lock on
+ * `lockPath`, then releases it.
+ *
+ * The lock is an `O_EXCL` lockfile: creating it fails when another holder
+ * exists, which serializes mutators across separate `btcr2` processes. This is
+ * the missing half of a safe read-modify-write on the keystore file: an atomic
+ * rename keeps the file from tearing, but only mutual exclusion (paired with a
+ * reload inside the lock) keeps two concurrent writers from clobbering each
+ * other's changes. A lock whose writer has died, or that has aged past
+ * `staleMs`, is broken so a crash cannot deadlock future invocations.
+ *
+ * @throws {KeyStoreError} `KEYSTORE_LOCKED_ERROR` if the lock cannot be acquired
+ *   within `timeoutMs`, or `KEYSTORE_LOCK_ERROR` on an unexpected filesystem error.
+ */
+export function withFileLock<T>(lockPath: string, fn: () => T, options: LockOptions = {}): T {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const token = `${process.pid}.${tokenCounter++}`;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      const fd = openSync(lockPath, 'wx', 0o600);
+      try {
+        writeSync(fd, token);
+      } finally {
+        closeSync(fd);
+      }
+      break;
+    } catch (error) {
+      if ((error as { code?: string }).code !== 'EEXIST') {
+        throw new KeyStoreError(
+          `Failed to acquire keystore lock at ${lockPath}.`,
+          'KEYSTORE_LOCK_ERROR',
+          { lockPath, cause: error instanceof Error ? error.message : String(error) },
+        );
+      }
+      if (breakIfStale(lockPath, staleMs)) continue;
+      if (Date.now() >= deadline) {
+        throw new KeyStoreError(
+          `Timed out after ${timeoutMs}ms waiting for the keystore lock at ${lockPath}. `
+          + 'Another btcr2 process may be writing; retry, or remove the lock file if no other process is running.',
+          'KEYSTORE_LOCKED_ERROR',
+          { lockPath, timeoutMs },
+        );
+      }
+      sleepSync(retryMs);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    releaseIfOwner(lockPath, token);
+  }
+}

--- a/packages/cli/tests/keystore-locking.spec.ts
+++ b/packages/cli/tests/keystore-locking.spec.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { KeyEntry } from '@did-btcr2/key-manager';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import { KeyStoreError } from '../src/keystore/error.js';
+import { FileKeyStore } from '../src/keystore/file-key-store.js';
+import type { LockOptions } from '../src/keystore/lock.js';
+import { withFileLock } from '../src/keystore/lock.js';
+import { expect } from './helpers.js';
+
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+const PASS = 'test passphrase';
+
+/** Watch-only entries avoid the argon2id cost; locking is independent of secret sealing. */
+function watchOnlyEntry(seed: number): KeyEntry {
+  return { publicKey: new Uint8Array(33).fill(seed), tags: { name: `watch-${seed}` } };
+}
+
+describe('keystore locking', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-lock-'));
+    path = join(dir, 'keystore.json');
+  });
+
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  function openStore(lock?: LockOptions): FileKeyStore {
+    return new FileKeyStore({ path, getPassphrase: () => PASS, argonParams: FAST, ...(lock && { lock }) });
+  }
+
+  describe('withFileLock', () => {
+    it('serializes: a nested acquisition of a held lock fails with KEYSTORE_LOCKED_ERROR', () => {
+      const lockPath = join(dir, 'x.lock');
+      let innerRan = false;
+      withFileLock(lockPath, () => {
+        expect(() => withFileLock(lockPath, () => { innerRan = true; },
+          { timeoutMs: 60, retryMs: 10, staleMs: 60_000 },
+        )).to.throw(KeyStoreError).with.property('type', 'KEYSTORE_LOCKED_ERROR');
+      }, { timeoutMs: 1000, retryMs: 10 });
+      expect(innerRan).to.equal(false);
+    });
+
+    it('removes the lock file after running', () => {
+      const lockPath = join(dir, 'y.lock');
+      const result = withFileLock(lockPath, () => 42);
+      expect(result).to.equal(42);
+      expect(existsSync(lockPath)).to.equal(false);
+    });
+
+    it('releases the lock even when the body throws', () => {
+      const lockPath = join(dir, 'z.lock');
+      expect(() => withFileLock(lockPath, () => { throw new Error('boom'); })).to.throw('boom');
+      expect(existsSync(lockPath)).to.equal(false);
+    });
+
+    it('breaks a lock whose writer process is gone', () => {
+      const lockPath = join(dir, 'dead.lock');
+      writeFileSync(lockPath, '999999999.0', { mode: 0o600 }); // a pid that does not exist
+      let ran = false;
+      withFileLock(lockPath, () => { ran = true; }, { timeoutMs: 1000, retryMs: 10 });
+      expect(ran).to.equal(true);
+    });
+
+    it('breaks a lock that has aged past the stale threshold', () => {
+      const lockPath = join(dir, 'old.lock');
+      writeFileSync(lockPath, `${process.pid}.0`, { mode: 0o600 }); // our live pid...
+      const old = new Date(Date.now() - 60_000);
+      utimesSync(lockPath, old, old); // ...but backdated well past staleMs
+      let ran = false;
+      withFileLock(lockPath, () => { ran = true; }, { timeoutMs: 1000, retryMs: 10, staleMs: 1000 });
+      expect(ran).to.equal(true);
+    });
+  });
+
+  describe('FileKeyStore concurrent mutation', () => {
+    it('merges a concurrent writer\'s addition instead of clobbering it', () => {
+      // Both instances load the empty file, then each writes a different key.
+      // Without the reload-under-lock, the second flush would drop the first key.
+      const a = openStore();
+      const b = openStore();
+      a.set('urn:a', watchOnlyEntry(1));
+      b.set('urn:b', watchOnlyEntry(2));
+
+      const reopened = openStore();
+      expect(reopened.has('urn:a')).to.equal(true);
+      expect(reopened.has('urn:b')).to.equal(true);
+    });
+
+    it('merges concurrent deletes instead of resurrecting a removed key', () => {
+      openStore().set('urn:a', watchOnlyEntry(1));
+      openStore().set('urn:b', watchOnlyEntry(2));
+
+      const a = openStore(); // stale snapshot {a, b}
+      const b = openStore(); // stale snapshot {a, b}
+      a.delete('urn:a');
+      b.delete('urn:b'); // b's snapshot still held urn:a; the reload must not resurrect it
+
+      const reopened = openStore();
+      expect(reopened.has('urn:a')).to.equal(false);
+      expect(reopened.has('urn:b')).to.equal(false);
+    });
+
+    it('blocks a mutation while another process holds the lock, then fails with KEYSTORE_LOCKED_ERROR', () => {
+      writeFileSync(`${path}.lock`, `${process.pid}.held`, { mode: 0o600 }); // a fresh, live holder
+      const store = openStore({ timeoutMs: 80, retryMs: 10, staleMs: 60_000 });
+      expect(() => store.set('urn:a', watchOnlyEntry(1)))
+        .to.throw(KeyStoreError).with.property('type', 'KEYSTORE_LOCKED_ERROR');
+
+      rmSync(`${path}.lock`, { force: true }); // holder releases
+      store.set('urn:a', watchOnlyEntry(1));
+      expect(openStore().has('urn:a')).to.equal(true);
+    });
+
+    it('does not take the lock for reads', () => {
+      openStore().set('urn:a', watchOnlyEntry(1));
+      writeFileSync(`${path}.lock`, `${process.pid}.held`, { mode: 0o600 }); // hold the lock
+      const store = openStore({ timeoutMs: 50, retryMs: 10, staleMs: 60_000 });
+
+      // Reads complete despite the held lock; only mutations serialize.
+      expect(store.has('urn:a')).to.equal(true);
+      expect(store.list().length).to.equal(1);
+      expect(store.getActive()).to.equal(undefined);
+      rmSync(`${path}.lock`, { force: true });
+    });
+
+    it('leaves no lock file behind after a successful mutation', () => {
+      openStore().set('urn:a', watchOnlyEntry(1));
+      expect(existsSync(`${path}.lock`)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
* chore(release): bump cli 0.12.3
* fix(cli): serialize keystore mutations behind a cross-process lock with reload-merge
* docs(adr): add ADR 052 (cross-process file locking for the CLI keystore)