### PR TITLE
harden the resolver provide() trust boundary

### DIFF
--- a/docs/adr/055-resolver-provide-trust-boundary.md
+++ b/docs/adr/055-resolver-provide-trust-boundary.md
@@ -1,0 +1,53 @@
+---
+title: "ADR 055: Harden the Resolver provide() Trust Boundary"
+---
+
+# ADR 055: Harden the Resolver provide() Trust Boundary
+
+**Status:** Accepted
+
+**Date:** 2026-06-27
+
+**Branch / PR:** `fix/resolver-provide-hardening`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 051](051-update-verifies-signing-key.md)
+
+## Context
+
+The Resolver is a sans-I/O state machine ([ADR 016](016-sans-io-resolver.md)): it emits typed `DataNeed` requests and the caller fulfills them through `provide()`. That makes `provide()` a trust boundary. The data crossing it, Bitcoin beacon signals, CAS announcements, signed updates, SMT proofs, genesis documents, comes from the network and from sidecar bundles, so it is influenceable by whoever produced the on-chain signals or assembled the sidecar.
+
+Three gaps sat on that boundary:
+
+1. **Unvalidated payloads.** `provide()` validated the SMT proof's root hash against the need's `smtRootHash`, but it did **not** validate the CAS announcement or the signed update against the need's `announcementHash` / `updateHash`. The on-chain signal commits to a specific hash; the caller could nonetheless supply a different announcement or update, and it was accepted and stored. Resolution then either failed opaquely much later (the lookup by the committed hash missed) or proceeded on data the signal never committed to.
+
+2. **Unchecked casts.** `provide()` cast each payload with `as` and no runtime shape check, so a malformed payload flowed downstream as a bad cast and surfaced as a confusing error far from the boundary where it entered.
+
+3. **Unbounded discovery.** After applying the updates found so far, the resolver looks for beacon services those updates added and loops back to discover their signals. That loop had no bound. A crafted document whose updates keep adding beacon services drives discovery without terminating: an unbounded-work vector.
+
+## Decision
+
+### 1. Validate provided data against the requested hash
+
+`provide()` now checks the CAS announcement's canonical hash against `need.announcementHash` and the signed update's canonical hash against `need.updateHash`, mirroring the SMT root-hash check that was already there. A mismatch throws `ResolveError` (`INVALID_DID_UPDATE`) at the boundary. Correct callers are unaffected: the hash already matches the on-chain commitment, which is exactly why the downstream lookups worked.
+
+### 2. Guard payload shapes at the boundary
+
+`provide()` runtime-checks each payload's shape, a `Map` for beacon signals, the required fields for a CAS announcement, a signed update, and an SMT proof, and an object for a genesis document, and throws a typed error naming the need when the shape is wrong, instead of forcing it through with an `as` cast.
+
+### 3. Bound discovery rounds
+
+A `maxDiscoveryRounds` option (default 10, exposed on `ResolutionOptions`) caps the apply-then-rediscover loop. Exceeding it throws `ResolveError` (`INVALID_DID_DOCUMENT`). A well-formed document reaches a fixed point in a handful of rounds; the cap stops a pathological or malicious chain of beacon services from looping without end.
+
+## Consequences
+
+- A signal that commits to one hash but is fulfilled with different data is rejected at `provide()`, not silently used. Resolution fails with a clear, local error instead of an opaque downstream one or a proof over unverified data.
+- A malformed payload fails fast with a typed error naming the need, rather than a surprise far from the boundary.
+- Resolution terminates: the discovery loop is bounded, so a malicious beacon-chaining document fails closed rather than spinning.
+- `ResolutionOptions` gains an additive `maxDiscoveryRounds` (default 10). Existing callers are unchanged and protected by default; a caller with an unusual but legitimate topology can raise it, and a cautious caller can lower it.
+- The hash checks reject only previously-broken inputs (data that did not match the on-chain commitment); they do not change behavior for matching data.
+
+## Rejected alternatives
+
+- **Trust the caller, or validate only downstream.** The `provide()` boundary is precisely where network-influenced data enters the sans-I/O core; validating there fails fast and locally. Downstream-only validation surfaces errors far from their cause, and for the discovery loop it never fires at all.
+- **A fixed, non-configurable round cap.** Ten rounds suits real documents, but a configurable bound lets a legitimate caller with unusual topology raise it and a cautious caller lower it, without a code change.
+- **Schema-validate entire documents at the boundary.** Heavier than needed. The shape guards check the fields the resolver actually consumes, and the hash checks bind each payload to its on-chain commitment, which is the real integrity property the boundary needs to enforce.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -55,6 +55,7 @@ children:
   - ./052-cli-keystore-file-locking.md
   - ./053-bitcoin-defaults-in-sdk.md
   - ./054-cryptosuite-method-agnostic.md
+  - ./055-resolver-provide-trust-boundary.md
 ---
 
 # Architecture Decision Records
@@ -117,3 +118,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 052 | 2026-06-26 | [Cross-Process File Locking for the CLI Keystore](052-cli-keystore-file-locking.md) |
 | 053 | 2026-06-27 | [Bitcoin Service Defaults Belong to the SDK, Not the Sans-I/O Transport](053-bitcoin-defaults-in-sdk.md) |
 | 054 | 2026-06-27 | [Make the bip340-jcs-2025 Cryptosuite Method-Agnostic](054-cryptosuite-method-agnostic.md) |
+| 055 | 2026-06-27 | [Harden the Resolver provide() Trust Boundary](055-resolver-provide-trust-boundary.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.41.0",
+    "version": "0.42.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/interfaces.ts
+++ b/packages/method/src/core/interfaces.ts
@@ -35,6 +35,14 @@ export interface ResolutionOptions extends DidResolutionOptions {
    * Includes Singleton beacon updates, CAS announcements, and SMT proofs.
    */
   sidecar?: Sidecar;
+
+  /**
+   * Maximum number of multi-round beacon-discovery passes before resolution
+   * fails. Each pass applies the updates found so far, then looks for new beacon
+   * services those updates added. A document whose updates keep adding beacon
+   * services would otherwise drive discovery without bound. Default: 10.
+   */
+  maxDiscoveryRounds?: number;
 }
 
 /**

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -37,6 +37,14 @@ import type { CASAnnouncement, Sidecar, SidecarData } from './types.js';
 import { equalBytes } from '@noble/curves/utils.js';
 
 /**
+ * Default upper bound on multi-round beacon discovery. Each round applies the
+ * updates found so far and looks for beacon services those updates added; a
+ * document whose updates keep adding services would otherwise loop unbounded.
+ * Overridable via `ResolutionOptions.maxDiscoveryRounds`.
+ */
+export const DEFAULT_MAX_DISCOVERY_ROUNDS = 10;
+
+/**
  * The response object for DID Resolution.
  */
 export interface DidResolutionResponse {
@@ -111,6 +119,38 @@ export interface BeaconProcessResult {
   needs: Array<DataNeed>;
 }
 
+// ─── provide() payload guards ────────────────────────────────────────────────
+// Runtime shape checks so a malformed payload fails fast at the provide()
+// boundary rather than flowing downstream as an unchecked `as` cast.
+
+/** True if `value` is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** True if `value` has the shape of a CAS Announcement (a flat record of string hashes). */
+function isCASAnnouncement(value: unknown): value is CASAnnouncement {
+  return isRecord(value) && Object.values(value).every(v => typeof v === 'string');
+}
+
+/** True if `value` has the shape of a signed BTCR2 update. */
+function isSignedBTCR2Update(value: unknown): value is SignedBTCR2Update {
+  if(!isRecord(value)) return false;
+  return Array.isArray(value.patch)
+    && typeof value.sourceHash === 'string'
+    && typeof value.targetHash === 'string'
+    && typeof value.targetVersionId === 'number'
+    && isRecord(value.proof);
+}
+
+/** True if `value` has the shape of an SMT inclusion / non-inclusion proof. */
+function isSMTProof(value: unknown): value is SMTProof {
+  if(!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.collapsed === 'string'
+    && Array.isArray(value.hashes);
+}
+
 /**
  * Different possible Resolver states representing phases in the resolution process.
  */
@@ -163,6 +203,11 @@ export class Resolver {
   #unsortedUpdates: Array<[SignedBTCR2Update, BlockMetadata]> = [];
   #resolvedResponse: DidResolutionResponse | null = null;
 
+  /** Upper bound on multi-round beacon-discovery passes; see {@link DEFAULT_MAX_DISCOVERY_ROUNDS}. */
+  readonly #maxDiscoveryRounds: number;
+  /** Count of beacon-discovery passes driven by updates adding new beacon services. */
+  #discoveryRounds = 0;
+
   /**
    * @internal Use {@link DidBtcr2.resolve} to create instances.
    */
@@ -170,13 +215,14 @@ export class Resolver {
     didComponents: DidComponents,
     sidecarData: SidecarData,
     currentDocument: DidDocument | null,
-    options?: { versionId?: string; versionTime?: string; genesisDocument?: object }
+    options?: { versionId?: string; versionTime?: string; genesisDocument?: object; maxDiscoveryRounds?: number }
   ) {
     this.#didComponents = didComponents;
     this.#sidecarData = sidecarData;
     this.#currentDocument = currentDocument;
     this.#versionId = options?.versionId;
     this.#versionTime = options?.versionTime;
+    this.#maxDiscoveryRounds = options?.maxDiscoveryRounds ?? DEFAULT_MAX_DISCOVERY_ROUNDS;
 
     // If a genesis document was provided (from sidecar), pre-seed it for validation
     if(options?.genesisDocument) {
@@ -653,6 +699,17 @@ export class Resolver {
             });
 
             if(hasNewServices) {
+              // Bound multi-round discovery: a document whose updates keep adding
+              // beacon services would otherwise loop without end. Fail closed once
+              // the configured number of rounds is exceeded.
+              if(++this.#discoveryRounds > this.#maxDiscoveryRounds) {
+                throw new ResolveError(
+                  `Exceeded maximum beacon-discovery rounds (${this.#maxDiscoveryRounds}); `
+                  + 'the DID document may chain beacon services without terminating.',
+                  INVALID_DID_DOCUMENT,
+                  { maxDiscoveryRounds: this.#maxDiscoveryRounds }
+                );
+              }
               // Loop back to discover signals for new beacon services
               this.#phase = ResolverPhase.BeaconDiscovery;
               continue;
@@ -697,42 +754,85 @@ export class Resolver {
   provide(need: DataNeed, data: object | Map<BeaconService, Array<BeaconSignal>> | CASAnnouncement | SignedBTCR2Update | SMTProof): void {
     switch(need.kind) {
       case 'NeedGenesisDocument': {
+        if(!isRecord(data)) {
+          throw new ResolveError(
+            'Provided data for NeedGenesisDocument must be a document object.',
+            INVALID_DID_UPDATE, { kind: need.kind }
+          );
+        }
         this.#providedGenesisDocument = data;
         break;
       }
 
       case 'NeedBeaconSignals': {
-        const signals = data as Map<BeaconService, Array<BeaconSignal>>;
-        for(const [service, serviceSignals] of signals) {
+        if(!(data instanceof Map)) {
+          throw new ResolveError(
+            'Provided data for NeedBeaconSignals must be a Map of beacon services to signals.',
+            INVALID_DID_UPDATE, { kind: need.kind }
+          );
+        }
+        for(const [service, serviceSignals] of data) {
           this.#beaconServicesSignals.set(service, serviceSignals);
         }
         break;
       }
 
       case 'NeedCASAnnouncement': {
-        const announcement = data as CASAnnouncement;
-        this.#sidecarData.casMap.set(canonicalHash(announcement, { encoding: 'hex' }), announcement);
+        if(!isCASAnnouncement(data)) {
+          throw new ResolveError(
+            'Provided data for NeedCASAnnouncement is not a CAS announcement.',
+            INVALID_DID_UPDATE, { kind: need.kind }
+          );
+        }
+        // Fail fast if the provided announcement is not the one the on-chain
+        // signal requested: its canonical hash must equal the need's hash.
+        const announcementHash = canonicalHash(data, { encoding: 'hex' });
+        if(announcementHash !== need.announcementHash) {
+          throw new ResolveError(
+            `CAS announcement hash mismatch: expected ${need.announcementHash}, got ${announcementHash}.`,
+            INVALID_DID_UPDATE, { expected: need.announcementHash, actual: announcementHash }
+          );
+        }
+        this.#sidecarData.casMap.set(announcementHash, data);
         break;
       }
 
       case 'NeedSignedUpdate': {
-        const update = data as SignedBTCR2Update;
-        this.#sidecarData.updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
+        if(!isSignedBTCR2Update(data)) {
+          throw new ResolveError(
+            'Provided data for NeedSignedUpdate is not a signed BTCR2 update.',
+            INVALID_DID_UPDATE, { kind: need.kind }
+          );
+        }
+        // Fail fast if the provided update is not the one the on-chain signal
+        // requested: its canonical hash must equal the need's hash.
+        const updateHash = canonicalHash(data, { encoding: 'hex' });
+        if(updateHash !== need.updateHash) {
+          throw new ResolveError(
+            `Signed update hash mismatch: expected ${need.updateHash}, got ${updateHash}.`,
+            INVALID_DID_UPDATE, { expected: need.updateHash, actual: updateHash }
+          );
+        }
+        this.#sidecarData.updateMap.set(updateHash, data);
         break;
       }
 
       case 'NeedSMTProof': {
-        const smtNeed = need as NeedSMTProof;
-        const proof = data as SMTProof;
-        // proof.id is base64url per spec; smtRootHash is the hex on-chain signal.
-        const proofIdHex = encodeHash(decodeHash(proof.id, 'base64urlnopad'), 'hex');
-        if(proofIdHex !== smtNeed.smtRootHash) {
+        if(!isSMTProof(data)) {
           throw new ResolveError(
-            `SMT proof root hash mismatch: expected ${smtNeed.smtRootHash}, got ${proofIdHex}`,
-            INVALID_DID_UPDATE, { expected: smtNeed.smtRootHash, actual: proofIdHex }
+            'Provided data for NeedSMTProof is not an SMT proof.',
+            INVALID_DID_UPDATE, { kind: need.kind }
           );
         }
-        this.#sidecarData.smtMap.set(smtNeed.smtRootHash, proof);
+        // proof.id is base64url per spec; smtRootHash is the hex on-chain signal.
+        const proofIdHex = encodeHash(decodeHash(data.id, 'base64urlnopad'), 'hex');
+        if(proofIdHex !== need.smtRootHash) {
+          throw new ResolveError(
+            `SMT proof root hash mismatch: expected ${need.smtRootHash}, got ${proofIdHex}`,
+            INVALID_DID_UPDATE, { expected: need.smtRootHash, actual: proofIdHex }
+          );
+        }
+        this.#sidecarData.smtMap.set(need.smtRootHash, data);
         break;
       }
     }

--- a/packages/method/src/did-btcr2.ts
+++ b/packages/method/src/did-btcr2.ts
@@ -124,9 +124,10 @@ export class DidBtcr2 implements DidMethod {
 
     // Return the sans-I/O state machine
     return new Resolver(didComponents, sidecarData, currentDocument, {
-      versionId       : resolutionOptions.versionId,
-      versionTime     : resolutionOptions.versionTime,
-      genesisDocument : resolutionOptions.sidecar?.genesisDocument
+      versionId          : resolutionOptions.versionId,
+      versionTime        : resolutionOptions.versionTime,
+      genesisDocument    : resolutionOptions.sidecar?.genesisDocument,
+      maxDiscoveryRounds : resolutionOptions.maxDiscoveryRounds
     });
   }
 

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -621,4 +621,130 @@ describe('Resolver', () => {
       }
     });
   });
+
+  describe('provide() validation and bounded discovery (hardening)', () => {
+    // Drive a deterministic DID to the NeedSignedUpdate phase via a singleton
+    // signal whose hash is absent from the (empty) sidecar.
+    function reachNeedSignedUpdate(): { resolver: ReturnType<typeof DidBtcr2.resolve>; need: NeedSignedUpdate } {
+      const { did } = deterministicData[2];
+      const resolver = DidBtcr2.resolve(did);
+      let state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected action-required');
+      const beaconNeed = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      signals.set(beaconNeed.beaconServices[0] as BeaconService, [{
+        tx            : {} as any,
+        signalBytes   : 'deadbeef'.repeat(8),
+        blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+      }]);
+      resolver.provide(beaconNeed, signals);
+      state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedSignedUpdate');
+      return { resolver, need: state.needs[0] as NeedSignedUpdate };
+    }
+
+    it('rejects a NeedSignedUpdate payload whose hash does not match the signal', () => {
+      const { resolver, need } = reachNeedSignedUpdate();
+      // Well-formed signed-update shape, but not the update the signal asked for.
+      const wellFormedButWrong = {
+        '@context'      : [],
+        patch           : [],
+        sourceHash      : 'aa',
+        targetHash      : 'bb',
+        targetVersionId : 2,
+        proof           : {
+          type               : 'DataIntegrityProof',
+          cryptosuite        : 'bip340-jcs-2025',
+          verificationMethod : 'did:btcr2:x#k',
+          proofPurpose       : 'capabilityInvocation',
+          proofValue         : 'zz'
+        }
+      };
+      expect(() => resolver.provide(need, wellFormedButWrong as any)).to.throw(/hash mismatch/i);
+    });
+
+    it('rejects a NeedSignedUpdate payload that is not a signed update', () => {
+      const { resolver, need } = reachNeedSignedUpdate();
+      expect(() => resolver.provide(need, { not: 'an update' } as any)).to.throw(/not a signed BTCR2 update/i);
+    });
+
+    it('rejects a NeedCASAnnouncement payload whose hash does not match the signal', () => {
+      const { genesisDocument } = externalData[2];
+      const casGenesisDoc = JSON.parse(JSON.stringify(genesisDocument));
+      casGenesisDoc.service[0].type = 'CASBeacon';
+      const casDid = DidBtcr2.create(hash(canonicalize(casGenesisDoc)), { idType: 'EXTERNAL', version: 1, network: 'regtest' });
+      const resolver = DidBtcr2.resolve(casDid, { sidecar: { genesisDocument: casGenesisDoc } });
+
+      let state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+      const beaconNeed = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      signals.set(beaconNeed.beaconServices[0] as BeaconService, [{
+        tx            : {} as any,
+        signalBytes   : 'abcdef01'.repeat(8),
+        blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+      }]);
+      resolver.provide(beaconNeed, signals);
+
+      state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedCASAnnouncement');
+      const casNeed = state.needs[0] as NeedCASAnnouncement;
+      // Valid announcement shape (record of string hashes), wrong hash.
+      expect(() => resolver.provide(casNeed, { someUpdate: 'someHash' } as any)).to.throw(/hash mismatch/i);
+    });
+
+    it('rejects a non-Map payload for NeedBeaconSignals', () => {
+      const resolver = DidBtcr2.resolve(deterministicData[0].did);
+      const state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected action-required');
+      expect(() => resolver.provide(state.needs[0] as NeedBeaconSignals, [] as any)).to.throw(/Map of beacon services/i);
+    });
+
+    it('rejects a non-object payload for NeedGenesisDocument', () => {
+      const resolver = DidBtcr2.resolve(externalData[0].did);
+      const state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected action-required');
+      expect(state.needs[0].kind).to.equal('NeedGenesisDocument');
+      expect(() => resolver.provide(state.needs[0] as NeedGenesisDocument, 'not-an-object' as any)).to.throw(/document object/i);
+    });
+
+    it('fails closed when discovery exceeds maxDiscoveryRounds', () => {
+      const fixture = deterministicData[2];
+      const did = fixture.did;
+
+      // Resolve once to get the source document.
+      const initResolver = DidBtcr2.resolve(did);
+      let initState = initResolver.resolve();
+      if(initState.status !== 'action-required') throw new Error('expected action-required');
+      provideEmptySignals(initResolver, initState.needs[0] as NeedBeaconSignals);
+      initState = initResolver.resolve();
+      if(initState.status !== 'resolved') throw new Error('expected resolved');
+      const sourceDocument = initState.result.didDocument;
+
+      // An update that adds a new beacon service, forcing one discovery round.
+      const patches = [{
+        op    : 'add' as const,
+        path  : '/service/-',
+        value : { id: `${did}#beacon-new`, type: 'SingletonBeacon', serviceEndpoint: 'bitcoin:mqTxx2aK3Ay3cDk5xM5E5wT6J4QoT6f8vT' }
+      }];
+      const vm = sourceDocument.verificationMethod![0]!;
+      const unsigned = Updater.construct(sourceDocument, patches, 1);
+      const signed = Updater.sign(did, unsigned, vm, new LocalSigner(hexToBytes(fixture.secretKey)));
+      const updateHashHex = canonicalHash(signed, { encoding: 'hex' });
+
+      // A zero round budget means the first loop-back fails closed.
+      const resolver = DidBtcr2.resolve(did, { sidecar: { updates: [signed] }, maxDiscoveryRounds: 0 });
+      const state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+      const round1 = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      signals.set(round1.beaconServices[0] as BeaconService, [{
+        tx            : {} as any,
+        signalBytes   : updateHashHex,
+        blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+      }]);
+      resolver.provide(round1, signals);
+      expect(() => resolver.resolve()).to.throw(/maximum beacon-discovery rounds/i);
+    });
+  });
 });


### PR DESCRIPTION
* chore(release): bump method 0.42.0, api 0.13.1, cli 0.12.6
* feat(method): validate provide() payloads and bound resolver discovery rounds
* docs(adr): add ADR 055 (harden the resolver provide() trust boundary)