### PR TITLE
harden beacon signal discovery against malformed OP_RETURN outputs

### DIFF
--- a/docs/adr/056-beacon-signal-format-validation.md
+++ b/docs/adr/056-beacon-signal-format-validation.md
@@ -1,0 +1,48 @@
+---
+title: "ADR 056: Validate the Beacon Signal Output Format and Document the CAS Announcement Hash Chain"
+---
+
+# ADR 056: Validate the Beacon Signal Output Format and Document the CAS Announcement Hash Chain
+
+**Status:** Accepted
+
+**Date:** 2026-06-27
+
+**Branch / PR:** `fix/beacon-signal-validation`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 037](037-single-party-beacon-and-two-axis-model.md), [ADR 055](055-resolver-provide-trust-boundary.md)
+
+## Context
+
+Beacon signal discovery is the entry point of the resolver's read path: it scans the Bitcoin transactions at each beacon address and extracts the 32-byte update or announcement hash that each signal commits to. A beacon signal is a single `OP_RETURN` data push, on the wire `0x6a 0x20 <32 bytes>`, whose asm form is exactly `OP_RETURN OP_PUSHBYTES_32 <64-hex>`. The encode side is already pinned (`opReturnScript` produces precisely that 34-byte NULL_DATA script).
+
+The decode side was lax. Both discovery paths (the Esplora REST `indexer` and the Bitcoin Core `fullnode` traversal) checked only that the output's `scriptpubkey_asm` *contained* the substring `OP_RETURN`, then took the *last* whitespace-delimited asm token as the signal hash, with an empty-string check as the only guard. Two failure modes followed:
+
+1. **Phantom signals from malformed outputs.** A bare `OP_RETURN` with no push yields the literal token `OP_RETURN` as the "hash". A push of the wrong size, or a non-hex payload, yields a short or non-hex "hash". Either way a value that is not a 32-byte commitment flows downstream as if it were a real signal, producing a sidecar-map miss and an opaque, far-from-source failure (or, with adversarial sidecar data, a lookup against an attacker-chosen key).
+
+2. **Substring false positives.** Because the check was `includes('OP_RETURN')` rather than "the output *is* an OP_RETURN data push," any script whose asm merely mentioned the keyword could be misread as a signal.
+
+Separately, the CAS beacon's resolution path links an on-chain signal to a signed update through two hashes with an encoding transition at each hop (hex on-chain and for map keys, base64urlnopad for announcement values). [ADR 055](055-resolver-provide-trust-boundary.md) made `provide()` enforce those hashes, and pre-loaded sidecar maps enforce them structurally by keying on `canonicalHash`. But the chain itself, and specifically its hex/base64url transitions, was undocumented and had no regression guard, so a future change to a default encoding could silently break resolution: every lookup would simply miss.
+
+## Decision
+
+### 1. Strictly parse the beacon signal output
+
+A single shared decoder, `extractOpReturnSignal(asm)`, returns the 32-byte hash if and only if the asm is exactly three tokens, `OP_RETURN`, then `OP_PUSHBYTES_32`, then a 64-character hex payload, and returns `null` for everything else (empty input, a bare `OP_RETURN`, a wrong-size push opcode, a payload that is not exactly 32 bytes of hex, a multi-push output, or a script where `OP_RETURN` is not the leading opcode). The payload is lowercased so it matches the hex-keyed sidecar maps. Both the REST and fullnode discovery paths now route through this one function and drop any output it rejects.
+
+### 2. Document and regression-test the CAS announcement hash chain
+
+The two-hop chain and its encoding transitions are documented inline on `CASBeacon` (the signal hop: on-chain `signalBytes` in hex equals `canonicalHash(announcement, hex)`, the `casMap` key; the update hop: each announcement value, base64urlnopad, decodes to hex to equal `canonicalHash(signedUpdate, hex)`, the `updateMap` key). A regression test pins both identities directly and drives a broadcast-shaped announcement through `processSignals` end-to-end, so a drift in any default encoding fails loudly at that test rather than silently breaking resolution.
+
+## Consequences
+
+- A beacon address output that is not a well-formed 32-byte `OP_RETURN` push is ignored during discovery, so it can no longer surface as a phantom signal. Only genuine 32-byte commitments enter the resolver.
+- The two discovery paths share one decoder, so the REST and fullnode reads cannot drift in how they recognize a signal, and the recognition rule has direct unit coverage instead of being exercised only against a live chain.
+- The behavior change is narrow: a correctly-formed signal is parsed exactly as before (now lowercased, a no-op for the lowercase hex that Esplora and Bitcoin Core already emit). Only previously-malformed outputs change outcome, from a downstream miss to being dropped at the source.
+- The CAS hash chain's encoding contract is documented and guarded, so a future change to `canonicalHash`'s default encoding or to the announcement-value encoding fails a fast, local test rather than silently producing empty resolutions.
+
+## Rejected alternatives
+
+- **Keep the substring check and tolerate odd shapes.** The substring match is what admits phantom signals; "is exactly an `OP_RETURN OP_PUSHBYTES_32 <32-byte>` push" is the real predicate the read path needs, and is what the encode side already produces.
+- **Accept any push length and validate downstream.** The 32-byte size is part of the signal definition; enforcing it at extraction keeps the invalid value out of the sidecar-lookup machinery entirely, consistent with [ADR 055](055-resolver-provide-trust-boundary.md)'s fail-fast-at-the-boundary stance.
+- **Add a runtime re-check of the CAS chain inside `processSignals`.** Redundant: `provide()` already validates supplied data against the need's hash, and pre-loaded maps are keyed by `canonicalHash`, so a mismatched entry simply misses the lookup. The remaining gap was documentation and a regression guard, not another runtime check.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -56,6 +56,7 @@ children:
   - ./053-bitcoin-defaults-in-sdk.md
   - ./054-cryptosuite-method-agnostic.md
   - ./055-resolver-provide-trust-boundary.md
+  - ./056-beacon-signal-format-validation.md
 ---
 
 # Architecture Decision Records
@@ -119,3 +120,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 053 | 2026-06-27 | [Bitcoin Service Defaults Belong to the SDK, Not the Sans-I/O Transport](053-bitcoin-defaults-in-sdk.md) |
 | 054 | 2026-06-27 | [Make the bip340-jcs-2025 Cryptosuite Method-Agnostic](054-cryptosuite-method-agnostic.md) |
 | 055 | 2026-06-27 | [Harden the Resolver provide() Trust Boundary](055-resolver-provide-trust-boundary.md) |
+| 056 | 2026-06-27 | [Validate the Beacon Signal Output Format and Document the CAS Announcement Hash Chain](056-beacon-signal-format-validation.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.42.0",
+    "version": "0.43.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -26,6 +26,28 @@ export interface CASBroadcastOptions extends BroadcastOptions {
  * During resolution, the CAS Announcement is retrieved from the sidecar (or CAS)
  * and used to look up the individual signed update for the DID being resolved.
  *
+ * ## CAS announcement hash chain
+ *
+ * Resolution links an on-chain signal to a signed update through two hashes, with
+ * an encoding transition at each hop. The write path ({@link broadcastSignal})
+ * produces both hashes; the read path ({@link processSignals}) re-derives them:
+ *
+ * 1. **Signal hop.** The OP_RETURN payload is `canonicalHash(announcement)` in
+ *    **hex**: this is `signal.signalBytes` and the lookup key into `sidecar.casMap`.
+ *    Broadcast emits `hash(canonicalize(announcement))`; the resolver keys `casMap`
+ *    by `canonicalHash(announcement, { encoding: 'hex' })`. These are the same bytes,
+ *    so `signalBytes === canonicalHash(announcement, hex)`.
+ * 2. **Update hop.** Each `announcement[did]` is `canonicalHash(signedUpdate)` in
+ *    **base64urlnopad** (per spec). It is decoded back to **hex** to key
+ *    `sidecar.updateMap`, so `hex(decode(announcement[did])) === canonicalHash(signedUpdate, hex)`.
+ *
+ * Both links are enforced when sidecar data is supplied via `Resolver.provide()`
+ * (which validates the provided announcement and update against the need's hash),
+ * and structurally when sidecar maps are pre-loaded (they are keyed by
+ * `canonicalHash`, so a mismatched entry simply misses the lookup). The two
+ * encoding transitions (hex for on-chain and map keys, base64urlnopad for
+ * announcement values) are the subtle part: a regression test pins them.
+ *
  * @class CASBeacon
  * @type {CASBeacon}
  * @extends {SinglePartyBeacon}

--- a/packages/method/src/core/beacon/signal-discovery.ts
+++ b/packages/method/src/core/beacon/signal-discovery.ts
@@ -11,6 +11,40 @@ import type { BeaconService, BeaconSignal } from './interfaces.js';
 import { BeaconUtils } from './utils.js';
 
 /**
+ * Parses a scriptPubKey asm string and returns the beacon signal hash if and only
+ * if the output is exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hex>`.
+ *
+ * Beacon signals encode a single 32-byte update or announcement hash in an
+ * OP_RETURN data push. Any other shape (a bare `OP_RETURN`, a push of the wrong
+ * size, or a non-hex payload) is not a valid signal and returns `null`, so a
+ * malformed or adversarial on-chain output cannot be mistaken for a real signal
+ * downstream.
+ *
+ * @param {string | undefined} asm The scriptPubKey asm string to parse.
+ * @returns {string | null} The lowercased 32-byte hex hash, or `null` if not a valid signal.
+ */
+export function extractOpReturnSignal(asm: string | undefined): string | null {
+  if(!asm) {
+    return null;
+  }
+
+  // A standard NULL_DATA beacon output is exactly three asm tokens: the OP_RETURN
+  // opcode, the 32-byte push opcode, and the 64-character hex payload.
+  const tokens = asm.trim().split(/\s+/);
+  if(tokens.length !== 3 || tokens[0] !== 'OP_RETURN' || tokens[1] !== 'OP_PUSHBYTES_32') {
+    return null;
+  }
+
+  // The payload must be exactly 32 bytes of hex (64 hex characters).
+  const signalHash = tokens[2];
+  if(!/^[0-9a-fA-F]{64}$/.test(signalHash)) {
+    return null;
+  }
+
+  return signalHash.toLowerCase();
+}
+
+/**
  * Static utility class for discovering Beacon Signals on the Bitcoin blockchain.
  * Extracted from `Resolver` for single-responsibility and independent testability.
  *
@@ -62,23 +96,14 @@ export class BeaconSignalDiscovery {
          *  value: 0
          * }
          */
-        if(!signalVout || !signalVout.scriptpubkey_asm.includes('OP_RETURN')) {
+        if(!signalVout) {
           continue;
         }
 
-        // Construct output map for easier access
-        const outputMap = new Map<string, string | number>(Object.entries(signalVout));
-
-        // Grab the signal vout scriptpubkey
-        const signalVoutScriptPubkey = outputMap.get('scriptpubkey_asm') as string;
-
-        // If the signal vout scriptpubkey does not exist, continue to next signal
-        if(!signalVoutScriptPubkey){
-          continue;
-        }
-
-        // Extract hex string hash of the signal bytes from the scriptpubkey
-        const updateHash = signalVoutScriptPubkey.split(' ').slice(-1)[0];
+        // A beacon signal output must be exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
+        // Reject any other shape (bare OP_RETURN, wrong push size, non-hex payload) so a
+        // malformed on-chain output cannot masquerade as a phantom signal downstream.
+        const updateHash = extractOpReturnSignal(signalVout.scriptpubkey_asm);
         if(!updateHash) {
           continue;
         }
@@ -192,20 +217,17 @@ export class BeaconSignalDiscovery {
             continue;
           }
 
-          // Look for 'OP_RETURN' in the scriptPubKey asm
+          // A beacon signal output must be exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
+          // Reject any other shape so a malformed on-chain output cannot masquerade as a
+          // phantom signal downstream.
           const txVoutScriptPubkeyAsm = prevout.vout[vin.vout].scriptPubKey.asm;
-          if(!txVoutScriptPubkeyAsm.includes('OP_RETURN')) {
+          const updateHash = extractOpReturnSignal(txVoutScriptPubkeyAsm);
+          if(!updateHash) {
             continue;
           }
 
           // Log the found txid and beacon
           console.info(`Tx ${tx.txid} contains beacon service address ${scriptPubKey.address} and OP_RETURN!`, tx);
-
-          // Extract hex string hash of the signal bytes from the scriptpubkey
-          const updateHash = txVoutScriptPubkeyAsm.split(' ').slice(-1)[0];
-          if(!updateHash) {
-            continue;
-          }
 
           // Push the beacon signal object to the beacon signals array for that beacon service
           beaconServiceSignals.get(beaconService)?.push({

--- a/packages/method/tests/beacon.spec.ts
+++ b/packages/method/tests/beacon.spec.ts
@@ -1,4 +1,4 @@
-import { canonicalize, canonicalHash, hash } from '@did-btcr2/common';
+import { canonicalize, canonicalHash, decode, encode, hash } from '@did-btcr2/common';
 import type { SignedBTCR2Update } from '@did-btcr2/method';
 import { BTCR2MerkleTree } from '@did-btcr2/smt';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
@@ -306,5 +306,62 @@ describe('BeaconFactory.establish', () => {
   it('throws on an unknown beacon type', () => {
     const service = { id: base, type: 'BogusBeacon', serviceEndpoint: endpoint } as unknown as BeaconService;
     expect(() => BeaconFactory.establish(service)).to.throw('Invalid Beacon Type');
+  });
+});
+
+describe('CAS announcement hash chain (regression)', () => {
+  // Pins the two encoding transitions that link an on-chain CAS signal to a signed
+  // update (see the CASBeacon class docs). If canonicalHash's default encoding
+  // (base64urlnopad) or the on-chain hex encoding ever drifts, resolution would
+  // silently fail to find the update; these assertions make that break loud.
+  const service: BeaconService = {
+    id              : `${DID}#beacon-1`,
+    type            : 'CASBeacon',
+    serviceEndpoint : 'bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+  };
+  const beacon = new CASBeacon(service);
+
+  it('signal hop: on-chain signalBytes (hex) equals the casMap key canonicalHash(announcement, hex)', () => {
+    const update = fakeUpdate('cas-chain-signal');
+    // The announcement is built exactly as broadcastSignal builds it.
+    const announcement: CASAnnouncement = { [DID]: canonicalHash(update) };
+
+    // Broadcast writes hash(canonicalize(announcement)) as the OP_RETURN payload, hex on-chain.
+    const onChainSignalHex = bytesToHex(hash(canonicalize(announcement)));
+    // The resolver keys casMap by canonicalHash(announcement, { encoding: 'hex' }).
+    const casMapKey = canonicalHash(announcement, { encoding: 'hex' });
+
+    expect(casMapKey).to.equal(onChainSignalHex);
+  });
+
+  it('update hop: decoded announcement value (hex) equals the updateMap key canonicalHash(update, hex)', () => {
+    const update = fakeUpdate('cas-chain-update');
+
+    // The announcement stores the update hash as base64urlnopad (canonicalHash default).
+    const announcementValueB64 = canonicalHash(update);
+    // The resolver decodes that value to hex to key updateMap.
+    const decodedToHex = encode(decode(announcementValueB64, 'base64urlnopad'), 'hex');
+    const updateMapKey = canonicalHash(update, { encoding: 'hex' });
+
+    expect(decodedToHex).to.equal(updateMapKey);
+  });
+
+  it('end-to-end: a broadcast-shaped announcement resolves to the update with no needs', () => {
+    const update = fakeUpdate('cas-chain-e2e');
+
+    // Mirror broadcastSignal: announcement value is base64urlnopad, signal is the hex announcement hash.
+    const announcement: CASAnnouncement = { [DID]: canonicalHash(update) };
+    const announcementHashHex = bytesToHex(hash(canonicalize(announcement)));
+
+    // Mirror Resolver.sidecarData: both maps keyed by canonicalHash hex.
+    const sidecar = emptySidecar();
+    sidecar.casMap.set(canonicalHash(announcement, { encoding: 'hex' }), announcement);
+    sidecar.updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
+
+    const result = beacon.processSignals([fakeSignal(announcementHashHex)], sidecar);
+
+    expect(result.updates).to.have.length(1);
+    expect(result.updates[0]![0]).to.deep.equal(update);
+    expect(result.needs).to.be.empty;
   });
 });

--- a/packages/method/tests/signal-discovery.spec.ts
+++ b/packages/method/tests/signal-discovery.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { extractOpReturnSignal } from '../src/core/beacon/signal-discovery.js';
+
+/**
+ * Beacon signal extraction from a scriptPubKey asm string.
+ *
+ * A beacon signal output is exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hex>`
+ * (the on-the-wire `0x6a 0x20 <32 bytes>` NULL_DATA shape, see
+ * `op-return-script.spec.ts` for the encode side). {@link extractOpReturnSignal}
+ * is the strict decoder: it returns the 32-byte hash only for that exact shape
+ * and `null` for everything else, so a malformed or adversarial on-chain output
+ * cannot be mistaken for a real signal during resolution. Before this guard, any
+ * output containing the `OP_RETURN` keyword had its last asm token taken verbatim
+ * as the signal hash, so a bare `OP_RETURN` or a wrong-size push produced a
+ * phantom signal (e.g. the literal string `OP_RETURN`, or a short hex) that flowed
+ * downstream as a real update reference.
+ */
+describe('extractOpReturnSignal', () => {
+  const HASH = '570f177c65e64fb5cf61180b664cdddf09ab76153c2b192e22006e5b22a3917a';
+
+  it('extracts the 32-byte hash from a well-formed beacon signal output', () => {
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(HASH);
+  });
+
+  it('lowercases an uppercase hex payload so it matches hex-keyed sidecar maps', () => {
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH.toUpperCase()}`)).to.equal(HASH);
+  });
+
+  it('tolerates surrounding and repeated whitespace', () => {
+    expect(extractOpReturnSignal(`  OP_RETURN   OP_PUSHBYTES_32   ${HASH}  `)).to.equal(HASH);
+  });
+
+  it('returns null for undefined or empty input', () => {
+    expect(extractOpReturnSignal(undefined)).to.equal(null);
+    expect(extractOpReturnSignal('')).to.equal(null);
+    expect(extractOpReturnSignal('   ')).to.equal(null);
+  });
+
+  it('returns null for a bare OP_RETURN with no data push', () => {
+    expect(extractOpReturnSignal('OP_RETURN')).to.equal(null);
+  });
+
+  it('returns null for a wrong-size push opcode (not OP_PUSHBYTES_32)', () => {
+    expect(extractOpReturnSignal('OP_RETURN OP_PUSHBYTES_4 deadbeef')).to.equal(null);
+  });
+
+  it('returns null when the payload is not exactly 32 bytes of hex (too short)', () => {
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH.slice(0, 62)}`)).to.equal(null);
+  });
+
+  it('returns null when the payload is not exactly 32 bytes of hex (too long)', () => {
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH}ab`)).to.equal(null);
+  });
+
+  it('returns null for a non-hex payload of the right length', () => {
+    const nonHex = 'z'.repeat(64);
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${nonHex}`)).to.equal(null);
+  });
+
+  it('returns null for a multi-push OP_RETURN (more than one data element)', () => {
+    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH} OP_PUSHBYTES_4 deadbeef`)).to.equal(null);
+  });
+
+  it('returns null for a non-OP_RETURN script', () => {
+    // A p2wpkh scriptPubKey asm: no OP_RETURN, must never yield a signal.
+    expect(extractOpReturnSignal('OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6')).to.equal(null);
+  });
+
+  it('returns null when OP_RETURN is present but not the leading opcode', () => {
+    // OP_RETURN must be the first token of a NULL_DATA output; a script that merely
+    // contains the keyword elsewhere is not a beacon signal.
+    expect(extractOpReturnSignal(`OP_DUP OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(null);
+  });
+});


### PR DESCRIPTION
* chore(release): bump method 0.43.0, api 0.13.2, cli 0.12.7
* feat(method): strict OP_RETURN beacon signal parsing + CAS hash-chain regression
* docs(adr): add ADR 056 (beacon signal-format validation + CAS hash chain)