### PR TITLE
remove unused Document class and add resolver early-return tests

### DIFF
--- a/docs/adr/061-remove-dead-document-class.md
+++ b/docs/adr/061-remove-dead-document-class.md
@@ -1,0 +1,81 @@
+---
+title: "ADR 061: Remove the Unused Public Document Wrapper Class"
+---
+
+# ADR 061: Remove the Unused Public Document Wrapper Class
+
+**Status:** Accepted
+
+**Date:** 2026-06-30
+
+**Branch / PR:** `chore/method-hygiene`
+
+**References:** [ADR 058](058-remove-legacy-helia-cas-path.md), [ADR 016](016-sans-io-resolver.md)
+
+## Context
+
+`packages/method/src/utils/did-document.ts` defined a class named `Document`:
+
+```ts
+export class Document {
+  public static isValid(didDocument: DidDocument | GenesisDocument): boolean {
+    return new DidDocument(didDocument).validateGenesis();
+  }
+}
+```
+
+It is a three-line static wrapper that does nothing a caller cannot do directly with
+`new DidDocument(...).validateGenesis()`. It has zero callers anywhere in the monorepo
+(source, tests, lib scripts, test vectors), yet it was reachable as a public export,
+`import { Document } from '@did-btcr2/method'`, through the wildcard barrel
+`export * from './utils/did-document.js'` in `method/src/index.ts`. The name also collides
+conceptually with the DOM `Document` and with the package's real `DidDocument`, making it a
+trap for anyone scanning the public surface.
+
+A repository convention already covers this situation:
+[ADR 058](058-remove-legacy-helia-cas-path.md) removed the dead public method
+`Appendix.fetchFromCas` and recorded it as a breaking, minor-version change. This decision
+applies the same treatment to the `Document` class.
+
+## Decision
+
+### Remove the `Document` class outright
+
+Delete the class. Callers that need genesis validation use the live API directly:
+`new DidDocument(doc).validateGenesis()` or `DidDocument.validate(doc)`. The barrel export
+needs no edit, it is a wildcard re-export with no named `Document` entry, so the public
+surface is automatically corrected once the class is gone.
+
+### Treat the removal as a breaking, minor-version change
+
+Although `Document` was undocumented and uncalled, it was part of the published API surface,
+so removing it can break an external consumer importing it by name. Per 0.x semantics
+(breaking changes signalled by a minor bump) and the [ADR 058](058-remove-legacy-helia-cas-path.md)
+precedent, `@did-btcr2/method` takes a minor bump and this ADR serves as the release note.
+
+## Consequences
+
+- The published API of `@did-btcr2/method` no longer exports `Document`. A consumer importing
+  it by name must switch to `DidDocument` (which exposes the same `validateGenesis()` /
+  `validate()` behavior). No in-tree code was affected.
+- `DidDocument.validateGenesis()` is unchanged and remains in active use by the `DidDocument`
+  constructor and `DidDocument.validate()`; it is not orphaned by the removal.
+- The misleading `Document` name is gone from the surface, leaving `DidDocument`,
+  `GenesisDocument`, and `Btcr2DidDocument` as the document types.
+
+## Rejected alternatives
+
+- **Deprecate first, remove later.** A deprecation cycle is warranted for an API with real
+  users or real behavior. This class has neither: zero callers and no behavior of its own
+  beyond delegating to `DidDocument`. A deprecation shim would prolong the confusing name for
+  no benefit.
+- **Keep it.** Retaining a named, public, never-called wrapper invites accidental use and
+  keeps a second spelling of `validateGenesis` on the surface. The cost of carrying it
+  outweighs any hypothetical convenience.
+
+## Note
+
+The same branch also added resolver unit tests covering the previously-untested
+`versionId`, `versionTime`, and `deactivated` early-return branches in `Resolver.updates()`
+(see [ADR 016](016-sans-io-resolver.md) for the resolver state machine). That is test
+coverage rather than a design decision and is recorded here only for branch traceability.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -61,6 +61,7 @@ children:
   - ./058-remove-legacy-helia-cas-path.md
   - ./059-unbounded-beacon-discovery-default.md
   - ./060-resolver-cross-round-version-continuity.md
+  - ./061-remove-dead-document-class.md
 ---
 
 # Architecture Decision Records
@@ -129,3 +130,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 058 | 2026-06-29 | [Remove the Legacy Helia CAS Read Path and Shrink the Method Bundle](058-remove-legacy-helia-cas-path.md) |
 | 059 | 2026-06-29 | [Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap](059-unbounded-beacon-discovery-default.md) |
 | 060 | 2026-06-29 | [Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds](060-resolver-cross-round-version-continuity.md) |
+| 061 | 2026-06-30 | [Remove the Unused Public Document Wrapper Class](061-remove-dead-document-class.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.6",
+    "version": "0.13.7",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.47.0",
+    "version": "0.48.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/utils/did-document.ts
+++ b/packages/method/src/utils/did-document.ts
@@ -480,13 +480,6 @@ export class DidDocument implements Btcr2DidDocument {
   }
 }
 
-export class Document {
-  public static isValid(didDocument: DidDocument | GenesisDocument): boolean {
-    return new DidDocument(didDocument).validateGenesis();
-  }
-}
-
-
 /**
  * GenesisDocument extends the DidDocument class for creating and managing intermediate DID documents.
  * This class is used to create a minimal DID document with a placeholder ID.

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { randomBytes } from 'crypto';
 import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, JSONPatch } from '@did-btcr2/common';
+import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner } from '@did-btcr2/keypair';
 import { BTCR2MerkleTree, hashToHex } from '@did-btcr2/smt';
@@ -121,6 +122,69 @@ function driveDiscoveryChain(
     resolver.provide(need, signals);
     state = resolver.resolve();
   }
+  if(state.status !== 'resolved') throw new Error('expected resolved');
+  return state.result;
+}
+
+/**
+ * A benign, non-beacon mutation that keeps the document valid: append an existing key reference
+ * to assertionMethod (duplicate string refs are allowed by isValidVerificationRelationships).
+ * Used to build version hops that do NOT add a beacon, so the whole chain stays in one round.
+ */
+function benignPatch(did: string): PatchOperation[] {
+  return [{ op: 'add' as const, path: '/assertionMethod/-', value: `${did}#initialKey` }];
+}
+
+/**
+ * Build a linear chain of signed updates (v2, v3, ...) from `sourceDocument`, applying
+ * `patchesPerHop[i]` at hop i with correctly chained sourceHashes. With no beacon-adding
+ * patches, every update is discoverable in a single discovery round on the genesis beacon.
+ */
+function buildUpdateChain(
+  did: string,
+  sourceDocument: DidDocument,
+  secretKey: string,
+  patchesPerHop: Array<PatchOperation[]>
+): Array<SignedBTCR2Update> {
+  const vm = sourceDocument.verificationMethod![0]!;
+  const signer = new LocalSigner(hexToBytes(secretKey));
+  const signed: Array<SignedBTCR2Update> = [];
+  let currentDoc: DidDocument = sourceDocument;
+  patchesPerHop.forEach((patches, i) => {
+    const unsigned = Updater.construct(currentDoc, patches, i + 1);
+    signed.push(Updater.sign(did, unsigned, vm, signer));
+    currentDoc = JSONPatch.apply(currentDoc, patches) as DidDocument;
+  });
+  return signed;
+}
+
+/**
+ * Drive a resolver delivering every update as a signal on the single genesis beacon in one
+ * discovery round (the updates add no beacons). Optional versionId/versionTime limits and
+ * per-update block times exercise the early-return branches inside Resolver.updates().
+ */
+function driveSingleBeacon(
+  did: string,
+  updates: Array<SignedBTCR2Update>,
+  options?: { versionId?: string; versionTime?: string; times?: Array<number> }
+): ReturnType<typeof driveDiscoveryChain> {
+  const resolver = DidBtcr2.resolve(did, {
+    sidecar : { updates },
+    ...(options?.versionId ? { versionId: options.versionId } : {}),
+    ...(options?.versionTime ? { versionTime: options.versionTime } : {})
+  });
+  let state = resolver.resolve();
+  if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+  const need = state.needs[0] as NeedBeaconSignals;
+  const genesis = need.beaconServices[0] as BeaconService;
+  const signals = new Map<BeaconService, Array<BeaconSignal>>();
+  signals.set(genesis, updates.map((update, i) => ({
+    tx            : {} as any,
+    signalBytes   : canonicalHash(update, { encoding: 'hex' }),
+    blockMetadata : { height: 100 + i, time: options?.times?.[i] ?? (1700000000 + i), confirmations: 6 }
+  })));
+  resolver.provide(need, signals);
+  state = resolver.resolve();
   if(state.status !== 'resolved') throw new Error('expected resolved');
   return state.result;
 }
@@ -700,6 +764,51 @@ describe('Resolver', () => {
       const resolved = driveDiscoveryChain(fixture.did, updates, signalByAddress);
       expect(resolved.metadata.versionId).to.equal(`${hops + 1}`);
       expect(resolved.didDocument.service.length).to.equal(sourceDocument.service.length + hops);
+    });
+  });
+
+  describe('update-processing limits (versionId / versionTime / deactivated)', () => {
+    const fixture = deterministicData[2]; // regtest - has a known secretKey
+
+    it('stops at the requested versionId and ignores later updates', () => {
+      const source = resolveDeterministic(fixture.did);
+      // v2, v3, v4 - three benign hops, all delivered on the genesis beacon in one round.
+      const updates = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      const { metadata, didDocument } = driveSingleBeacon(fixture.did, updates, { versionId: '3' });
+      // The loop applies v2 then v3; once currentVersionId reaches 3 it returns, never applying v4.
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('stops before an update dated after versionTime', () => {
+      const source = resolveDeterministic(fixture.did);
+      const updates = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // v2 block time 2023-11-14, v3 block time 2027-01-15; versionTime sits between them, so
+      // v2 applies and v3 is short-circuited before it is applied.
+      const { metadata, didDocument } = driveSingleBeacon(fixture.did, updates, {
+        versionTime : '2025-01-01T00:00:00Z',
+        times       : [1700000000, 1800000000]
+      });
+      expect(metadata.versionId).to.equal('2');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 1);
+    });
+
+    it('stops at a deactivating update and reports deactivated', () => {
+      const source = resolveDeterministic(fixture.did);
+      const updates = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        [{ op: 'add' as const, path: '/deactivated', value: true }], // v2 deactivates
+        benignPatch(fixture.did)                                     // v3 must never be reached
+      ]);
+      const { metadata, didDocument } = driveSingleBeacon(fixture.did, updates);
+      expect(metadata.deactivated).to.equal(true);
+      expect(didDocument.deactivated).to.equal(true);
+      expect(metadata.versionId).to.equal('2');
+      // v3's benign append was never applied, so assertionMethod is unchanged from genesis.
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length);
     });
   });
 


### PR DESCRIPTION
* chore(release): bump method 0.48.0, api 0.13.7, cli 0.12.12
* test(method): cover resolver versionId/versionTime/deactivated early-returns
* refactor(method): remove the unused public Document wrapper class
* docs(adr): add ADR 061 (remove dead Document class)