### PR TITLE
make the bip340-jcs-2025 cryptosuite method-agnostic

### DIFF
--- a/docs/adr/054-cryptosuite-method-agnostic.md
+++ b/docs/adr/054-cryptosuite-method-agnostic.md
@@ -1,0 +1,54 @@
+---
+title: "ADR 054: Make the bip340-jcs-2025 Cryptosuite Method-Agnostic"
+---
+
+# ADR 054: Make the bip340-jcs-2025 Cryptosuite Method-Agnostic
+
+**Status:** Accepted
+
+**Date:** 2026-06-27
+
+**Branch / PR:** `refactor/cryptosuite-method-agnostic` (resolves [#92](https://github.com/dcdpr/did-btcr2-js/issues/92))
+
+**References:** [ADR 002](002-jcs-canonicalization-and-cryptosuite.md), [ADR 025](025-sans-io-updater.md), [ADR 046](046-extract-aggregation-package.md), [ADR 050](050-split-aggregation-packages.md)
+
+## Context
+
+The `@did-btcr2/cryptosuite` package implements the `bip340-jcs-2025` Data Integrity proof suite ([ADR 002](002-jcs-canonicalization-and-cryptosuite.md)). The {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/ | Data Integrity BIP340 Cryptosuites spec} defines a method-agnostic suite: it secures any JSON document (a Verifiable Credential, a DID document, anything) with a Multikey verification method and a BIP340 Schnorr signature over a JCS-canonicalized hash. Nothing in the suite is did:btcr2-specific.
+
+The package's API said otherwise. `addProof` took an `UnsignedBTCR2Update` and returned a `SignedBTCR2Update`; the proof configuration (`DataIntegrityConfig`) carried the ZCAP `capability` and `capabilityAction` fields a did:btcr2 update proof uses; the cryptosuite and data-integrity-proof interfaces threaded these did:btcr2 types throughout. The cryptography was already generic, only the types were did:btcr2-shaped. As issue [#92](https://github.com/dcdpr/did-btcr2-js/issues/92) put it, the suite "should be generic, rather than BTCR2 specific," so any DID method, or a Verifiable Credential issuer, could sign a JSON document with it.
+
+A consequence of the did:btcr2 typing: a consumer that only wanted a signed JSON document still had to reach for a did:btcr2 update type. The aggregation package, for example, imported `SignedBTCR2Update` from the cryptosuite purely to type the opaque signed blobs it shuttles into CAS announcements and SMT leaves; it never reads a single did:btcr2 field of them.
+
+## Decision
+
+### 1. Generic cryptosuite types
+
+`addProof`, `createProof`, `verifyProof`, and `transformDocument` become generic over an unsecured document (a JSON record). The suite gains `UnsecuredDocument`, `SecuredDocument<T>` (`= T & { proof }`), `DataIntegrityProofOptions` (the standard proof options, with an index signature so a cryptosuite or application can carry extra proof properties), and `DataIntegrityProofObject` (options plus `proofValue`). `addProof<T>(document, options)` returns `SecuredDocument<T>`. The did:btcr2 types (`UnsignedBTCR2Update`, `SignedBTCR2Update`, `BTCR2Update`) and the ZCAP config fields leave the cryptosuite. Signing, canonicalization, and signature encoding are unchanged: this is a type-level generalization, not a behavior change.
+
+### 2. did:btcr2 types live in the method package
+
+The did:btcr2 update data structures and the did:btcr2 proof configuration (the standard options plus `capability`/`capabilityAction`) move to `@did-btcr2/method`, the package that owns did:btcr2 specifics. `method`, and the `api` and `cli` that depend on it, source them from there. They are declared as type aliases rather than interfaces, so they satisfy the suite's generic `UnsecuredDocument` (a `Record`) constraint.
+
+### 3. The SDK crypto facade goes generic too
+
+The SDK's Data Integrity facade (the `api` crypto sub-facade) mirrors the now-generic suite: `signDocument`, `addProof`, and `verifyDocument` are generic over the document. The SDK therefore exposes the suite's headline capability, signing any JSON document such as a Verifiable Credential, rather than only did:btcr2 updates.
+
+### 4. Aggregation uses the generic secured-document type
+
+Aggregation treats a signed update as an opaque secured document: it stores it, canonicalizes and hashes it for a CAS announcement or an SMT leaf, and never reads a did:btcr2 field. It now types those blobs as the cryptosuite's generic `SecuredDocument`. This repoints aggregation's one dependency on the moved type without adding a `method` dependency, keeping the package method-independent as it was extracted ([ADR 046](046-extract-aggregation-package.md), [ADR 050](050-split-aggregation-packages.md)).
+
+## Consequences
+
+- The cryptosuite is what the spec describes: a method-agnostic Data Integrity suite. A Verifiable Credential issuer, or another DID method, can sign and verify with it directly.
+- Breaking change to `@did-btcr2/cryptosuite`: `UnsignedBTCR2Update`/`SignedBTCR2Update`/`BTCR2Update` and `DataIntegrityConfig` are gone, replaced by the generic types, and `addProof` is generic. Pre-1.0, this is a minor bump.
+- `@did-btcr2/method` gains the did:btcr2 update types it always owned conceptually; `api` and `cli` source them from `method`. method's public surface grows by that re-export; the api and cli surfaces are otherwise unchanged.
+- The breaking low-level bump cascades dependency-uptake bumps to the cryptosuite's dependents.
+- Aggregation's public types that named `SignedBTCR2Update` now name `SecuredDocument`: a behavior-equivalent type-name change, a minor bump for aggregation.
+
+## Rejected alternatives
+
+- **Land the did:btcr2 types in `@did-btcr2/common`** so every consumer, aggregation included, keeps importing them unchanged. Rejected: `common` is the lowest shared layer, and pushing did:btcr2 update structures into it spreads method specifics downward, the opposite of what [#92](https://github.com/dcdpr/did-btcr2-js/issues/92) asks. The method package is the right owner.
+- **Make aggregation depend on `method`** to keep importing `SignedBTCR2Update`. Rejected: it re-couples a deliberately method-independent package ([ADR 046](046-extract-aggregation-package.md), [ADR 050](050-split-aggregation-packages.md)) to `method`, for a type aggregation only ever uses opaquely. The generic `SecuredDocument` fits what aggregation actually does.
+- **Leave the SDK crypto facade did:btcr2-typed.** Rejected: it would expose a generic suite through a did:btcr2-shaped door, defeating the Verifiable Credential use case [#92](https://github.com/dcdpr/did-btcr2-js/issues/92) calls out.
+- **Declare the method did:btcr2 types as interfaces.** Rejected: TypeScript does not treat an interface as assignable to `Record<string, unknown>` (the suite's generic document constraint), so the generic `addProof` could not accept them. Type aliases carry the implicit index signature that makes them assignable.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -54,6 +54,7 @@ children:
   - ./051-update-verifies-signing-key.md
   - ./052-cli-keystore-file-locking.md
   - ./053-bitcoin-defaults-in-sdk.md
+  - ./054-cryptosuite-method-agnostic.md
 ---
 
 # Architecture Decision Records
@@ -115,3 +116,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 051 | 2026-06-26 | [Verify the Signing Key Against the Named Verification Method in Updater.sign](051-update-verifies-signing-key.md) |
 | 052 | 2026-06-26 | [Cross-Process File Locking for the CLI Keystore](052-cli-keystore-file-locking.md) |
 | 053 | 2026-06-27 | [Bitcoin Service Defaults Belong to the SDK, Not the Sans-I/O Transport](053-bitcoin-defaults-in-sdk.md) |
+| 054 | 2026-06-27 | [Make the bip340-jcs-2025 Cryptosuite Method-Agnostic](054-cryptosuite-method-agnostic.md) |

--- a/packages/aggregation/package.json
+++ b/packages/aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/aggregation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Multi-party coordination for did:btcr2 aggregate beacons: sans-I/O AggregationService and AggregationParticipant state machines, MuSig2 (BIP-327) signing sessions, cohort conditions, and pluggable transports (Nostr, HTTP, in-memory).",
   "main": "./dist/cjs/index.js",

--- a/packages/aggregation/src/core/beacon-strategy.ts
+++ b/packages/aggregation/src/core/beacon-strategy.ts
@@ -1,5 +1,5 @@
 import { canonicalize } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof } from '@did-btcr2/smt';
 import { base64UrlToHash, blockHash, didToIndex, hashToBase64Url, verifySerializedProof } from '@did-btcr2/smt';
 import type { AggregationCohort } from './cohort.js';
@@ -52,7 +52,7 @@ export interface AggregateBeaconStrategy {
   validateParticipantView(params: {
     participantDid: string;
     included: boolean;
-    submittedUpdate?: SignedBTCR2Update;
+    submittedUpdate?: SecuredDocument;
     expectedHash?: string;
     body: BaseBody;
   }): BeaconValidationResult;

--- a/packages/aggregation/src/core/cohort.ts
+++ b/packages/aggregation/src/core/cohort.ts
@@ -1,6 +1,6 @@
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { canonicalHash, canonicalize, hash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof, TreeEntry } from '@did-btcr2/smt';
 import { BTCR2MerkleTree } from '@did-btcr2/smt';
 import { schnorr } from '@noble/curves/secp256k1.js';
@@ -113,7 +113,7 @@ export class AggregationCohort {
   beaconAddress: string = '';
 
   /** Pending DID updates submitted by participants, keyed by DID. */
-  pendingUpdates: Map<string, SignedBTCR2Update> = new Map();
+  pendingUpdates: Map<string, SecuredDocument> = new Map();
 
   /**
    * Participant DIDs that explicitly declined to submit an update this round
@@ -274,7 +274,7 @@ export class AggregationCohort {
     );
   }
 
-  public addUpdate(participantDid: string, signedUpdate: SignedBTCR2Update): void {
+  public addUpdate(participantDid: string, signedUpdate: SecuredDocument): void {
     if(!this.participants.includes(participantDid)) {
       throw new AggregationCohortError(
         `Participant ${participantDid} is not in cohort ${this.id}.`,

--- a/packages/aggregation/src/participant/participant-runner.ts
+++ b/packages/aggregation/src/participant/participant-runner.ts
@@ -1,4 +1,4 @@
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import type { BaseMessage } from '../core/messages/base.js';
 import {
@@ -30,7 +30,7 @@ export type ShouldJoin = (advert: CohortAdvert) => Promise<boolean>;
 export type OnProvideUpdate = (info: {
   cohortId: string;
   beaconAddress: string;
-}) => Promise<SignedBTCR2Update | null>;
+}) => Promise<SecuredDocument | null>;
 
 /** Decision callback: approve or reject aggregated data. */
 export type OnValidateData = (info: PendingValidation) => Promise<{ approved: boolean }>;

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -1,5 +1,5 @@
 import { canonicalHash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof} from '@did-btcr2/smt';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
@@ -126,7 +126,7 @@ interface ParticipantCohortState {
   serviceDid: string;
   advert?: CohortAdvert;
   cohort?: AggregationCohort;
-  submittedUpdate?: SignedBTCR2Update;
+  submittedUpdate?: SecuredDocument;
   /**
    * This round's intent, persisted because the phase advances past
    * NonIncluded/UpdateSubmitted into validation/signing. true = submitted an
@@ -339,7 +339,7 @@ export class AggregationParticipant {
    * User action: submit a signed BTCR2 update for inclusion in the cohort's
    * aggregated signal.
    */
-  public submitUpdate(cohortId: string, signedUpdate: SignedBTCR2Update): BaseMessage[] {
+  public submitUpdate(cohortId: string, signedUpdate: SecuredDocument): BaseMessage[] {
     const state = this.#cohortStates.get(cohortId);
     if(!state || state.phase !== ParticipantCohortPhase.CohortReady) {
       throw new AggregationParticipantError(

--- a/packages/aggregation/src/service/service.ts
+++ b/packages/aggregation/src/service/service.ts
@@ -1,5 +1,5 @@
 import { canonicalize } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import { BIP340Cryptosuite, SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import type { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
@@ -429,7 +429,7 @@ export class AggregationService {
 
 
   /** Updates collected so far for a cohort. */
-  collectedUpdates(cohortId: string): ReadonlyMap<string, SignedBTCR2Update> {
+  collectedUpdates(cohortId: string): ReadonlyMap<string, SecuredDocument> {
     const state = this.#cohortStates.get(cohortId);
     if(!state) return new Map();
     return state.cohort.pendingUpdates;
@@ -449,7 +449,7 @@ export class AggregationService {
     if(!state) return;
     if(state.phase !== ServiceCohortPhase.CohortSet && state.phase !== ServiceCohortPhase.CollectingUpdates) return;
 
-    const signedUpdate = message.body?.signedUpdate as SignedBTCR2Update | undefined;
+    const signedUpdate = message.body?.signedUpdate as SecuredDocument | undefined;
     if(!signedUpdate) {
       state.rejections.push({
         from   : message.from,
@@ -572,13 +572,13 @@ export class AggregationService {
    * signature fails verification.
    * @param {ServiceCohortState} state - the current state of the cohort to which the update was submitted
    * @param {string} sender - the DID of the participant who submitted the update
-   * @param {SignedBTCR2Update} signedUpdate - the signed update containing the proof to verify
+   * @param {SecuredDocument} signedUpdate - the signed update containing the proof to verify
    * @returns {boolean} - `true` if the proof is valid and the update can be accepted; `false` otherwise
    */
   #verifySubmittedUpdate(
     state: ServiceCohortState,
     sender: string,
-    signedUpdate: SignedBTCR2Update,
+    signedUpdate: SecuredDocument,
   ): boolean {
     const proof = signedUpdate.proof;
     if(!proof?.verificationMethod || !proof.proofValue) return false;

--- a/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
+++ b/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
@@ -1,4 +1,4 @@
-import type { DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
@@ -56,7 +56,7 @@ function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): Sig
     targetHash      : `zQmTargetHash${did.slice(-6)}`,
     targetVersionId : version,
   };
-  const config: DataIntegrityConfig = {
+  const config: Btcr2DataIntegrityConfig = {
     '@context'         : context,
     cryptosuite        : 'bip340-jcs-2025',
     type               : 'DataIntegrityProof',

--- a/packages/aggregation/tests/aggregation-multi-cohort.spec.ts
+++ b/packages/aggregation/tests/aggregation-multi-cohort.spec.ts
@@ -1,4 +1,4 @@
-import type { DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { p2tr, Script, Transaction } from '@scure/btc-signer';
@@ -42,7 +42,7 @@ function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): Sig
     targetHash      : `zQmTargetHash${did.slice(-6)}`,
     targetVersionId : version,
   };
-  const config: DataIntegrityConfig = {
+  const config: Btcr2DataIntegrityConfig = {
     '@context'         : context,
     cryptosuite        : 'bip340-jcs-2025',
     type               : 'DataIntegrityProof',

--- a/packages/aggregation/tests/aggregation-noninclusion.spec.ts
+++ b/packages/aggregation/tests/aggregation-noninclusion.spec.ts
@@ -1,4 +1,4 @@
-import type { DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { base64UrlToHash, blockHash, didToIndex, verifySerializedProof } from '@did-btcr2/smt';
@@ -52,7 +52,7 @@ function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): Sig
     targetHash      : `zQmTargetHash${did.slice(-6)}`,
     targetVersionId : version,
   };
-  const config: DataIntegrityConfig = {
+  const config: Btcr2DataIntegrityConfig = {
     '@context'         : context,
     cryptosuite        : 'bip340-jcs-2025',
     type               : 'DataIntegrityProof',

--- a/packages/aggregation/tests/aggregation-security.spec.ts
+++ b/packages/aggregation/tests/aggregation-security.spec.ts
@@ -1,4 +1,4 @@
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { expect } from 'chai';
 import {

--- a/packages/aggregation/tests/aggregation.spec.ts
+++ b/packages/aggregation/tests/aggregation.spec.ts
@@ -1,4 +1,4 @@
-import type { DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -50,7 +50,7 @@ function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): Sig
     targetHash      : `zQmTargetHash${did.slice(-6)}`,
     targetVersionId : version,
   };
-  const config: DataIntegrityConfig = {
+  const config: Btcr2DataIntegrityConfig = {
     '@context'         : context,
     cryptosuite        : 'bip340-jcs-2025',
     type               : 'DataIntegrityProof',

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -1,10 +1,9 @@
 import type { NetworkName } from '@did-btcr2/bitcoin';
 import type { DocumentBytes, KeyBytes, PatchOperation } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import type { Signer } from '@did-btcr2/keypair';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import type { KeyIdentifier } from '@did-btcr2/key-manager';
-import type { Btcr2DidDocument, DidCreateOptions, ResolutionOptions } from '@did-btcr2/method';
+import type { Btcr2DidDocument, DidCreateOptions, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 import { BitcoinApi } from './bitcoin.js';
 import { CasApi, DEFAULT_CAS_GATEWAY, type CasConfig } from './cas.js';

--- a/packages/api/src/crypto.ts
+++ b/packages/api/src/crypto.ts
@@ -1,10 +1,9 @@
 import type { Bytes, Entropy, HexString, KeyBytes, SchnorrKeyPairObject, SignatureBytes } from '@did-btcr2/common';
 import type {
-  BTCR2Update,
-  DataIntegrityConfig,
   DataIntegrityProofObject,
-  SignedBTCR2Update,
-  UnsignedBTCR2Update,
+  DataIntegrityProofOptions,
+  SecuredDocument,
+  UnsecuredDocument,
   VerificationResult
 } from '@did-btcr2/cryptosuite';
 import {
@@ -147,8 +146,8 @@ export class CryptosuiteApi {
    * @returns The created proof.
    */
   createProof(
-    document: BTCR2Update,
-    config: DataIntegrityConfig,
+    document: UnsecuredDocument,
+    config: DataIntegrityProofOptions,
     cryptosuite?: BIP340Cryptosuite
   ): DataIntegrityProofObject {
     const cs = cryptosuite ?? this.#requireCurrent();
@@ -162,7 +161,7 @@ export class CryptosuiteApi {
    * @param cryptosuite Optional explicit cryptosuite; defaults to current.
    * @returns The full verification result.
    */
-  verifyProof(document: SignedBTCR2Update, cryptosuite?: BIP340Cryptosuite): VerificationResult {
+  verifyProof(document: SecuredDocument, cryptosuite?: BIP340Cryptosuite): VerificationResult {
     const cs = cryptosuite ?? this.#requireCurrent();
     return cs.verifyProof(document);
   }
@@ -225,11 +224,11 @@ export class DataIntegrityProofApi {
    * @param proof Optional explicit proof instance; defaults to current.
    * @returns A document with a proof added.
    */
-  addProof(
-    document: UnsignedBTCR2Update,
-    config: DataIntegrityConfig,
+  addProof<T extends UnsecuredDocument>(
+    document: T,
+    config: DataIntegrityProofOptions,
     proof?: BIP340DataIntegrityProof
-  ): SignedBTCR2Update {
+  ): SecuredDocument<T> {
     const p = proof ?? this.#requireCurrent();
     return p.addProof(document, config);
   }
@@ -242,11 +241,11 @@ export class DataIntegrityProofApi {
    * @param config The Data Integrity proof configuration.
    * @returns The signed document with proof attached.
    */
-  signDocument(
+  signDocument<T extends UnsecuredDocument>(
     multikey: SchnorrMultikey,
-    document: UnsignedBTCR2Update,
-    config: DataIntegrityConfig
-  ): SignedBTCR2Update {
+    document: T,
+    config: DataIntegrityProofOptions
+  ): SecuredDocument<T> {
     const cs = new BIP340Cryptosuite(multikey);
     const proofInst = new BIP340DataIntegrityProof(cs);
     return proofInst.addProof(document, config);
@@ -502,26 +501,26 @@ export class CryptoApi {
   }
 
   /**
-   * Sign a BTCR2 update document using the current proof instance.
+   * Add a Data Integrity proof to a document using the current proof instance.
    * Shorthand for `crypto.proof.addProof(document, config)`.
    *
    * Requires {@link activate} to have been called first, or the three
    * sub-facades to have been configured individually.
-   * @param document The unsigned BTCR2 update document.
-   * @param config The Data Integrity proof configuration.
-   * @returns The signed document with proof attached.
+   * @param document The unsecured document to sign (any JSON object).
+   * @param config The Data Integrity proof options.
+   * @returns The secured document with proof attached.
    */
-  signDocument(document: UnsignedBTCR2Update, config: DataIntegrityConfig): SignedBTCR2Update {
+  signDocument<T extends UnsecuredDocument>(document: T, config: DataIntegrityProofOptions): SecuredDocument<T> {
     return this.proof.addProof(document, config);
   }
 
   /**
-   * Verify a signed BTCR2 update document using the current cryptosuite.
+   * Verify a secured document using the current cryptosuite.
    * Shorthand for `crypto.cryptosuite.verifyProof(document)`.
-   * @param document The signed document to verify.
+   * @param document The secured document to verify.
    * @returns The full verification result.
    */
-  verifyDocument(document: SignedBTCR2Update): VerificationResult {
+  verifyDocument(document: SecuredDocument): VerificationResult {
     return this.cryptosuite.verifyProof(document);
   }
 }

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -1,9 +1,8 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import type { DocumentBytes, KeyBytes, PatchOperation } from '@did-btcr2/common';
 import { decode as decodeHash, IdentifierTypes, INVALID_DID_UPDATE, NotImplementedError, UpdateError } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
 import type { Signer } from '@did-btcr2/keypair';
-import type { Btcr2DidDocument, CASAnnouncement, DidCreateOptions, NeedCASAnnouncement, NeedGenesisDocument, NeedSignedUpdate, ResolutionOptions } from '@did-btcr2/method';
+import type { Btcr2DidDocument, CASAnnouncement, DidCreateOptions, NeedCASAnnouncement, NeedGenesisDocument, NeedSignedUpdate, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
 import { BeaconFactory, BeaconSignalDiscovery, DidBtcr2 } from '@did-btcr2/method';
 import type { DidResolutionResult, DidVerificationMethod } from '@web5/dids';
 import type { BitcoinApi } from './bitcoin.js';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,5 @@
 import type { PatchOperation } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
-import type { Btcr2DidDocument, ResolutionOptions } from '@did-btcr2/method';
+import type { Btcr2DidDocument, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 
 export type NetworkOption = 'bitcoin' | 'testnet3' | 'testnet4' | 'signet' | 'mutinynet' | 'regtest';

--- a/packages/cryptosuite/package.json
+++ b/packages/cryptosuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cryptosuite",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "type": "module",
   "description": "W3C Data Integrity proof suite using BIP-340 Schnorr signatures over JCS-canonicalized documents. Creates and verifies bip340-jcs-2025 proofs for did:btcr2 DID updates.",
   "main": "./dist/cjs/index.js",

--- a/packages/cryptosuite/src/cryptosuite/index.ts
+++ b/packages/cryptosuite/src/cryptosuite/index.ts
@@ -16,7 +16,7 @@ import { sha256 } from '@noble/hashes/sha2';
 import { concatBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { base58btc } from 'multiformats/bases/base58';
 import { BIP340DataIntegrityProof } from '../data-integrity-proof/index.js';
-import type { SignedBTCR2Update, BTCR2Update, DataIntegrityConfig, DataIntegrityProofObject } from '../data-integrity-proof/interface.js';
+import type { DataIntegrityProofObject, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from '../data-integrity-proof/interface.js';
 import type { SchnorrMultikey } from '../multikey/index.js';
 import type { Cryptosuite, VerificationResult } from './interface.js';
 
@@ -64,15 +64,15 @@ export class BIP340Cryptosuite implements Cryptosuite {
   /**
    * Create a proof for an insecure document.
    * @param {DidUpdatePayload} document The document to create a proof for.
-   * @param {DataIntegrityConfig} config The options to use when creating the proof.
+   * @param {DataIntegrityProofOptions} config The options to use when creating the proof.
    * @returns {DataIntegrityProofObject} The proof for the document.
    */
   createProof(
-    document: BTCR2Update,
-    config: DataIntegrityConfig
+    document: UnsecuredDocument,
+    config: DataIntegrityProofOptions
   ): DataIntegrityProofObject {
     // Set the context using the document context or the existing config context
-    config['@context'] = document['@context'] ?? config['@context'];
+    config['@context'] = (document['@context'] as string | string[] | undefined) ?? config['@context'];
 
     // Create a canonical form of the proof configuration
     const canonicalConfig = this.proofConfiguration(config);
@@ -104,10 +104,10 @@ export class BIP340Cryptosuite implements Cryptosuite {
 
   /**
    * Verify a proof for a secure document.
-   * @param {SignedBTCR2Update} secureDocument The secure document to verify.
+   * @param {SecuredDocument} secureDocument The secured document to verify.
    * @returns {VerificationResult} The result of the verification.
    */
-  verifyProof(secureDocument: SignedBTCR2Update): VerificationResult {
+  verifyProof(secureDocument: SecuredDocument): VerificationResult {
     // Destructure the proof from the secure document and create an unsecured document without the proof
     const { proof, ...unsecureDocument } = secureDocument;
 
@@ -135,12 +135,12 @@ export class BIP340Cryptosuite implements Cryptosuite {
 
   /**
    * Transform a document into canonical form.
-   * @param {UnsignedBTCR2Update | SignedBTCR2Update} document The document to transform.
-   * @param {DataIntegrityConfig} config The config to use when transforming the document.
+   * @param {UnsecuredDocument} document The document to transform.
+   * @param {DataIntegrityProofOptions} config The config to use when transforming the document.
    * @returns {string} The canonicalized document.
    * @throws {MethodError} if the document cannot be transformed.
    */
-  transformDocument(document: BTCR2Update, config: DataIntegrityConfig): string {
+  transformDocument(document: UnsecuredDocument, config: DataIntegrityProofOptions): string {
     // Get the type from the options and check if it matches this type
     if (config.type !== this.type) {
       throw new MethodError(
@@ -183,11 +183,11 @@ export class BIP340Cryptosuite implements Cryptosuite {
 
   /**
    * Configure the proof by canonicalzing it.
-   * @param {DataIntegrityConfig} config The config to use when transforming the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when transforming the proof.
    * @returns {string} The canonicalized proof configuration.
    * @throws {CryptosuiteError} if the proof configuration cannot be canonicalized.
    */
-  proofConfiguration(config: DataIntegrityConfig): CanonicalizedProofConfig {
+  proofConfiguration(config: DataIntegrityProofOptions): CanonicalizedProofConfig {
     // If the config type does not match the cryptosuite type, throw CryptosuiteError
     if (config.type !== this.type) {
       throw new CryptosuiteError(
@@ -220,11 +220,11 @@ export class BIP340Cryptosuite implements Cryptosuite {
   /**
    * Serialize the proof into a byte array.
    * @param {HashBytes} hash The canonicalized proof configuration.
-   * @param {DataIntegrityConfig} config The config to use when serializing the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when serializing the proof.
    * @returns {SignatureBytes} The serialized proof.
    * @throws {CryptosuiteError} if the multikey does not match the verification method.
    */
-  proofSerialization(hash: HashBytes, config: DataIntegrityConfig): SignatureBytes {
+  proofSerialization(hash: HashBytes, config: DataIntegrityProofOptions): SignatureBytes {
     // Check if the verification method from the config does not match the multikey fullId
     if (config.verificationMethod !== this.multikey.fullId()) {
       // Throw CryptosuiteError
@@ -242,14 +242,14 @@ export class BIP340Cryptosuite implements Cryptosuite {
    * Verify the proof by comparing the hash of the proof configuration and document to the proof bytes.
    * @param {HashBytes} hash The canonicalized proof configuration and document hash.
    * @param {SignatureBytes} signature The proof bytes to verify against.
-   * @param {DataIntegrityConfig} config The config to use when verifying the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when verifying the proof.
    * @returns {boolean} True if the proof is verified, false otherwise.
    * @throws {CryptosuiteError} if the multikey does not match the verification method.
    */
   proofVerification(
     hash: HashBytes,
     signature: SignatureBytes,
-    config: DataIntegrityConfig
+    config: DataIntegrityProofOptions
   ): boolean {
     // If the config verification method !== the multikey fullId, throw CryptosuiteError
     if (config.verificationMethod !== this.multikey.fullId()) {

--- a/packages/cryptosuite/src/cryptosuite/interface.ts
+++ b/packages/cryptosuite/src/cryptosuite/interface.ts
@@ -4,17 +4,16 @@ import type {
   SignatureBytes
 } from '@did-btcr2/common';
 import type {
-  BTCR2Update,
-  DataIntegrityConfig,
   DataIntegrityProofObject,
-  SignedBTCR2Update,
-  UnsignedBTCR2Update
+  DataIntegrityProofOptions,
+  SecuredDocument,
+  UnsecuredDocument
 } from '../data-integrity-proof/interface.js';
 import type { SchnorrMultikey } from '../multikey/index.js';
 
 export interface VerificationResult {
     verified: boolean;
-    verifiedDocument?: SignedBTCR2Update;
+    verifiedDocument?: SecuredDocument;
     mediaType?: string;
 }
 
@@ -41,28 +40,28 @@ export interface Cryptosuite {
   multikey: SchnorrMultikey;
 
   /**
-   * Create a proof for an insecure document.
-   * @param {UnsignedBTCR2Update} insecureDocument The document to create a proof for.
-   * @param {DataIntegrityConfig} config The config to use when creating the proof.
-   * @returns {Proof} The proof for the document.
+   * Create a proof for an unsecured document.
+   * @param {UnsecuredDocument} insecureDocument The document to create a proof for.
+   * @param {DataIntegrityProofOptions} config The proof options to use when creating the proof.
+   * @returns {DataIntegrityProofObject} The proof for the document.
    */
-  createProof(insecureDocument: UnsignedBTCR2Update, config: DataIntegrityConfig): DataIntegrityProofObject;
+  createProof(insecureDocument: UnsecuredDocument, config: DataIntegrityProofOptions): DataIntegrityProofObject;
 
   /**
-   * Verify a proof for a secure document.
-   * @param {SignedBTCR2Update} secureDocument The secure document to verify.
+   * Verify a proof for a secured document.
+   * @param {SecuredDocument} secureDocument The secured document to verify.
    * @returns {VerificationResult} The result of the verification.
    */
-  verifyProof(secureDocument: SignedBTCR2Update): VerificationResult;
+  verifyProof(secureDocument: SecuredDocument): VerificationResult;
 
   /**
-   * Transform a document (secure didUpdateInvocation or insecure didUpdatePayload) into canonical form.
-   * @param {UnsignedBTCR2Update | SignedBTCR2Update} document The document to transform.
-   * @param {DataIntegrityConfig} config The config to use when transforming the document.
+   * Transform a document (secured or unsecured) into canonical form.
+   * @param {UnsecuredDocument} document The document to transform.
+   * @param {DataIntegrityProofOptions} config The proof options to use when transforming the document.
    * @returns {string} The canonicalized document.
    * @throws {MethodError} if the document cannot be transformed.
    */
-  transformDocument(document: BTCR2Update, config: DataIntegrityConfig): string;
+  transformDocument(document: UnsecuredDocument, config: DataIntegrityProofOptions): string;
 
   /**
    * Generate a hash of the canonical proof configuration and document.
@@ -74,32 +73,32 @@ export interface Cryptosuite {
 
   /**
    * Configure the proof by canonicalzing it.
-   * @param {DataIntegrityConfig} config The config to use when transforming the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when transforming the proof.
    * @returns {string} The canonicalized proof configuration.
    * @throws {MethodError} if the proof configuration cannot be canonicalized.
    */
-  proofConfiguration(config: DataIntegrityConfig): CanonicalizedProofConfig;
+  proofConfiguration(config: DataIntegrityProofOptions): CanonicalizedProofConfig;
 
   /**
    * Serialize the proof into a byte array.
    * @param {HashBytes} hash The canonicalized proof configuration.
-   * @param {DataIntegrityConfig} config The config to use when serializing the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when serializing the proof.
    * @returns {SignatureBytes} The serialized proof.
    * @throws {MethodError} if the multikey does not match the verification method.
    */
-  proofSerialization(hash: HashBytes, config: DataIntegrityConfig): SignatureBytes;
+  proofSerialization(hash: HashBytes, config: DataIntegrityProofOptions): SignatureBytes;
 
   /**
    * Verify the proof by comparing the hash of the proof configuration and document to the proof bytes.
    * @param {HashBytes} hash The canonicalized proof configuration.
    * @param {SignatureBytes} signature The serialized proof.
-   * @param {DataIntegrityConfig} config The config to use when verifying the proof.
+   * @param {DataIntegrityProofOptions} config The config to use when verifying the proof.
    * @returns {boolean} True if the proof is verified, false otherwise.
    * @throws {MethodError} if the multikey does not match the verification method.
    */
   proofVerification(
     hash: HashBytes,
     signature: SignatureBytes,
-    config: DataIntegrityConfig
+    config: DataIntegrityProofOptions
   ): boolean;
 }

--- a/packages/cryptosuite/src/data-integrity-proof/index.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/index.ts
@@ -1,7 +1,7 @@
 import { DataIntegrityProofError, PROOF_GENERATION_ERROR, PROOF_VERIFICATION_ERROR } from '@did-btcr2/common';
 import type { BIP340Cryptosuite } from '../cryptosuite/index.js';
 import type { VerificationResult } from '../cryptosuite/interface.js';
-import type { SignedBTCR2Update, UnsignedBTCR2Update, DataIntegrityConfig, DataIntegrityProof } from './interface.js';
+import type { DataIntegrityProof, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from './interface.js';
 
 /**
  * Implements section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}
@@ -24,11 +24,11 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
 
   /**
    * Add a proof to a document.
-   * @param {UnsignedBTCR2Update} unsignedDocument The document to add the proof to.
-   * @param {DataIntegrityConfig} config The configuration for generating the proof.
-   * @returns {SignedBTCR2Update} A document with a proof added.
+   * @param {UnsecuredDocument} unsignedDocument The document to add the proof to.
+   * @param {DataIntegrityProofOptions} config The proof options for generating the proof.
+   * @returns {SecuredDocument} A document with a proof added.
    */
-  addProof(unsignedDocument: UnsignedBTCR2Update, config: DataIntegrityConfig): SignedBTCR2Update {
+  addProof<T extends UnsecuredDocument>(unsignedDocument: T, config: DataIntegrityProofOptions): SecuredDocument<T> {
     // Generate the proof
     const proof = this.cryptosuite.createProof(unsignedDocument, config);
 
@@ -61,13 +61,13 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
         );
     }
 
-    // Cast the unsignedDocument to a SignedBTCR2Update to add the proof
-    const signedDocument = unsignedDocument as SignedBTCR2Update;
+    // Attach the proof, securing the document
+    const signedDocument = unsignedDocument as SecuredDocument<T>;
 
-    // Set the proof in the document and return as a SignedBTCR2Update
+    // Set the proof in the document and return the secured document
     signedDocument.proof = proof;
 
-    // Return the signed document
+    // Return the secured document
     return signedDocument;
   }
 
@@ -88,7 +88,7 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
     expectedChallenge?: string,
   ): VerificationResult {
     // Parse the document
-    const signedDocument = JSON.parse(document) as SignedBTCR2Update;
+    const signedDocument = JSON.parse(document) as SecuredDocument;
 
     // Parse the proof from the document
     const proof = signedDocument.proof;

--- a/packages/cryptosuite/src/data-integrity-proof/interface.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/interface.ts
@@ -1,168 +1,98 @@
-import type { PatchOperation } from '@did-btcr2/common';
 import type { Cryptosuite, VerificationResult } from '../cryptosuite/interface.js';
 
-export type BTCR2Update = UnsignedBTCR2Update | SignedBTCR2Update;
+/**
+ * An unsecured document: any JSON object to which a Data Integrity proof can be
+ * added. This cryptosuite is method-agnostic, so a document is just a JSON
+ * record; applications (DID methods, Verifiable Credentials) layer their own
+ * concrete document shapes on top.
+ */
+export type UnsecuredDocument = Record<string, unknown>;
 
 /**
- * A {@link https://dcdpr.github.io/did-btcr2/terminology.html#btcr2-update | BTCR2 Update} without a data integrity proof.
- * See {@link https://dcdpr.github.io/did-btcr2/data-structures.html#btcr2-unsigned-update | BTCR2 Unsigned Update (data structure)}.
+ * A secured document: an unsecured document `T` with a Data Integrity proof
+ * attached under `proof`.
  */
-export interface UnsignedBTCR2Update {
-    /**
-     * JSON-LD context URIs for interpreting this payload, including contexts
-     * for ZCAP (capabilities), Data Integrity proofs, and JSON-LD patch ops.
-     */
-    '@context': string[];
-
-    /**
-     * A JSON Patch (or JSON-LD Patch) object defining the mutations to apply to
-     * the DID Document. Applying this patch to the current DID Document yields
-     * the new DID Document (which must remain valid per DID Core spec).
-     */
-    patch: Array<PatchOperation>;
-
-    /**
-     * The multihash of the current (source) DID Document, encoded as a multibase
-     * base58-btc string. This is a SHA-256 hash of the canonicalized source DID
-     * Document, used to ensure the patch is applied to the correct document state.
-     */
-    sourceHash: string;
-
-    /**
-     * The multihash of the updated (target) DID Document, encoded as multibase
-     * base58-btc. This is the SHA-256 hash of the canonicalized
-     * DID Document after applying the patch, used to verify the update result.
-     */
-    targetHash: string;
-
-    /**
-     * The version number of the DID Document after this update.
-     * It is equal to the previous document version + 1.
-     */
-    targetVersionId: number;
-}
-
-/**
- * A {@link https://dcdpr.github.io/did-btcr2/terminology.html#btcr2-signed-update | BTCR2 Update} with a data integrity proof.
- * See {@link https://dcdpr.github.io/did-btcr2/data-structures.html#btcr2-signed-update | BTCR2 Signed Update (data structure)}.
- */
-export interface SignedBTCR2Update extends UnsignedBTCR2Update {
- /**
-  * A digital signature added to a BTCR2 Unsigned Update in order to convert to a BTCR2 Signed Update.
-  */
+export type SecuredDocument<T extends UnsecuredDocument = UnsecuredDocument> = T & {
   proof: DataIntegrityProofObject;
-}
+};
 
 /**
- * A {@link https://dcdpr.github.io/did-btcr2/data-structures.html#data-integrity-config | Data Integrity Config}
- * used when adding a Data Integrity Proof to a BTCR2 Unsigned Update.
+ * Data Integrity proof options: the proof configuration without the signature
+ * (`proofValue`). Carries the standard Data Integrity proof properties; a
+ * cryptosuite or application MAY include further properties (for example a ZCAP
+ * `capability`), which are canonicalized into the proof alongside the standard
+ * ones.
  *
  * See Verifiable Credential Data Integrity section {@link https://w3c.github.io/vc-data-integrity/#proofs | 2.1 Proofs}
- * or BIP340 Cryptosuite section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}
- * for more information.
+ * or BIP340 Cryptosuite section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}.
  */
-export interface DataIntegrityConfig {
-  /**
-   * JSON-LD context URIs for interpreting this payload, including contexts
-   * for ZCAP (capabilities), Data Integrity proofs, and JSON-LD patch ops.
-   */
-  '@context': string[];
+export interface DataIntegrityProofOptions {
+  /** JSON-LD context for interpreting the proof; usually inherited from the secured document. */
+  '@context'?: string | string[];
 
-  /**
-   * The proof type, e.g. "DataIntegrityProof".
-   */
+  /** The proof type, always `"DataIntegrityProof"` for this suite. */
   type: 'DataIntegrityProof';
 
-  /**
-   * The purpose of the proof, which the spec sets to "capabilityInvocation".
-   */
-  proofPurpose: string;
-
-  /**
-   * The means and information needed to verify the proof.
-   */
-  verificationMethod: string;
-
-  /**
-   * The cryptographic suite used, e.g. "bip-340-jcs-2025".
-   */
+  /** The cryptographic suite that produced the proof, e.g. `"bip340-jcs-2025"`. */
   cryptosuite: string;
 
-  /**
-   * The root capability being invoked, e.g. `urn:zcap:root:<urlencoded-did>`
-   */
-  capability?: string;
+  /** The verification method (key) used to produce and verify the proof. */
+  verificationMethod: string;
 
-  /**
-   * The action performed under the capability, set to "Write" in the spec
-   * for DID document updates.
-   */
-  capabilityAction?: string;
+  /** The reason the proof was created, e.g. `"assertionMethod"` or `"capabilityInvocation"`. */
+  proofPurpose: string;
 
-  /**
-   * The date and time the proof was created
-   */
+  /** The date and time the proof was created (XML Schema dateTime). */
   created?: string;
 
-  /**
-   * The date and time the proof expires
-   */
+  /** The date and time the proof expires (XML Schema dateTime). */
   expires?: string;
 
-  /**
-   * Conveys one or more security domains in which the proof is meant to be used.
-   */
+  /** One or more security domains in which the proof is meant to be used. */
   domain?: string | string[];
 
-  /**
-   * Should be included if a domain is included, used once for a particular domain and window of time.
-   */
+  /** A challenge, used once for a particular domain and window of time. */
   challenge?: string;
+
+  /** Additional proof properties defined by a cryptosuite or application. */
+  [key: string]: unknown;
 }
 
 /**
- * A {@link https://dcdpr.github.io/did-btcr2/terminology.html#data-integrity-proof | Data Integrity Proof}
- * added to a BTCR2 Unsigned Update.
+ * A Data Integrity proof: the proof options plus the encoded signature.
  *
  * See Verifiable Credential Data Integrity section {@link https://w3c.github.io/vc-data-integrity/#proofs | 2.1 Proofs}
- * or BIP340 Cryptosuite section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}
- * for more information.
+ * or BIP340 Cryptosuite section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}.
  */
-export interface DataIntegrityProofObject extends DataIntegrityConfig {
-  /**
-   * The cryptographic signature value. The exact property name may be defined
-   * by the cryptosuite (for instance, `proofValue` for a raw signature) and
-   * contains the actual signature bytes in an encoded form.
-   */
+export interface DataIntegrityProofObject extends DataIntegrityProofOptions {
+  /** The signature value: the encoded BIP340 Schnorr signature over the proof hash. */
   proofValue: string;
 }
 
 /**
- * Interface representing a BIP-340 DataIntegrityProof.
+ * Interface for a Data Integrity proof manager bound to a {@link Cryptosuite}.
  * @interface DataIntegrityProof
  * @type {DataIntegrityProof}
  */
 export interface DataIntegrityProof {
-  /**
-   * Cryptosuite class object
-   */
+  /** The cryptosuite used for proof generation and verification. */
   cryptosuite: Cryptosuite;
 
   /**
-   * Add a proof to a document.
-   * @param {BTCR2Update} document The document to add a proof to.
-   * @param {DataIntegrityConfig} config The config to use when adding the proof.
-   * @returns {SignedBTCR2Update} The document with the added proof.
+   * Add a Data Integrity proof to a document, returning the secured document.
+   * @param {object} document The unsecured document to add the proof to.
+   * @param {DataIntegrityProofOptions} options The proof options to use when generating the proof.
+   * @returns {SecuredDocument} The document with a `proof` attached.
    */
-  addProof(document: BTCR2Update,config: DataIntegrityConfig): SignedBTCR2Update;
+  addProof<T extends UnsecuredDocument>(document: T, options: DataIntegrityProofOptions): SecuredDocument<T>;
 
   /**
-   * Verify a proof.
-   * @param {string} document The document to verify.
-   * @param {string} expectedPurpose The expected purpose of the proof.
+   * Verify the proof on a secured document.
+   * @param {string} document The stringified secured document to verify.
+   * @param {string} expectedPurpose The expected proof purpose.
    * @param {string} mediaType The media type of the document.
-   * @param {string[]} expectedDomain The expected domain of the proof.
-   * @param {string} expectedChallenge The expected challenge of the proof.
+   * @param {string[]} expectedDomain The expected proof domain.
+   * @param {string} expectedChallenge The expected proof challenge.
    * @returns {VerificationResult} The result of verifying the proof.
    */
   verifyProof(

--- a/packages/cryptosuite/tests/cryptosuite.spec.ts
+++ b/packages/cryptosuite/tests/cryptosuite.spec.ts
@@ -1,7 +1,7 @@
 import { SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
 import { expect } from 'chai';
 import type {
-  DataIntegrityConfig} from '../src/index.js';
+  DataIntegrityProofOptions} from '../src/index.js';
 import {
   BIP340Cryptosuite,
   BIP340DataIntegrityProof,
@@ -27,7 +27,7 @@ const unsecuredDocument = {
 } as any;
 const id = '#initialKey';
 const controller = 'did:btcr2:k1qqpkyr20hr2ugzcdctulmprrdkz5slj3an64l0x4encgc6kpfz7g5dsaaw53r';
-const config: DataIntegrityConfig = {
+const config: DataIntegrityProofOptions = {
   '@context' : [
     'https://w3id.org/security/v2',
     'https://w3id.org/zcap/v1',

--- a/packages/cryptosuite/tests/data-integrity-proof.spec.ts
+++ b/packages/cryptosuite/tests/data-integrity-proof.spec.ts
@@ -1,7 +1,7 @@
 import { SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
 import { expect } from 'chai';
 import type {
-  DataIntegrityConfig} from '../src/index.js';
+  DataIntegrityProofOptions} from '../src/index.js';
 import {
   BIP340Cryptosuite,
   BIP340DataIntegrityProof,
@@ -28,7 +28,7 @@ const unsecuredDocument = {
 const id = '#initialKey';
 const controller = 'did:btcr2:k1qqpkyr20hr2ugzcdctulmprrdkz5slj3an64l0x4encgc6kpfz7g5dsaaw53r';
 const SECRET = 58272841933928377480411201276100309631103600890521640850330825422752012700281n;
-const config: DataIntegrityConfig = {
+const config: DataIntegrityProofOptions = {
   '@context' : [
     'https://w3id.org/security/v2',
     'https://w3id.org/zcap/v1',

--- a/packages/method/lib/anchor-scenarios.ts
+++ b/packages/method/lib/anchor-scenarios.ts
@@ -26,7 +26,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { canonicalHash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 
 import { anchorSignal } from './wallet/tx-builder.js';
 import type { Network } from './wallet/store.js';

--- a/packages/method/lib/build-artifacts.ts
+++ b/packages/method/lib/build-artifacts.ts
@@ -39,7 +39,7 @@ import { fileURLToPath } from 'node:url';
 
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { canonicalHash, canonicalize, encode } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { blockHash, BTCR2MerkleTree, type SerializedSMTProof } from '@did-btcr2/smt';
 import { hex } from '@scure/base';

--- a/packages/method/lib/generate-scenario.ts
+++ b/packages/method/lib/generate-scenario.ts
@@ -27,7 +27,7 @@ import { fileURLToPath } from 'node:url';
 
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { JSONPatch, type PatchOperation } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { hex } from '@scure/base';
 import { p2pkh, p2tr, p2wpkh } from '@scure/btc-signer';

--- a/packages/method/lib/route-delivery.ts
+++ b/packages/method/lib/route-delivery.ts
@@ -37,7 +37,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { canonicalHash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = join(HERE, 'data');

--- a/packages/method/lib/verify-scenarios.ts
+++ b/packages/method/lib/verify-scenarios.ts
@@ -31,7 +31,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { canonicalHash, canonicalize } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import { DidBtcr2 } from '../src/did-btcr2.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
 

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.40.2",
+    "version": "0.41.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -1,6 +1,6 @@
 import type { AddressUtxo, BitcoinConnection, BTCNetwork } from '@did-btcr2/bitcoin';
 import type { KeyBytes } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import { concatBytes, hexToBytes } from '@noble/hashes/utils.js';
 import { Address, OutScript, p2pkh, p2tr, p2wpkh, Script, SigHash, Transaction } from '@scure/btc-signer';

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -1,6 +1,6 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import { canonicalHash, canonicalize, decode, encode, hash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';

--- a/packages/method/src/core/beacon/singleton-beacon.ts
+++ b/packages/method/src/core/beacon/singleton-beacon.ts
@@ -1,6 +1,6 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import { canonicalize, hash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';

--- a/packages/method/src/core/beacon/smt-beacon.ts
+++ b/packages/method/src/core/beacon/smt-beacon.ts
@@ -1,6 +1,6 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import { canonicalize } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import { base64UrlToHash, blockHash, BTCR2MerkleTree, didToIndex, hashToHex, verifySerializedProof } from '@did-btcr2/smt';
 import { randomBytes } from '@noble/hashes/utils';

--- a/packages/method/src/core/btcr2-update.ts
+++ b/packages/method/src/core/btcr2-update.ts
@@ -1,0 +1,87 @@
+import type { PatchOperation } from '@did-btcr2/common';
+import type { DataIntegrityProofObject, DataIntegrityProofOptions } from '@did-btcr2/cryptosuite';
+
+/**
+ * A {@link https://dcdpr.github.io/did-btcr2/terminology.html#btcr2-update | BTCR2 Update} without a data integrity proof.
+ * See {@link https://dcdpr.github.io/did-btcr2/data-structures.html#btcr2-unsigned-update | BTCR2 Unsigned Update (data structure)}.
+ *
+ * This is the did:btcr2-specific document the generic `@did-btcr2/cryptosuite`
+ * suite secures; the suite itself is method-agnostic and knows nothing about it.
+ * Declared as a type alias (not an interface) so it satisfies the suite's
+ * generic `UnsecuredDocument` (a plain JSON record) constraint.
+ */
+export type UnsignedBTCR2Update = {
+  /**
+   * JSON-LD context URIs for interpreting this payload, including contexts
+   * for ZCAP (capabilities), Data Integrity proofs, and JSON-LD patch ops.
+   */
+  '@context': string[];
+
+  /**
+   * A JSON Patch (or JSON-LD Patch) object defining the mutations to apply to
+   * the DID Document. Applying this patch to the current DID Document yields
+   * the new DID Document (which must remain valid per DID Core spec).
+   */
+  patch: Array<PatchOperation>;
+
+  /**
+   * The multihash of the current (source) DID Document, encoded as a multibase
+   * base58-btc string. This is a SHA-256 hash of the canonicalized source DID
+   * Document, used to ensure the patch is applied to the correct document state.
+   */
+  sourceHash: string;
+
+  /**
+   * The multihash of the updated (target) DID Document, encoded as multibase
+   * base58-btc. This is the SHA-256 hash of the canonicalized DID Document
+   * after applying the patch, used to verify the update result.
+   */
+  targetHash: string;
+
+  /**
+   * The version number of the DID Document after this update.
+   * It is equal to the previous document version + 1.
+   */
+  targetVersionId: number;
+};
+
+/**
+ * A Data Integrity proof on a BTCR2 update: the generic proof object plus the
+ * ZCAP capability-invocation fields a did:btcr2 update proof carries.
+ */
+export type Btcr2DataIntegrityProof = DataIntegrityProofObject & {
+  /** The root capability being invoked, e.g. `urn:zcap:root:<urlencoded-did>`. */
+  capability?: string;
+
+  /** The action performed under the capability, set to `"Write"` for DID document updates. */
+  capabilityAction?: string;
+};
+
+/**
+ * A {@link https://dcdpr.github.io/did-btcr2/terminology.html#btcr2-signed-update | BTCR2 Update} with a data integrity proof.
+ * See {@link https://dcdpr.github.io/did-btcr2/data-structures.html#btcr2-signed-update | BTCR2 Signed Update (data structure)}.
+ */
+export type SignedBTCR2Update = UnsignedBTCR2Update & {
+  /** The Data Integrity proof that converts an unsigned update into a signed update. */
+  proof: Btcr2DataIntegrityProof;
+};
+
+/** Either form of a BTCR2 Update. */
+export type BTCR2Update = UnsignedBTCR2Update | SignedBTCR2Update;
+
+/**
+ * Data Integrity proof options for a BTCR2 update: the standard
+ * {@link DataIntegrityProofOptions} plus the ZCAP capability-invocation fields a
+ * did:btcr2 update proof carries. See
+ * {@link https://dcdpr.github.io/did-btcr2/data-structures.html#data-integrity-config | Data Integrity Config}.
+ */
+export type Btcr2DataIntegrityConfig = DataIntegrityProofOptions & {
+  /** JSON-LD context URIs for the proof (ZCAP, Data Integrity, JSON-LD patch). */
+  '@context': string[];
+
+  /** The root capability being invoked, e.g. `urn:zcap:root:<urlencoded-did>`. */
+  capability?: string;
+
+  /** The action performed under the capability, set to `"Write"` for DID document updates. */
+  capabilityAction?: string;
+};

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -17,7 +17,7 @@ import type { HashBytes } from '@did-btcr2/common';
 import type {
   SignedBTCR2Update,
   UnsignedBTCR2Update
-} from '@did-btcr2/cryptosuite';
+} from './btcr2-update.js';
 import {
   BIP340Cryptosuite,
   BIP340DataIntegrityProof,

--- a/packages/method/src/core/types.ts
+++ b/packages/method/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from './btcr2-update.js';
 import type { SMTProof } from './interfaces.js';
 
 /**

--- a/packages/method/src/core/updater.ts
+++ b/packages/method/src/core/updater.ts
@@ -1,8 +1,9 @@
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import type { PatchOperation } from '@did-btcr2/common';
 import { canonicalHash, INVALID_DID_UPDATE, JSONPatch, UpdateError } from '@did-btcr2/common';
-import { SchnorrMultikey, type DataIntegrityConfig, type SignedBTCR2Update, type UnsignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import type { Signer } from '@did-btcr2/keypair';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from './btcr2-update.js';
 import { DidDocument, type Btcr2DidDocument, type DidVerificationMethod } from '../utils/did-document.js';
 import { BeaconFactory } from './beacon/factory.js';
 import type { BeaconService } from './beacon/interfaces.js';
@@ -287,7 +288,7 @@ export class Updater {
       );
     }
 
-    const config: DataIntegrityConfig = {
+    const config: Btcr2DataIntegrityConfig = {
       '@context' : [
         'https://w3id.org/security/v2',
         'https://w3id.org/zcap/v1',

--- a/packages/method/src/index.ts
+++ b/packages/method/src/index.ts
@@ -11,6 +11,7 @@ export * from './core/beacon/smt-beacon.js';
 export * from './core/beacon/utils.js';
 
 // Core
+export * from './core/btcr2-update.js';
 export * from './core/did-sender-resolver.js';
 export * from './core/identifier.js';
 export * from './core/interfaces.js';

--- a/packages/method/tests/beacon.spec.ts
+++ b/packages/method/tests/beacon.spec.ts
@@ -1,5 +1,5 @@
 import { canonicalize, canonicalHash, hash } from '@did-btcr2/common';
-import type { SignedBTCR2Update } from '@did-btcr2/cryptosuite';
+import type { SignedBTCR2Update } from '@did-btcr2/method';
 import { BTCR2MerkleTree } from '@did-btcr2/smt';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
 import { expect } from 'chai';


### PR DESCRIPTION
* chore(release): bump cryptosuite 9.0.0, method 0.41.0, api 0.13.0, aggregation 0.3.0, cli 0.12.5
* refactor(cryptosuite)!: make the Data Integrity suite generic; move btcr2 update types to method
* docs(adr): add ADR 054 (make the bip340-jcs-2025 cryptosuite method-agnostic)

closes #92 