### PR TITLE
resolve DID histories whose updates span beacon-discovery rounds

### DIFF
--- a/docs/adr/060-resolver-cross-round-version-continuity.md
+++ b/docs/adr/060-resolver-cross-round-version-continuity.md
@@ -1,0 +1,122 @@
+---
+title: "ADR 060: Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds"
+---
+
+# ADR 060: Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds
+
+**Status:** Accepted
+
+**Date:** 2026-06-29
+
+**Branch / PR:** `fix/resolver-cross-round-versioning`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 059](059-unbounded-beacon-discovery-default.md), [did:btcr2 Resolve](https://dcdpr.github.io/did-btcr2/operations/resolve.html), [W3C DID Resolution](https://w3c.github.io/did-resolution/)
+
+## Context
+
+The did:btcr2 read algorithm resolves a DID by processing beacon signals in a single
+loop. It keeps two pieces of state for the whole loop: a monotonic `current_version_id`
+(starting at 1) and an `update_hash_history` (appended to as each update is applied, and
+indexed when confirming a duplicate). On every pass it re-derives the beacon set from the
+contemporary DID document, so a beacon added by one update is searched on the next pass.
+The version counter and the history are therefore loop-invariant: they span the entire
+resolution, including signals found on beacons that earlier updates introduced.
+
+This implementation's `Resolver` ([ADR 016](016-sans-io-resolver.md)) is a sans-I/O state
+machine. It cannot block to fetch signals, so it splits that one loop into discovery
+**rounds**: apply the updates found so far, look for beacon services those updates added,
+then loop back to request their signals. The per-round update application lived entirely
+inside the static `Resolver.updates()`, which initialized `currentVersionId = 1` and a
+fresh `updateHashHistory = []` on **every** call. The two pieces of state the spec keeps
+for the whole loop were being reset once per round.
+
+The consequence is a real resolution failure. Consider a legitimate linear history:
+
+- genesis is version 1, on the genesis beacon;
+- an update takes v1 to v2 and adds beacon B, announced on the genesis beacon;
+- an update takes v2 to v3, announced on beacon B.
+
+Round one finds the v2 update, applies it (`currentVersionId` 1 to 2), and discovers
+beacon B. Round two finds the v3 update, but `Resolver.updates()` has reset
+`currentVersionId` to 1, so it sees `targetVersionId` 3 against a counter of 1, takes the
+`targetVersionId > currentVersionId + 1` branch, and raises `LATE_PUBLISHING`. A
+conformant DID fails to resolve the moment its history is spread across the beacons it
+builds up. [ADR 059](059-unbounded-beacon-discovery-default.md) noted this under its
+Context and left it for its own change; this is that change.
+
+The reset also meant `metadata.versionId` reported only the last round's local count
+rather than the document's true version, and `updateHashHistory` was empty in every round
+after the first, so a duplicate update republished on a later-round beacon could not be
+confirmed against its history.
+
+## Decision
+
+### 1. Lift the version counter and update-hash history to resolution-wide state
+
+`currentVersionId` and `updateHashHistory` are now instance fields on the `Resolver`
+(`#currentVersionId`, initialized to 1; `#updateHashHistory`, initialized to `[]`). They
+model exactly what the spec models: state that persists for the whole resolution, not for
+a single batch of signals.
+
+### 2. Thread that state through `Resolver.updates()`
+
+`Resolver.updates()` takes an optional fifth parameter,
+`resolutionState: { currentVersionId, updateHashHistory }`, defaulting to
+`{ currentVersionId: 1, updateHashHistory: [] }`. It continues the counter from the
+carried value and appends to the carried history array (shared by reference, so appends
+are visible to the next round). The `ApplyUpdates` phase passes the instance fields in and
+carries the reached version forward by reading it back from the response's
+`metadata.versionId`, which the algorithm already sets at every return point. Standalone
+callers (for example test-vector generation) omit the parameter and get the spec's fresh
+start, so their behavior is unchanged.
+
+The net effect: a resolution split across N discovery rounds now behaves identically to
+processing the same signals in one continuous loop. The rounds are an I/O-scheduling
+detail, no longer a semantic boundary.
+
+## Consequences
+
+- A DID whose later versions are announced on beacons that earlier updates added now
+  resolves, instead of failing at round two with `LATE_PUBLISHING`. This removes a
+  divergence from the did:btcr2 read algorithm.
+- `metadata.versionId` on the resolved result now reflects the document's true version
+  across the whole history rather than the last round's local count.
+- Duplicate confirmation works across rounds: `updateHashHistory` accumulates for the
+  whole resolution, so a republished earlier update is checked against the history that
+  actually contains it.
+- `Resolver.updates()` stays backward compatible. The new parameter is optional and
+  defaults to a fresh start; the only in-tree caller is the resolver's own `ApplyUpdates`
+  phase, and the documented static utility usage is unaffected.
+- The resolver test fixtures changed shape. `buildDiscoveryChain()` previously built an
+  artificial chain where every update re-declared `targetVersionId: 2`, the only shape the
+  reset counter would accept across rounds. It now builds a genuine linear history
+  (v1 to v2 to v3 ...), which is what the fix makes resolvable and what the
+  `maxDiscoveryRounds` tests from [ADR 059](059-unbounded-beacon-discovery-default.md) now
+  exercise. A dedicated regression test asserts a three-hop history resolves to version 4.
+
+## Rejected alternatives
+
+- **Accumulate all updates across rounds, then apply once at the end.** This cannot work:
+  discovery depends on application. A later update is only discoverable after the earlier
+  update that adds its beacon has been applied. Application and discovery are necessarily
+  interleaved, so the loop-invariant state has to be carried, not deferred.
+- **Carry only the version counter, keep resetting the history.** The happy path (no
+  duplicates) would pass, because the history is only read when confirming a duplicate.
+  But it would diverge from the spec, which keeps one history for the whole loop, and a
+  duplicate republished on a later-round beacon would fail to confirm against an empty
+  history. Carrying both keeps multi-round resolution identical to single-round.
+- **Mutate the carrier object to write the version back.** `Resolver.updates()` has
+  several early-return points (version-time, version-id, and deactivation limits), so
+  writing the counter back on every exit would be error-prone. The response already
+  carries the reached version in `metadata.versionId` at every return, so reading it back
+  is both simpler and provably consistent with whatever the method returns.
+
+## Out of scope
+
+The per-tuple `currentVersionId` increment in `Resolver.updates()` is unconditional, which
+matches the spec's "Process updates Array" step that increments the counter after the
+duplicate-or-apply check rather than only on apply. This change does not alter that
+behavior; it only stops the counter and history from resetting between rounds. Any question
+about how the read algorithm increments on a confirmed duplicate is a separate,
+pre-existing matter that this fix neither introduces nor worsens, and is left for its own
+review.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -60,6 +60,7 @@ children:
   - ./057-did-document-validation-standards.md
   - ./058-remove-legacy-helia-cas-path.md
   - ./059-unbounded-beacon-discovery-default.md
+  - ./060-resolver-cross-round-version-continuity.md
 ---
 
 # Architecture Decision Records
@@ -127,3 +128,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 057 | 2026-06-28 | [Extensible @context and Uniform Multikey Enforcement in DID Document Validation](057-did-document-validation-standards.md) |
 | 058 | 2026-06-29 | [Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle](058-remove-legacy-helia-cas-path.md) |
 | 059 | 2026-06-29 | [Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap](059-unbounded-beacon-discovery-default.md) |
+| 060 | 2026-06-29 | [Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds](060-resolver-cross-round-version-continuity.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.46.0",
+    "version": "0.47.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -197,6 +197,20 @@ export class Resolver {
   #resolvedResponse: DidResolutionResponse | null = null;
 
   /**
+   * Monotonic DID-document version counter and the update-hash history that backs
+   * duplicate confirmation, both carried across the entire resolution. The spec's
+   * read algorithm keeps a single version counter and a single update-hash history
+   * for the whole signal-processing loop, re-deriving beacons from the contemporary
+   * document on each pass. This sans-I/O resolver splits that one loop into discovery
+   * rounds, so the two must persist across rounds rather than restart each pass.
+   * Restarting them would reject a legitimate linear history whose later updates are
+   * announced on beacons that earlier updates added: round two would forget it had
+   * already reached version two, see version three, and raise a late-publishing error.
+   */
+  #currentVersionId = 1;
+  #updateHashHistory: HashBytes[] = [];
+
+  /**
    * Opt-in upper bound on multi-round beacon-discovery passes. `Infinity` (the
    * default) leaves discovery unbounded; termination is already guaranteed by
    * de-duplicating already-queried beacon addresses. A positive value is a
@@ -345,19 +359,25 @@ export class Resolver {
    * @param {Array<[SignedBTCR2Update, BlockMetadata]>} unsortedUpdates The unsorted array of BTCR2 Signed Updates and their associated Block Metadata.
    * @param {string} [versionTime] The optional version time to limit updates to.
    * @param {string} [versionId] The optional version id to limit updates to.
+   * @param {{ currentVersionId: number; updateHashHistory: HashBytes[] }} [resolutionState]
+   *   Version counter and update-hash history carried from earlier discovery rounds.
+   *   Standalone callers omit it and start fresh at version 1 with an empty history.
    * @returns {DidResolutionResponse} The updated DID Document, number of confirmations, and version id.
    */
   static updates(
     currentDocument: DidDocument,
     unsortedUpdates: Array<[SignedBTCR2Update, BlockMetadata]>,
     versionTime?: string,
-    versionId?: string
+    versionId?: string,
+    resolutionState: { currentVersionId: number; updateHashHistory: HashBytes[] } =
+    { currentVersionId: 1, updateHashHistory: [] }
   ): DidResolutionResponse {
-    // Start the version number being processed at 1
-    let currentVersionId = 1;
-
-    // Initialize an empty array to hold the update hashes (raw bytes)
-    const updateHashHistory: HashBytes[] = [];
+    // Continue the version counter and update-hash history from earlier discovery
+    // rounds so the whole resolution is one monotonic sequence, matching the spec's
+    // single signal-processing loop. updateHashHistory is shared by reference, so the
+    // appends made below are visible to the next round.
+    let currentVersionId = resolutionState.currentVersionId;
+    const updateHashHistory: HashBytes[] = resolutionState.updateHashHistory;
 
     // 1. Sort updates by targetVersionId (ascending), using blockheight as tie-breaker
     const updates = unsortedUpdates.sort(([upd0, blk0], [upd1, blk1]) =>
@@ -682,13 +702,20 @@ export class Resolver {
         // Apply collected updates, then check for new beacon services (multi-round).
         case ResolverPhase.ApplyUpdates: {
           if(this.#unsortedUpdates.length > 0) {
-            // Apply all collected updates to the current document
+            // Apply this round's updates, continuing the resolution-wide version
+            // counter and update-hash history rather than restarting them. Without
+            // this carry, a linear history split across discovery rounds would be
+            // rejected at round two as late publishing.
             this.#resolvedResponse = Resolver.updates(
               this.#currentDocument!,
               this.#unsortedUpdates,
               this.#versionTime,
-              this.#versionId
+              this.#versionId,
+              { currentVersionId: this.#currentVersionId, updateHashHistory: this.#updateHashHistory }
             );
+            // updates() reports the version it reached via metadata.versionId; carry
+            // it forward so the next round continues the monotonic sequence.
+            this.#currentVersionId = Number(this.#resolvedResponse.metadata.versionId);
             this.#currentDocument = this.#resolvedResponse.didDocument;
             this.#unsortedUpdates = [];
 

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -12,7 +12,7 @@ import { BeaconUtils } from '../src/core/beacon/utils.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
 import type { DidDocument } from '../src/utils/did-document.js';
 import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
-import type { NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';
+import type { DidResolutionResponse, NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';
 import { Updater } from '../src/core/updater.js';
 import deterministicData from './data/deterministic-data.js';
 import externalData from './data/external-data.js';
@@ -37,12 +37,12 @@ function resolveDeterministic(did: string): DidDocument {
  * Build a chain of `numHops` signed updates that each add a new SingletonBeacon
  * service, wired so the beacon added by one hop carries the update for the next.
  *
- * Every update is a v1-to-v2 update (sourceVersionId 1) whose sourceHash chains
- * to the running document. That is the only shape that drives the resolver's
- * per-round discovery counter: Resolver.updates() restarts its version counter
- * each round, so a genuine linear history spread across rounds (v2, v3, ...) would
- * be rejected as late publishing. This re-declared-v2 chain is exactly the runaway
- * shape an opt-in maxDiscoveryRounds is meant to bound.
+ * This is a genuine linear history: hop i is a v(i+1)-to-v(i+2) update whose
+ * sourceHash chains to the running document. Hop 0 (v1-to-v2) is announced on the
+ * genesis beacon, the beacon it adds carries hop 1 (v2-to-v3), and so on. Each new
+ * version is only discoverable a round later, on a beacon the previous update added,
+ * so resolving past v2 requires the version counter to persist across discovery
+ * rounds rather than reset each pass.
  *
  * Returns the signed updates (for the sidecar) plus a map from beacon address to
  * the hex update hash to deliver on the beacon at that address; the terminal
@@ -78,7 +78,7 @@ function buildDiscoveryChain(
       value : { id: `${did}#beacon-${i}`, type: 'SingletonBeacon', serviceEndpoint: `bitcoin:${address}` }
     }];
 
-    const unsigned = Updater.construct(currentDoc, patches, 1);
+    const unsigned = Updater.construct(currentDoc, patches, i + 1);
     const signed = Updater.sign(did, unsigned, vm, signer);
     updates.push(signed);
 
@@ -102,7 +102,7 @@ function driveDiscoveryChain(
   updates: Array<SignedBTCR2Update>,
   signalByAddress: Map<string, string>,
   options?: { maxDiscoveryRounds?: number }
-): DidDocument {
+): DidResolutionResponse {
   const resolver = DidBtcr2.resolve(did, { sidecar: { updates }, ...options });
   let height = 100;
   let state = resolver.resolve();
@@ -122,7 +122,7 @@ function driveDiscoveryChain(
     state = resolver.resolve();
   }
   if(state.status !== 'resolved') throw new Error('expected resolved');
-  return state.result.didDocument;
+  return state.result;
 }
 
 describe('Resolver', () => {
@@ -685,6 +685,24 @@ describe('Resolver', () => {
     });
   });
 
+  describe('cross-round version continuity (regression)', () => {
+    it('resolves a linear history whose later versions live on beacons added by earlier updates', () => {
+      const fixture = deterministicData[2]; // regtest - has a known secretKey
+      const sourceDocument = resolveDeterministic(fixture.did);
+      const hops = 3;
+      const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, hops);
+
+      // Genesis is v1. Hop 0 (v1->v2) is announced on the genesis beacon, hop 1
+      // (v2->v3) on the beacon hop 0 added, hop 2 (v3->v4) on the beacon hop 1 added.
+      // Each version is only discoverable a round later, so resolving past v2 requires
+      // the version counter to persist across discovery rounds. Previously the resolver
+      // reset that counter every round and rejected hop 1 at round two as late publishing.
+      const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress);
+      expect(resolved.metadata.versionId).to.equal(`${hops + 1}`);
+      expect(resolved.didDocument.service.length).to.equal(sourceDocument.service.length + hops);
+    });
+  });
+
   describe('edge cases', () => {
     it('resolves immediately for k1 when no beacon services have signals', () => {
       const resolver = DidBtcr2.resolve(deterministicData[0].did);
@@ -828,7 +846,7 @@ describe('Resolver', () => {
       const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, hops);
 
       const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress);
-      expect(resolved.service.length).to.equal(initialServiceCount + hops);
+      expect(resolved.didDocument.service.length).to.equal(initialServiceCount + hops);
     });
 
     it('treats a non-positive maxDiscoveryRounds as unbounded', () => {
@@ -838,7 +856,7 @@ describe('Resolver', () => {
 
       // 0 used to trip immediately; under the new semantics it means "no limit".
       const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress, { maxDiscoveryRounds: 0 });
-      expect(resolved.service.length).to.equal(sourceDocument.service.length + 3);
+      expect(resolved.didDocument.service.length).to.equal(sourceDocument.service.length + 3);
     });
 
     it('still enforces an explicit positive maxDiscoveryRounds cap (INTERNAL_ERROR)', () => {


### PR DESCRIPTION
* chore(release): bump method 0.47.0, api 0.13.6, cli 0.12.11
* fix(method): persist version counter and update-hash history across resolver discovery rounds
* docs(adr): add ADR 060 (cross-round resolver version continuity)