### PR TITLE
remove legacy Helia and shrink method bundle

### DIFF
--- a/docs/adr/058-remove-legacy-helia-cas-path.md
+++ b/docs/adr/058-remove-legacy-helia-cas-path.md
@@ -1,0 +1,47 @@
+---
+title: "ADR 058: Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle"
+---
+
+# ADR 058: Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle
+
+**Status:** Accepted
+
+**Date:** 2026-06-29
+
+**Branch / PR:** `refactor/remove-helia-cas-path`
+
+**References:** [ADR 023](023-cas-read-path.md)
+
+## Context
+
+`Appendix.fetchFromCas()` was an early content-addressed-store read helper: it derived a CIDv1 from a content hash and fetched the block by spinning up an in-process Helia (IPFS) node via dynamic `import('helia')` and `import('@helia/strings')`. The canonical CAS read path is now `CasApi` (ADR 023): resolution emits a `Need*` for CAS-delivered content and the caller fulfills it, with IPFS access supplied by the SDK's executor rather than the method package embedding an IPFS node.
+
+That left `fetchFromCas` as dead code: it has no callers anywhere in the workspace, only its own definition. Its cost was not zero, though:
+
+- It kept `helia` and `@helia/strings` in the method package's runtime dependencies. Helia pulls a large libp2p / IPFS subtree, which dominated the browser bundle.
+- It was the only `src` use of `multiformats` (`CID` + digest), so `multiformats` was a direct runtime dependency and was bundled into both the CJS and browser outputs.
+- The CJS build config carried a `noExternal` carve-out forcing `multiformats` inline (it has no `require` export), plus a comment explaining why Helia was deliberately left external. Both existed only to service this one method.
+
+`multiformats` is still used directly by two scenario-tooling scripts under `lib/` (`publish-scenarios.ts`, `verify-live.ts`), which derive CIDs to pin and fetch CAS objects exactly as a resolver would. Those are development tools, not part of the published runtime surface.
+
+## Decision
+
+Remove the legacy Helia read path and the dependency weight it carried:
+
+1. **Delete `Appendix.fetchFromCas()`** and its now-unused imports (`CID`, the digest factory, and the `HashBytes` type). CAS reads go solely through the `CasApi` path per [ADR 023](023-cas-read-path.md).
+2. **Drop `helia` and `@helia/strings`** from the method package entirely; nothing else references them.
+3. **Demote `multiformats` to a dev dependency.** No `src` module imports it anymore; the published runtime reaches it only transitively (through `@web5/dids`, which declares its own dependency), while the `lib/` scenario scripts that import it directly are dev tooling.
+4. **Remove the now-moot CJS `noExternal` carve-out** for `multiformats` and the stale Helia comment from the tsup config. With no direct `multiformats` import, the CJS bundle contains none.
+
+## Consequences
+
+- The method browser bundle drops from roughly 4.0 MB to 1.5 MB (`browser.js` 4,122,945 to 1,572,273 bytes; `browser.mjs` 3,884,046 to 1,488,588 bytes), about a 62% reduction, almost all of it the removed Helia / libp2p subtree. The CJS bundle drops from 137 KB to 111 KB.
+- Two runtime dependencies (`helia`, `@helia/strings`) leave the method package, and a third (`multiformats`) leaves its runtime surface. This is the first concrete step toward the monorepo bundle-size and extraneous-dependency goals.
+- `Appendix.fetchFromCas` is a public static (`Appendix` is re-exported from the package barrel), so its removal is a breaking change to the public surface and is released as a minor version bump under 0.x semantics.
+- CAS resolution behavior is unchanged: the path was already dead, and the live path (`CasApi`) is untouched. All existing tests pass without modification.
+
+## Rejected alternatives
+
+- **Keep the dead method "just in case."** It had no callers and duplicated a capability the SDK already owns (ADR 023). Carrying an embedded IPFS node in the method package to keep a dead code path is exactly the weight this change removes.
+- **Keep `multiformats` as a runtime dependency.** No published runtime module imports it directly anymore; the transitive path via `@web5/dids` covers runtime use, and the only direct importers left are dev-only scenario scripts. Declaring it as a dev dependency states that accurately.
+- **Keep the lazy `import('helia')` but drop the dependency.** A dynamic import of an undeclared package is a latent runtime failure, and it would still force the tsup carve-out and the explanatory build comment to stay. Removing the dead path removes the reason for both.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -58,6 +58,7 @@ children:
   - ./055-resolver-provide-trust-boundary.md
   - ./056-beacon-signal-format-validation.md
   - ./057-did-document-validation-standards.md
+  - ./058-remove-legacy-helia-cas-path.md
 ---
 
 # Architecture Decision Records
@@ -123,3 +124,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 055 | 2026-06-27 | [Harden the Resolver provide() Trust Boundary](055-resolver-provide-trust-boundary.md) |
 | 056 | 2026-06-27 | [Validate the Beacon Signal Output Format and Document the CAS Announcement Hash Chain](056-beacon-signal-format-validation.md) |
 | 057 | 2026-06-28 | [Extensible @context and Uniform Multikey Enforcement in DID Document Validation](057-did-document-validation-standards.md) |
+| 058 | 2026-06-29 | [Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle](058-remove-legacy-helia-cas-path.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.44.0",
+    "version": "0.45.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",
@@ -110,7 +110,6 @@
         "@did-btcr2/cryptosuite": "workspace:^",
         "@did-btcr2/keypair": "workspace:^",
         "@did-btcr2/smt": "workspace:^",
-        "@helia/strings": "^4.1.0",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
         "@noble/secp256k1": "^2.3.0",
@@ -123,8 +122,6 @@
         "@web5/dids": "^1.2.0",
         "canonicalize": "^2.1.0",
         "dotenv": "^16.6.1",
-        "helia": "^5.5.1",
-        "multiformats": "^13.4.2",
         "nostr-tools": "^2.23.3"
     },
     "devDependencies": {
@@ -146,6 +143,7 @@
         "globals": "^15.15.0",
         "mocha": "^10.8.2",
         "mocha-junit-reporter": "^2.2.1",
+        "multiformats": "^13.4.2",
         "node-stdlib-browser": "^1.3.1",
         "rimraf": "^6.1.3",
         "tsup": "^8.5.1",

--- a/packages/method/src/utils/appendix.ts
+++ b/packages/method/src/utils/appendix.ts
@@ -1,4 +1,3 @@
-import type { HashBytes } from '@did-btcr2/common';
 import type {
   DidDocument,
   DidService,
@@ -8,8 +7,6 @@ import {
   DidErrorCode,
   DidVerificationRelationship
 } from '@web5/dids';
-import { CID } from 'multiformats';
-import { create as createDigest } from 'multiformats/hashes/digest';
 import type { RootCapability } from '../core/interfaces.js';
 
 /**
@@ -203,26 +200,5 @@ export class Appendix {
 
     // 9. Return rootCapability.
     return rootCapability;
-  }
-
-  /**
-   * Implements CAS Lookup Step from {@link https://dcdpr.github.io/did-btcr2/operations/resolve.html#process-beacon-signals | 7.2.e Process Beacon Signals }.
-   * @param {HashBytes} hashBytes The hash bytes to look up in the CAS system.
-   * @returns {Promise<string | undefined>} The content fetched from the CAS system, or undefined if not found.
-   */
-  static async fetchFromCas(hashBytes: HashBytes): Promise<string | undefined> {
-    // Construct CID from hash bytes
-    const cid = CID.create(1, 1, createDigest(1, hashBytes));
-
-    // Lazy-load helia to avoid bundling its native deps into downstream CJS builds.
-    const { createHelia } = await import('helia');
-    const { strings } = await import('@helia/strings');
-
-    // Connect to IPFS/Helia node
-    const helia = await createHelia();
-    const node = strings(helia);
-
-    // Return the IPFS get result
-    return await node.get(cid, {});
   }
 }

--- a/packages/method/tsup.config.ts
+++ b/packages/method/tsup.config.ts
@@ -4,16 +4,9 @@ import { defineConfig } from 'tsup';
  * CJS bundle build.
  *
  * The ESM + types output is produced by `tsc` (see `tsconfig.json`).
- * This config only produces `dist/cjs/index.js` with ESM-only transitive
- * dependencies bundled inline so the output is usable via `require()`.
- *
- * Bundled-inline deps (no `require` export condition in their package.json):
- * - multiformats subpath exports
- *
- * `helia` and `@helia/strings` are intentionally NOT bundled, they are
- * lazy-loaded via `await import(...)` in `src/utils/appendix.ts` so Node's
- * runtime can resolve them as ESM without tsup trying to pull their native
- * (libp2p / node-datachannel) modules into the bundle.
+ * This config only produces `dist/cjs/index.js`; runtime dependencies are left
+ * external (resolved by the consumer), so the source must not import an ESM-only
+ * package directly without a `require` export condition.
  */
 export default defineConfig({
   entry     : ['src/index.ts'],
@@ -30,7 +23,4 @@ export default defineConfig({
   outExtension() {
     return { js: '.js' };
   },
-  noExternal : [
-    /^multiformats(\/|$)/,
-  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,9 +850,6 @@ importers:
       '@did-btcr2/smt':
         specifier: workspace:^
         version: link:../smt
-      '@helia/strings':
-        specifier: ^4.1.0
-        version: 4.1.0
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
@@ -889,12 +886,6 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
-      helia:
-        specifier: ^5.5.1
-        version: 5.5.1(react-native@0.81.4(@babel/core@7.29.0)(react@19.1.1))
-      multiformats:
-        specifier: ^13.4.2
-        version: 13.4.2
       nostr-tools:
         specifier: ^2.23.3
         version: 2.23.3(typescript@5.9.3)
@@ -953,6 +944,9 @@ importers:
       mocha-junit-reporter:
         specifier: ^2.2.1
         version: 2.2.1(mocha@10.8.2)
+      multiformats:
+        specifier: ^13.4.2
+        version: 13.4.2
       node-stdlib-browser:
         specifier: ^1.3.1
         version: 1.3.1


### PR DESCRIPTION
* chore(release): bump method 0.45.0, api 0.13.4, cli 0.12.9
* refactor(method): remove dead Helia CAS path, drop helia deps, demote multiformats to dev
* docs(adr): add ADR 058 (remove legacy Helia CAS read path, shrink bundle)