### PR TITLE
stop fixed beacon-discovery round limit on resolve

### DIFF
--- a/docs/adr/059-unbounded-beacon-discovery-default.md
+++ b/docs/adr/059-unbounded-beacon-discovery-default.md
@@ -1,0 +1,125 @@
+---
+title: "ADR 059: Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap"
+---
+
+# ADR 059: Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap
+
+**Status:** Accepted
+
+**Date:** 2026-06-29
+
+**Branch / PR:** `fix/resolver-discovery-rounds-default`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 055](055-resolver-provide-trust-boundary.md), [W3C DID Resolution](https://w3c.github.io/did-resolution/), [W3C DID Core](https://www.w3.org/TR/did-core/)
+
+## Context
+
+The Resolver applies the updates it has found, then looks for beacon services those
+updates added and loops back to discover their signals (multi-round discovery). [ADR
+055](055-resolver-provide-trust-boundary.md) added a `maxDiscoveryRounds` bound on
+that loop with a **default of 10**, and made exceeding it throw `ResolveError`
+(`INVALID_DID_DOCUMENT`). The stated worry was a document whose updates keep adding
+beacon services driving discovery without end.
+
+Three facts, verified against the current code and the specifications, undermine that
+default:
+
+1. **Termination does not depend on the cap.** Each beacon address is recorded in a
+   per-resolution cache (`#requestCache`, keyed by address string) the first time it
+   is queried, and discovery only loops back when an update introduces an address not
+   already in that cache. The set of reachable addresses is bounded by the finite
+   genesis document plus the finite set of applied updates, so the loop reaches a
+   fixed point and terminates on its own for any finite input. The cap is redundant
+   for correctness; it is purely a resource guard.
+
+2. **No specification calls for a round limit.** "Beacon discovery rounds" is a
+   did:btcr2 concept; generic resolution has no notion of it, and the did:btcr2 Read
+   algorithm defines no iteration or round limit. The W3C DID Resolution and DID Core
+   specifications do not mandate one either. DID Core only notes that developers
+   "might wish to limit recursion depth or breadth to reduce the potential attack
+   surface", an opt-in best practice, not a required default. A resolver that throws
+   on a DID the method says should resolve is diverging from the method's contract.
+
+3. **The error code was wrong.** A resolver that stops at its own configured limit has
+   not encountered a malformed document. DID Resolution reserves `INVALID_DID_DOCUMENT`
+   for a document that "was malformed" and `INTERNAL_ERROR` for "an unexpected error
+   during DID Resolution". A caller-imposed limit is an operational stop, not a data
+   defect, so `INTERNAL_ERROR` is the faithful code.
+
+A further observation reinforces that the default cap guarded a path no ordinary DID
+reaches: `Resolver.updates()` restarts its version counter at 1 on every round and the
+per-round update set is not carried across rounds, so a genuine linear history whose
+later versions are announced on beacons added by earlier versions (v2, then v3 on a
+new beacon, ...) is rejected as late publishing before a second discovery round can
+even run. The only inputs that actually drive many rounds are ones where each update
+re-declares `targetVersionId: 2` with a `sourceHash` chained to the running document,
+each adding a new beacon. That pathological, controller-signed shape is exactly what a
+resource guard is for, and it is what the regression test exercises. The cross-round
+version-counter limitation is a separate resolver issue, noted here as evidence and
+left for its own change.
+
+## Decision
+
+### 1. Default discovery to unbounded
+
+`maxDiscoveryRounds` now defaults to no limit (`Infinity`). A well-formed DID resolves
+in however many rounds its history requires; termination is guaranteed by address
+de-duplication, not by the cap.
+
+### 2. Keep the cap as an opt-in resource guard
+
+`ResolutionOptions.maxDiscoveryRounds` remains. A **positive** value imposes a finite
+bound for a caller that wants one (for example a public resolver bounding work per
+request). A non-positive value, or omitting the field, means no limit. This matches
+the DID Core "might wish to limit" guidance: available, not imposed.
+
+### 3. Surface an exceeded cap as INTERNAL_ERROR
+
+When a configured positive cap is exceeded, the resolver throws `ResolveError` with
+`INTERNAL_ERROR` and a message pointing the caller to raise or remove the limit. The
+document is well-formed; the resolver simply stopped at the caller's limit.
+
+### 4. Remove the exported default constant
+
+`DEFAULT_MAX_DISCOVERY_ROUNDS` is removed. There is no longer a numeric default to
+name, and keeping a `DEFAULT_*` constant that is not the default would mislead.
+
+## Consequences
+
+- A DID whose update history legitimately spans many discovery rounds resolves instead
+  of failing at an arbitrary round 11. This removes a divergence from the did:btcr2
+  read algorithm where a valid DID was reported as having an invalid document.
+- Callers that want a bound still have one, now correctly typed: an exceeded bound is an
+  `INTERNAL_ERROR` operational stop, not an `INVALID_DID_DOCUMENT` data defect.
+- `maxDiscoveryRounds: 0` previously tripped immediately (a zero budget). It now means
+  "no limit", consistent with the non-positive-means-unbounded rule. Any caller that
+  relied on `0` to force a failure must pass a positive value instead.
+- Removing the exported `DEFAULT_MAX_DISCOVERY_ROUNDS` is a breaking change for any
+  consumer importing it. The constant was introduced only in the immediately preceding
+  release and named an internal default; no in-tree consumer referenced it.
+- This reverses the default and the error code chosen in [ADR
+  055](055-resolver-provide-trust-boundary.md) section 3 while preserving that ADR's
+  other two hardening decisions (payload hash validation and shape guards at the
+  `provide()` boundary), which are unaffected.
+
+## Rejected alternatives
+
+- **Keep the fixed default of 10.** It rejects valid DIDs whose history exceeds it,
+  diverges from the method's read algorithm, and protects against a path that address
+  de-duplication already makes terminate. A default that can fail a conformant DID is
+  worse than no default.
+- **Remove the cap entirely.** A library embedded in a public resolver can reasonably
+  want to bound work per request as defense in depth. DID Core explicitly sanctions
+  that as an option. Keeping an opt-in knob costs almost nothing and leaves the policy
+  with the embedder, who knows their threat model, rather than removing the choice.
+- **Keep failing closed but relabel the document as invalid.** Calling a well-formed
+  document "invalid" because the resolver stopped early misreports the cause to the
+  caller. `INTERNAL_ERROR` names what actually happened.
+
+## Follow-ups
+
+- The cross-round version-counter reset in `Resolver.updates()` noted under Context is a
+  separate resolver defect: a legitimate linear history whose later versions are
+  announced on beacons added by earlier versions is rejected as late publishing before a
+  second discovery round runs. It is not addressed here and is tracked for its own
+  change, alongside the `provide()` idempotency work on the same discovery loop.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -59,6 +59,7 @@ children:
   - ./056-beacon-signal-format-validation.md
   - ./057-did-document-validation-standards.md
   - ./058-remove-legacy-helia-cas-path.md
+  - ./059-unbounded-beacon-discovery-default.md
 ---
 
 # Architecture Decision Records
@@ -125,3 +126,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 056 | 2026-06-27 | [Validate the Beacon Signal Output Format and Document the CAS Announcement Hash Chain](056-beacon-signal-format-validation.md) |
 | 057 | 2026-06-28 | [Extensible @context and Uniform Multikey Enforcement in DID Document Validation](057-did-document-validation-standards.md) |
 | 058 | 2026-06-29 | [Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle](058-remove-legacy-helia-cas-path.md) |
+| 059 | 2026-06-29 | [Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap](059-unbounded-beacon-discovery-default.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.4",
+    "version": "0.13.5",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.45.0",
+    "version": "0.46.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/interfaces.ts
+++ b/packages/method/src/core/interfaces.ts
@@ -37,10 +37,13 @@ export interface ResolutionOptions extends DidResolutionOptions {
   sidecar?: Sidecar;
 
   /**
-   * Maximum number of multi-round beacon-discovery passes before resolution
-   * fails. Each pass applies the updates found so far, then looks for new beacon
-   * services those updates added. A document whose updates keep adding beacon
-   * services would otherwise drive discovery without bound. Default: 10.
+   * Opt-in upper bound on multi-round beacon-discovery passes. Each pass applies
+   * the updates found so far, then looks for new beacon services those updates
+   * added. Discovery is unbounded by default: termination is already guaranteed
+   * by de-duplicating already-queried beacon addresses. Set a positive value only
+   * to impose a resource guard; a non-positive value or omitting the field means
+   * no limit. Exceeding a configured limit surfaces as an INTERNAL_ERROR, the
+   * document is well-formed, the resolver simply stopped at the caller's limit.
    */
   maxDiscoveryRounds?: number;
 }

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -6,6 +6,7 @@ import {
   DateUtils,
   encode as encodeHash,
   decode as decodeHash,
+  INTERNAL_ERROR,
   INVALID_DID_DOCUMENT,
   INVALID_DID_UPDATE,
   JSONPatch,
@@ -35,14 +36,6 @@ import { Identifier } from './identifier.js';
 import type { SMTProof } from './interfaces.js';
 import type { CASAnnouncement, Sidecar, SidecarData } from './types.js';
 import { equalBytes } from '@noble/curves/utils.js';
-
-/**
- * Default upper bound on multi-round beacon discovery. Each round applies the
- * updates found so far and looks for beacon services those updates added; a
- * document whose updates keep adding services would otherwise loop unbounded.
- * Overridable via `ResolutionOptions.maxDiscoveryRounds`.
- */
-export const DEFAULT_MAX_DISCOVERY_ROUNDS = 10;
 
 /**
  * The response object for DID Resolution.
@@ -203,7 +196,12 @@ export class Resolver {
   #unsortedUpdates: Array<[SignedBTCR2Update, BlockMetadata]> = [];
   #resolvedResponse: DidResolutionResponse | null = null;
 
-  /** Upper bound on multi-round beacon-discovery passes; see {@link DEFAULT_MAX_DISCOVERY_ROUNDS}. */
+  /**
+   * Opt-in upper bound on multi-round beacon-discovery passes. `Infinity` (the
+   * default) leaves discovery unbounded; termination is already guaranteed by
+   * de-duplicating already-queried beacon addresses. A positive value is a
+   * caller-imposed resource guard; a non-positive value or omission means no limit.
+   */
   readonly #maxDiscoveryRounds: number;
   /** Count of beacon-discovery passes driven by updates adding new beacon services. */
   #discoveryRounds = 0;
@@ -222,7 +220,10 @@ export class Resolver {
     this.#currentDocument = currentDocument;
     this.#versionId = options?.versionId;
     this.#versionTime = options?.versionTime;
-    this.#maxDiscoveryRounds = options?.maxDiscoveryRounds ?? DEFAULT_MAX_DISCOVERY_ROUNDS;
+    // Discovery is unbounded by default; a positive maxDiscoveryRounds opts into a
+    // finite resource guard. A non-positive or omitted value means no limit.
+    const rounds = options?.maxDiscoveryRounds;
+    this.#maxDiscoveryRounds = typeof rounds === 'number' && rounds > 0 ? rounds : Infinity;
 
     // If a genesis document was provided (from sidecar), pre-seed it for validation
     if(options?.genesisDocument) {
@@ -699,15 +700,18 @@ export class Resolver {
             });
 
             if(hasNewServices) {
-              // Bound multi-round discovery: a document whose updates keep adding
-              // beacon services would otherwise loop without end. Fail closed once
-              // the configured number of rounds is exceeded.
+              // Discovery is unbounded by default: termination is guaranteed by
+              // address de-duplication (#requestCache), so a well-formed DID
+              // resolves in however many rounds its history requires. An opt-in
+              // maxDiscoveryRounds lets a caller bound the work as a resource
+              // guard. Exceeding it is a limit the caller imposed, not a malformed
+              // document, so it surfaces as INTERNAL_ERROR, not INVALID_DID_DOCUMENT.
               if(++this.#discoveryRounds > this.#maxDiscoveryRounds) {
                 throw new ResolveError(
-                  `Exceeded maximum beacon-discovery rounds (${this.#maxDiscoveryRounds}); `
-                  + 'the DID document may chain beacon services without terminating.',
-                  INVALID_DID_DOCUMENT,
-                  { maxDiscoveryRounds: this.#maxDiscoveryRounds }
+                  `Exceeded the configured maximum of ${this.#maxDiscoveryRounds} beacon-discovery `
+                  + 'rounds. Raise or remove ResolutionOptions.maxDiscoveryRounds to resolve this DID.',
+                  INTERNAL_ERROR,
+                  { maxDiscoveryRounds: this.#maxDiscoveryRounds, discoveryRounds: this.#discoveryRounds }
                 );
               }
               // Loop back to discover signals for new beacon services

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1,11 +1,17 @@
 import { expect } from 'chai';
 import { randomBytes } from 'crypto';
-import { canonicalHash, encode, hash, canonicalize } from '@did-btcr2/common';
+import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, JSONPatch } from '@did-btcr2/common';
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner } from '@did-btcr2/keypair';
 import { BTCR2MerkleTree, hashToHex } from '@did-btcr2/smt';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hexToBytes } from '@noble/hashes/utils';
+import { p2wpkh } from '@scure/btc-signer';
 import { DidBtcr2 } from '../src/did-btcr2.js';
+import { BeaconUtils } from '../src/core/beacon/utils.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
+import type { DidDocument } from '../src/utils/did-document.js';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import type { NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';
 import { Updater } from '../src/core/updater.js';
 import deterministicData from './data/deterministic-data.js';
@@ -14,6 +20,109 @@ import externalData from './data/external-data.js';
 /** Helper: provide empty signals for a NeedBeaconSignals need. */
 function provideEmptySignals(resolver: ReturnType<typeof DidBtcr2.resolve>, need: NeedBeaconSignals): void {
   resolver.provide(need, new Map<BeaconService, Array<BeaconSignal>>());
+}
+
+/** Helper: resolve a deterministic (k1) DID with empty signals to obtain its source document. */
+function resolveDeterministic(did: string): DidDocument {
+  const resolver = DidBtcr2.resolve(did);
+  let state = resolver.resolve();
+  if(state.status !== 'action-required') throw new Error('expected action-required');
+  provideEmptySignals(resolver, state.needs[0] as NeedBeaconSignals);
+  state = resolver.resolve();
+  if(state.status !== 'resolved') throw new Error('expected resolved');
+  return state.result.didDocument;
+}
+
+/**
+ * Build a chain of `numHops` signed updates that each add a new SingletonBeacon
+ * service, wired so the beacon added by one hop carries the update for the next.
+ *
+ * Every update is a v1-to-v2 update (sourceVersionId 1) whose sourceHash chains
+ * to the running document. That is the only shape that drives the resolver's
+ * per-round discovery counter: Resolver.updates() restarts its version counter
+ * each round, so a genuine linear history spread across rounds (v2, v3, ...) would
+ * be rejected as late publishing. This re-declared-v2 chain is exactly the runaway
+ * shape an opt-in maxDiscoveryRounds is meant to bound.
+ *
+ * Returns the signed updates (for the sidecar) plus a map from beacon address to
+ * the hex update hash to deliver on the beacon at that address; the terminal
+ * beacon has no entry.
+ */
+function buildDiscoveryChain(
+  did: string,
+  sourceDocument: DidDocument,
+  secretKey: string,
+  numHops: number
+): { updates: Array<SignedBTCR2Update>; signalByAddress: Map<string, string> } {
+  const vm = sourceDocument.verificationMethod![0]!;
+  const signer = new LocalSigner(hexToBytes(secretKey));
+  const network = getNetwork('regtest');
+  const updates: Array<SignedBTCR2Update> = [];
+  const signalByAddress = new Map<string, string>();
+
+  // The first genesis beacon delivers the first update.
+  let prevAddress = BeaconUtils.parseBitcoinAddress(
+    BeaconUtils.getBeaconServices(sourceDocument)[0]!.serviceEndpoint as string
+  );
+  let currentDoc: DidDocument = sourceDocument;
+
+  for(let i = 0; i < numHops; i++) {
+    // Distinct, valid regtest P2WPKH address for the new beacon.
+    const secret = new Uint8Array(32);
+    secret[31] = i + 1;
+    const address = p2wpkh(secp256k1.getPublicKey(secret, true), network).address!;
+
+    const patches = [{
+      op    : 'add' as const,
+      path  : '/service/-',
+      value : { id: `${did}#beacon-${i}`, type: 'SingletonBeacon', serviceEndpoint: `bitcoin:${address}` }
+    }];
+
+    const unsigned = Updater.construct(currentDoc, patches, 1);
+    const signed = Updater.sign(did, unsigned, vm, signer);
+    updates.push(signed);
+
+    // The beacon discovered in the previous round points at this update.
+    signalByAddress.set(prevAddress, canonicalHash(signed, { encoding: 'hex' }));
+
+    currentDoc = JSONPatch.apply(currentDoc, patches) as DidDocument;
+    prevAddress = address;
+  }
+
+  return { updates, signalByAddress };
+}
+
+/**
+ * Drive a resolver through a beacon-discovery chain, delivering on each beacon the
+ * update hash recorded for its address (empty signals otherwise). Returns the
+ * resolved document, or propagates whatever the resolver throws.
+ */
+function driveDiscoveryChain(
+  did: string,
+  updates: Array<SignedBTCR2Update>,
+  signalByAddress: Map<string, string>,
+  options?: { maxDiscoveryRounds?: number }
+): DidDocument {
+  const resolver = DidBtcr2.resolve(did, { sidecar: { updates }, ...options });
+  let height = 100;
+  let state = resolver.resolve();
+  while(state.status === 'action-required') {
+    const need = state.needs[0];
+    if(need.kind !== 'NeedBeaconSignals') throw new Error(`unexpected need: ${need.kind}`);
+    const signals = new Map<BeaconService, Array<BeaconSignal>>();
+    for(const service of need.beaconServices) {
+      const address = BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string);
+      const updateHashHex = signalByAddress.get(address);
+      signals.set(service, updateHashHex
+        ? [{ tx: {} as any, signalBytes: updateHashHex, blockMetadata: { height: height++, time: 1700000000, confirmations: 6 } }]
+        : []
+      );
+    }
+    resolver.provide(need, signals);
+    state = resolver.resolve();
+  }
+  if(state.status !== 'resolved') throw new Error('expected resolved');
+  return state.result.didDocument;
 }
 
 describe('Resolver', () => {
@@ -708,43 +817,46 @@ describe('Resolver', () => {
       expect(() => resolver.provide(state.needs[0] as NeedGenesisDocument, 'not-an-object' as any)).to.throw(/document object/i);
     });
 
-    it('fails closed when discovery exceeds maxDiscoveryRounds', () => {
+    it('resolves a DID whose updates drive many discovery rounds (default is unbounded)', () => {
       const fixture = deterministicData[2];
-      const did = fixture.did;
+      const sourceDocument = resolveDeterministic(fixture.did);
+      const initialServiceCount = sourceDocument.service.length;
 
-      // Resolve once to get the source document.
-      const initResolver = DidBtcr2.resolve(did);
-      let initState = initResolver.resolve();
-      if(initState.status !== 'action-required') throw new Error('expected action-required');
-      provideEmptySignals(initResolver, initState.needs[0] as NeedBeaconSignals);
-      initState = initResolver.resolve();
-      if(initState.status !== 'resolved') throw new Error('expected resolved');
-      const sourceDocument = initState.result.didDocument;
+      // More rounds than the old fixed default of 10, so this would have failed
+      // closed before; the default is now unbounded and it resolves cleanly.
+      const hops = 12;
+      const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, hops);
 
-      // An update that adds a new beacon service, forcing one discovery round.
-      const patches = [{
-        op    : 'add' as const,
-        path  : '/service/-',
-        value : { id: `${did}#beacon-new`, type: 'SingletonBeacon', serviceEndpoint: 'bitcoin:mqTxx2aK3Ay3cDk5xM5E5wT6J4QoT6f8vT' }
-      }];
-      const vm = sourceDocument.verificationMethod![0]!;
-      const unsigned = Updater.construct(sourceDocument, patches, 1);
-      const signed = Updater.sign(did, unsigned, vm, new LocalSigner(hexToBytes(fixture.secretKey)));
-      const updateHashHex = canonicalHash(signed, { encoding: 'hex' });
+      const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress);
+      expect(resolved.service.length).to.equal(initialServiceCount + hops);
+    });
 
-      // A zero round budget means the first loop-back fails closed.
-      const resolver = DidBtcr2.resolve(did, { sidecar: { updates: [signed] }, maxDiscoveryRounds: 0 });
-      const state = resolver.resolve();
-      if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
-      const round1 = state.needs[0] as NeedBeaconSignals;
-      const signals = new Map<BeaconService, Array<BeaconSignal>>();
-      signals.set(round1.beaconServices[0] as BeaconService, [{
-        tx            : {} as any,
-        signalBytes   : updateHashHex,
-        blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
-      }]);
-      resolver.provide(round1, signals);
-      expect(() => resolver.resolve()).to.throw(/maximum beacon-discovery rounds/i);
+    it('treats a non-positive maxDiscoveryRounds as unbounded', () => {
+      const fixture = deterministicData[2];
+      const sourceDocument = resolveDeterministic(fixture.did);
+      const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, 3);
+
+      // 0 used to trip immediately; under the new semantics it means "no limit".
+      const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress, { maxDiscoveryRounds: 0 });
+      expect(resolved.service.length).to.equal(sourceDocument.service.length + 3);
+    });
+
+    it('still enforces an explicit positive maxDiscoveryRounds cap (INTERNAL_ERROR)', () => {
+      const fixture = deterministicData[2];
+      const sourceDocument = resolveDeterministic(fixture.did);
+      const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, 4);
+
+      // Cap at 2 rounds: the 3rd discovery round exceeds it. The document is
+      // well-formed, so the caller-imposed limit surfaces as INTERNAL_ERROR.
+      let thrown: any;
+      try {
+        driveDiscoveryChain(fixture.did, updates, signalByAddress, { maxDiscoveryRounds: 2 });
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected resolution to throw').to.exist;
+      expect(thrown.message).to.match(/beacon-discovery/i);
+      expect(thrown.type).to.equal(INTERNAL_ERROR);
     });
   });
 });


### PR DESCRIPTION
* chore(release): bump method 0.46.0, api 0.13.5, cli 0.12.10
* fix(method): default beacon discovery to unbounded with an opt-in maxDiscoveryRounds cap
* docs(adr): add ADR 059 (unbounded beacon-discovery default, opt-in cap)