### PR TITLE
harden did:btcr2 identifier encode/decode and reject forged versions

### DIFF
--- a/docs/adr/062-identifier-encoding-hardening.md
+++ b/docs/adr/062-identifier-encoding-hardening.md
@@ -1,0 +1,164 @@
+---
+title: "ADR 062: Harden did:btcr2 Identifier Encoding and Decoding"
+---
+
+# ADR 062: Harden did:btcr2 Identifier Encoding and Decoding
+
+**Status:** Accepted
+
+**Date:** 2026-06-30
+
+**Branch / PR:** `fix/identifier-encoding-hardening`
+
+**References:** [ADR 003](003-bech32m-did-encoding.md), [ADR 055](055-resolver-provide-trust-boundary.md), [ADR 057](057-did-document-validation-standards.md)
+
+## Context
+
+`Identifier.encode` / `Identifier.decode` (`packages/method/src/core/identifier.ts`) implement
+the Bech32m identifier encoding from [ADR 003](003-bech32m-did-encoding.md), following the
+[did:btcr2 specification](https://dcdpr.github.io/did-btcr2/) `algorithms` section. The first
+data byte packs two 4-bit fields: the high nibble is `btcr2_version` and the low nibble is
+`network_value`. For a v1 identifier the only valid `btcr2_version` is `0` (the spec defines
+`version_number = btcr2_version + 1`, and only version 1 exists). The remaining data bytes are
+the genesis bytes: a 33-byte compressed secp256k1 public key for a KEY identifier (hrp `k`), or
+a 32-byte hash for an EXTERNAL identifier (hrp `x`).
+
+An audit of the decode path found that the version guard was unreachable for the cases that
+matter. The decoder read the version with a loop:
+
+```ts
+let versionNibble = currentByte >>> 4;
+while (versionNibble === 0xF) {
+  version += 15;
+  // ...advance to the next nibble...
+  if (version > 1) {
+    throw new IdentifierError(`Invalid version: ${version}`, INVALID_DID, { identifier });
+  }
+}
+version += versionNibble;
+```
+
+The spec reserves a leading nibble of `0xF` for a future multi-byte version-extension scheme.
+The loop body, including the `version > 1` rejection, runs only when the leading nibble is
+exactly `0xF`. For a leading nibble of `0x1` through `0xE` the loop never executes, so the guard
+never fires: the decoder fell through to `version += versionNibble` and silently accepted the
+identifier with `version` set to 2 through 15. A forged first byte of `0x10` decoded as version 2,
+`0x20` as version 3, and so on. Because the genesis bytes still parsed as a valid public key, the
+forged identifier was accepted as a well-formed DID with a version this implementation does not
+define. This is the central defect: an identifier the encoder can never produce, and that the spec
+does not define, was treated as valid.
+
+Three smaller gaps accompanied it:
+
+1. **Decode network table.** The decoder mapped `network_value` 8 through 15 to `network_value - 11`
+   (yielding negative numbers and zero for 8 through 11, and 4 for 15), accepting reserved and
+   out-of-range values as if they were custom networks.
+2. **EXTERNAL genesis length was unchecked on both paths.** `encode` enforced a length only for KEY
+   (via the public-key constructor) and `decode` enforced none for EXTERNAL, so an EXTERNAL DID could
+   be minted or parsed with a hash of any length, producing an unresolvable identifier.
+3. **Encoder version and numeric-network handling.** `encode` rejected only `version > 1` (accepting
+   0 and negatives, which corrupt the version nibble) and carried a numeric-network branch that
+   appended `network + 11`; for a numeric network of 5 or more this overflows the 4-bit field and
+   corrupts the version nibble. It also retained a dead `NOT_IMPLEMENTED` branch from the
+   never-completed version-extension scheme.
+
+The defects and a regression test net for them originate from an internal audit commit
+(`c76a07e5`, branch `refactor/method-audit`) that was never merged. This decision re-expresses the
+fixes against the current code and reconciles the network boundary against the specification rather
+than porting the audit verbatim.
+
+### Specification facts grounding this decision
+
+- `version_number` is 1; `btcr2_version` is `version_number - 1`, which is `0`.
+- The first byte's high nibble is `btcr2_version` and its low nibble is `network_value`. This nibble
+  order was confirmed against the specification's worked decode example (a mutinynet identifier whose
+  `network_value` of 5 appears as a first byte of `0x05`).
+- `network_value` mapping: bitcoin 0, signet 1, regtest 2, testnet3 3, testnet4 4, mutinynet 5;
+  values 6 through 11 are reserved; values 12 through 14 are custom networks; 15 is out of range.
+
+## Decision
+
+### Read btcr2_version as a single flat nibble and require it to be 0
+
+Decode reads `btcr2_version = dataBytes[0] >>> 4` directly and rejects any non-zero value. The
+version-extension loop is removed. A leading nibble of `0x1` through `0xF` is now rejected, which
+closes the forged-version acceptance: `0xF` is the reserved extension marker that v1 does not
+implement, and `0x1` through `0xE` are versions this implementation does not define. `version` is
+fixed at 1 for every accepted identifier.
+
+### Enforce the strict network table on decode
+
+`network_value` 0 through 5 map to their named networks. Values 12 through 14 are custom networks and
+decode to the numeric values 1 through 3 (preserving the prior numeric-custom-network behavior).
+Values 6 through 11 and 15 are rejected as reserved or out of range.
+
+### Drop the numeric-network branch from encode; mint only named networks
+
+The public option type (`DidCreateOptions.network`) is a string, `DidBtcr2.create` defaults it to
+`"bitcoin"`, and there are no numeric-network callers in the monorepo. The encoder therefore accepts
+only known network names and resolves them through `BitcoinNetworkNames`. Removing the numeric branch
+removes the nibble-overflow corruption it could cause. Custom networks remain decode-only: an existing
+identifier that encodes a custom network can still be parsed, but this implementation does not mint
+new ones. The dead `NOT_IMPLEMENTED` version-extension branch is removed with it.
+
+### Enforce genesis-byte length for both identifier types on both paths
+
+KEY genesis bytes are validated by constructing a `CompressedSecp256k1PublicKey` (33 bytes, valid
+point), as before. EXTERNAL genesis bytes must be exactly 32 bytes, checked on both `encode` and
+`decode`. An EXTERNAL identifier with any other hash length is rejected rather than minted or parsed
+into an unresolvable DID.
+
+### Require version to be exactly 1 on encode
+
+`encode` rejects any `version` that is not strictly equal to 1, which also rejects `NaN` and
+non-number inputs. This replaces the prior `version > 1` check that accepted 0 and negatives.
+
+### Keep the encoder's network default at "bitcoin"
+
+`encode` continues to default an omitted `network` to `"bitcoin"`, matching `DidBtcr2.create`, so the
+two layers agree on the default rather than disagreeing about whether an omitted network is an error.
+A `null` or empty-string network is still rejected; only an omitted (`undefined`) network takes the
+default.
+
+### Treat the change as a breaking, minor-version change
+
+The decoder now rejects identifiers it previously accepted (forged versions, reserved networks,
+mis-sized EXTERNAL hashes), and the encoder rejects inputs it previously tolerated. Per 0.x semantics
+(breaking changes signalled by a minor bump) and the precedent of prior validation-tightening ADRs,
+`@did-btcr2/method` takes a minor bump and this ADR serves as the release note.
+
+## Consequences
+
+- A forged identifier with a non-zero `btcr2_version` is rejected at decode. Any consumer relying on
+  the previous silent acceptance of versions 2 through 15 will now see an `INVALID_DID` error, which
+  is the intended behavior: those identifiers are not valid v1 DIDs.
+- Reserved and out-of-range `network_value`s (6 through 11, 15) are rejected. Custom networks
+  (12 through 14) continue to decode to numeric 1 through 3.
+- EXTERNAL identifiers are well-formed by construction: a 32-byte hash is required to mint one and to
+  parse one. All in-tree EXTERNAL fixtures and vectors are already 32 bytes and are unaffected.
+- The encoder no longer mints custom/numeric networks. No in-tree caller did so; `DidBtcr2.create`
+  and the API facade pass named networks only.
+- The identifier round-trips for every existing fixture: a valid v1 identifier decodes to the same
+  components and re-encodes to the same string. The decode change is behavior-preserving for valid v1
+  identifiers (the leading nibble is 0, the network nibble is the low nibble, and the genesis bytes are
+  the remainder), and only tightens the rejection of malformed input.
+- The package ships a regression net covering forged versions (`0x10`, `0x20`, `0xE0`, `0xF0`), the
+  network boundary (6, 7, 8, 11, 15 rejected; 12 through 14 accepted; 0 through 5 via fixtures), and
+  EXTERNAL length on both paths.
+
+## Rejected alternatives
+
+- **Keep the version-extension loop and add a separate guard.** The loop implements a multi-byte
+  version scheme this version of the method does not define, and its presence is exactly what hid the
+  defect. A flat single-nibble read is both correct for v1 and impossible to misread.
+- **Preserve the lenient decode network table.** Mapping 8 through 15 to `network_value - 11` accepts
+  reserved values and produces negative network numbers. Rejecting reserved and out-of-range values
+  matches the specification's network table and prevents a reserved value from being silently
+  reinterpreted.
+- **Reject an omitted network in encode.** Treating `undefined` as an error would make the low-level
+  encoder stricter than `DidBtcr2.create`, which defaults to `"bitcoin"`. Defaulting in both places
+  keeps the two layers consistent and avoids a surprising failure for a caller that omits an optional
+  field. `null` and empty-string networks are still rejected.
+- **Keep the numeric-network encode branch.** It is unused, and its `network + 11` arithmetic overflows
+  the 4-bit network field for numeric networks of 5 or more, corrupting the version nibble. Removing it
+  eliminates a latent corruption path while leaving custom-network decoding intact.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -62,6 +62,7 @@ children:
   - ./059-unbounded-beacon-discovery-default.md
   - ./060-resolver-cross-round-version-continuity.md
   - ./061-remove-dead-document-class.md
+  - ./062-identifier-encoding-hardening.md
 ---
 
 # Architecture Decision Records
@@ -131,3 +132,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 059 | 2026-06-29 | [Beacon Discovery Is Unbounded by Default, With an Opt-In Round Cap](059-unbounded-beacon-discovery-default.md) |
 | 060 | 2026-06-29 | [Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds](060-resolver-cross-round-version-continuity.md) |
 | 061 | 2026-06-30 | [Remove the Unused Public Document Wrapper Class](061-remove-dead-document-class.md) |
+| 062 | 2026-06-30 | [Harden did:btcr2 Identifier Encoding and Decoding](062-identifier-encoding-hardening.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.7",
+    "version": "0.13.8",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.48.0",
+    "version": "0.49.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/identifier.ts
+++ b/packages/method/src/core/identifier.ts
@@ -55,30 +55,34 @@ export class Identifier {
    * @returns {string} The new did:btcr2 identifier.
    */
   static encode(genesisBytes: KeyBytes | DocumentBytes, options: DidCreateOptions): string {
-    // Deconstruct the options
-    const { idType, version = 1, network } = options;
+    // Deconstruct the options, defaulting version to 1 and network to "bitcoin" (matching DidBtcr2.create).
+    const { idType, version = 1, network = 'bitcoin' } = options;
 
-    // If idType is not a valid value per above, raise invalidDid error.
+    // idType MUST be "KEY" or "EXTERNAL".
     if (!(idType in IdentifierTypes)) {
-      throw new IdentifierError('Expected "idType" to be "KEY" or "EXTERNAL"', INVALID_DID, {idType});
+      throw new IdentifierError('Expected "idType" to be "KEY" or "EXTERNAL"', INVALID_DID, { idType });
     }
 
-    // 2. If version is greater than 1, raise invalidDid error.
-    if (isNaN(version) || version > 1) {
-      throw new IdentifierError('Expected "version" to be 1', INVALID_DID, {version});
+    // The only valid version_number is 1 (which encodes a btcr2_version of 0). Any other value would
+    // overflow or corrupt the version nibble, so reject everything except exactly 1. This also rejects
+    // NaN and non-number inputs, which are never strictly equal to 1.
+    if (version !== 1) {
+      throw new IdentifierError('Expected "version" to be 1', INVALID_DID, { version });
     }
 
-    // 3. If network is not a valid value (bitcoin|signet|regtest|testnet3|testnet4|number), raise invalidDid error.
-    if (typeof network === 'string' && !(network in BitcoinNetworkNames)) {
-      throw new IdentifierError('Invalid "network" name', INVALID_DID, {network});
+    // network MUST be a known network name. This encoder does not mint custom/numeric networks: the
+    // public surface (DidCreateOptions.network) is a string, and a numeric nibble >= 5 would overflow
+    // the 4-bit network field and corrupt the version nibble. Custom networks remain decode-only.
+    if (typeof network !== 'string') {
+      throw new IdentifierError('Expected "network" to be a known network name', INVALID_DID, { network });
+    }
+    const networkValue = BitcoinNetworkNames[network as keyof typeof BitcoinNetworkNames] as number | undefined;
+    if (networkValue === undefined) {
+      throw new IdentifierError('Invalid "network" name', INVALID_DID, { network });
     }
 
-    // 4. If network is a number and is outside the range of 1-8, raise invalidDid error.
-    if(typeof network === 'number' && (network < 0 || network > 8)) {
-      throw new IdentifierError('Invalid "network" number', INVALID_DID, {network});
-    }
-
-    // 5. If idType is “key” and genesisBytes is not a valid compressed secp256k1 public key, raise invalidDid error.
+    // genesisBytes MUST match the identifier type: a valid compressed secp256k1 public key for KEY,
+    // or a 32-byte hash for EXTERNAL. An EXTERNAL DID minted with any other length is unresolvable.
     if (idType === 'KEY') {
       try {
         new CompressedSecp256k1PublicKey(genesisBytes);
@@ -88,56 +92,20 @@ export class Identifier {
           INVALID_DID, { genesisBytes }
         );
       }
+    } else if (genesisBytes.length !== 32) {
+      throw new IdentifierError(
+        'Expected "genesisBytes" to be a 32-byte hash for EXTERNAL identifiers',
+        INVALID_DID, { genesisBytes }
+      );
     }
 
-    // 6. Map idType to hrp from the following:
-    //   6.1 “key” - “k”
-    //   6.2 “external” - “x”
+    // Map idType to its human-readable part: KEY -> "k", EXTERNAL -> "x".
     const hrp = idType === 'KEY' ? 'k' : 'x';
 
-    // 7. Create an empty nibbles numeric array.
-    const nibbles: Array<number> = [];
-
-    // 8. Set fCount equal to (version - 1) / 15, rounded down.
-    const fCount = Math.floor((version - 1) / 15);
-
-    // 9. Append hexadecimal F (decimal 15) to nibbles fCount times.
-    for (let i = 0; i < fCount; i++) {
-      nibbles.push(15);
-    }
-
-    // 10. Append (version - 1) mod 15 to nibbles.
-    nibbles.push((version - 1) % 15);
-
-    // 11. If network is a string, append the numeric value from the following map to nibbles:
-    //     "bitcoin" - 0
-    //     "signet" - 1
-    //     "regtest" - 2
-    //     "testnet3" - 3
-    //     "testnet4" - 4
-    //     "mutinynet" - 5
-    if(typeof network === 'string') {
-      nibbles.push(BitcoinNetworkNames[network as keyof typeof BitcoinNetworkNames]);
-    } else if (typeof network === 'number') {
-      // 12. If network is a number, append network + 11 to nibbles.
-      nibbles.push(network + 11);
-    }
-
-    // 13. If the number of entries in nibbles is odd, append 0.
-    if (nibbles.length % 2 !== 0) {
-      nibbles.push(0);
-    }
-
-    // 14. Create a dataBytes byte array from nibbles, where index is from 0 to nibbles.length / 2 - 1 and
-    //     encodingBytes[index] = (nibbles[2 * index] << 4) | nibbles[2 * index + 1].
-    if (fCount !== 0){
-      for(const index in Array.from({ length: (nibbles.length / 2) - 1 })) {
-        throw new IdentifierError('Not implemented', 'NOT_IMPLEMENTED', { index });
-      }
-    }
-    const dataBytes = new Uint8Array([(nibbles[2 * 0] << 4) | nibbles[2 * 0 + 1], ...genesisBytes]);
-
-    // 18. Return identifier.
+    // Pack btcr2_version (high nibble, = version - 1 = 0) and network_value (low nibble) into the first
+    // byte, then append genesisBytes. Bech32m-encode the result.
+    const firstByte = ((version - 1) << 4) | networkValue;
+    const dataBytes = new Uint8Array([firstByte, ...genesisBytes]);
     return `did:btcr2:${bech32m.encodeFromBytes(hrp, dataBytes)}`;
   }
 
@@ -150,129 +118,89 @@ export class Identifier {
    * @throws {DidErrorCode.MethodNotSupported} if the method is not supported
    */
   static decode(identifier: string): DidComponents {
-    // 1. Split identifier into an array of components at the colon : character.
+    // 1. Split the identifier into scheme, method, and encoded id at the colon character.
     const components = identifier.split(':');
 
-    // 2. If the length of the components array is not 3, raise invalidDid error.
+    // 2. There MUST be exactly three colon-separated components.
     if (components.length !== 3){
       throw new IdentifierError(`Invalid did: ${identifier}`, INVALID_DID, { identifier });
     }
 
-    // Deconstruct the components of the identifier: scheme, method, encoded
     const [scheme, method, encoded] = components;
 
-    // 3. If components[0] is not “did”, raise invalidDid error.
+    // 3. The scheme MUST be "did".
     if (scheme !== 'did') {
       throw new IdentifierError(`Invalid did: ${identifier}`, INVALID_DID, { identifier });
     }
-    // 4. If components[1] is not “btcr2”, raise methodNotSupported error.
+
+    // 4. The method MUST be "btcr2".
     if (method !== 'btcr2') {
       throw new IdentifierError(`Invalid did method: ${method}`, METHOD_NOT_SUPPORTED, { identifier });
     }
 
-    // 5. Set encodedString to components[2].
+    // 5. The method-specific id MUST be present.
     if (!encoded) {
       throw new IdentifierError(`Invalid method-specific id: ${identifier}`, INVALID_DID, { identifier });
     }
-    // 6. Pass encodedString to the Bech32m Decoding algorithm, retrieving hrp and dataBytes.
-    const {prefix: hrp, bytes: dataBytes} = bech32m.decodeToBytes(encoded);
 
-    // 7. If the Bech32m decoding algorithm fails, raise invalidDid error.
+    // 6. Bech32m-decode the id into its hrp and dataBytes.
+    const { prefix: hrp, bytes: dataBytes } = bech32m.decodeToBytes(encoded);
+
+    // 7. The hrp MUST be "k" (KEY) or "x" (EXTERNAL).
     if (!['x', 'k'].includes(hrp)) {
       throw new IdentifierError(`Invalid hrp: ${hrp}`, INVALID_DID, { identifier });
     }
-    if (!dataBytes) {
+
+    // 8. There MUST be at least one byte to read btcr2_version and network_value from.
+    if (!dataBytes || dataBytes.length < 1) {
       throw new IdentifierError(`Failed to decode id: ${encoded}`, INVALID_DID, { identifier });
     }
 
-    // 8. Map hrp to idType from the following:
-    //    “k” - “key”
-    //    “x” - “external”
-    //    other - raise invalidDid error
+    // 9. Map hrp to idType.
     const idType = hrp === 'k' ? 'KEY' : 'EXTERNAL';
 
-    // 9. Set version to 1.
-    let version = 1;
-    let byteIndex = 0;
-    // 10. If at any point in the remaining steps there are not enough nibbles to complete the process,
-    //     raise invalidDid error.
-    let nibblesConsumed = 0;
+    // 10. btcr2_version is the high nibble of the first byte and MUST be 0, which is version_number 1.
+    //     The version-extension scheme (a leading nibble of 0xF chaining into further bytes) is reserved
+    //     and not valid under v1, so any non-zero high nibble (0x1 through 0xF) is a malformed or forged
+    //     identifier and is rejected here. Reading a single flat nibble (rather than looping on 0xF) is
+    //     what makes this guard actually fire: the previous loop body never ran for a leading nibble of
+    //     0x1 through 0xE, silently accepting forged versions.
+    const btcr2Version = dataBytes[0] >>> 4;
+    if (btcr2Version !== 0) {
+      throw new IdentifierError(`Invalid btcr2_version (expected 0): ${btcr2Version}`, INVALID_DID, { identifier });
+    }
+    const version = 1;
 
-    // 11. Start with the first nibble (the higher nibble of the first byte) of dataBytes.
-    let currentByte = dataBytes[byteIndex];
-    let versionNibble = currentByte >>> 4;
-
-    // 12. Add the value of the current nibble to version.
-    while (versionNibble === 0xF) {
-      // 13. If the value of the nibble is hexadecimal F (decimal 15), advance to the next nibble (the lower nibble of
-      //     the current byte or the higher nibble of the next byte) and return to the previous step.
-      version += 15;
-
-      if (nibblesConsumed % 2 === 0) {
-        versionNibble = currentByte & 0x0F;
-      } else {
-        currentByte = dataBytes[++byteIndex];
-        versionNibble = currentByte >>> 4;
-      }
-      nibblesConsumed += 1;
-      // 14. If version is greater than 1, raise invalidDid error.
-      if (version > 1) {
-        throw new IdentifierError(`Invalid version: ${version}`, INVALID_DID, { identifier });
-      }
+    // 11. network_value is the low nibble of the first byte. 0-5 map to named networks; 12-14 are custom
+    //     networks (returned as the numeric values 1-3); 6-11 and 15 are reserved/out-of-range and rejected.
+    const networkValue = dataBytes[0] & 0x0F;
+    const networkName = BitcoinNetworkNames[networkValue] as string | undefined;
+    let network: string | number;
+    if (typeof networkName === 'string') {
+      network = networkName;
+    } else if (networkValue >= 12 && networkValue <= 14) {
+      network = networkValue - 11;
+    } else {
+      throw new IdentifierError(`Invalid network: ${networkValue}`, INVALID_DID, { identifier });
     }
 
-    version += versionNibble;
-    nibblesConsumed += 1;
+    // 12. genesisBytes is everything after the first byte.
+    const genesisBytes = dataBytes.slice(1);
 
-    // 15. Advance to the next nibble and set networkValue to its value.
-    let networkValue: number = nibblesConsumed % 2 === 0
-      ? dataBytes[++byteIndex] >>> 4
-      : currentByte & 0x0F;
-
-    nibblesConsumed += 1;
-
-    // 16. Map networkValue to network from the following:
-    //     0 - "bitcoin"
-    //     1 - "signet"
-    //     2 - "regtest"
-    //     3 - "testnet3"
-    //     4 - "testnet4"
-    //     5 - "mutinynet"
-    //     6-7 - raise invalidDid error
-    //     8-F - networkValue - 11
-    let network: string | number | undefined = BitcoinNetworkNames[networkValue];
-    if (!network) {
-      if (networkValue >= 0x8 && networkValue <= 0xF) {
-        network = networkValue - 11;
-      } else {
-        throw new IdentifierError(`Invalid did: ${identifier}`, INVALID_DID, { identifier });
-      }
-    }
-
-    // 17. If the number of nibbles consumed is odd:
-    if (nibblesConsumed % 2 === 1) {
-      //     17.1 Advance to the next nibble and set fillerNibble to its value.
-      const fillerNibble = currentByte & 0x0F;
-      //     17.2 If fillerNibble is not 0, raise invalidDid error.
-      if (fillerNibble !== 0) {
-        throw new IdentifierError(`Invalid did: ${identifier}`, INVALID_DID, { identifier });
-      }
-    }
-
-    // 18. Set genesisBytes to the remaining dataBytes.
-    const genesisBytes = dataBytes.slice(byteIndex + 1);
-
-    // 19. If idType is “key” and genesisBytes is not a valid compressed secp256k1 public key, raise invalidDid error.
+    // 13. genesisBytes MUST match the identifier type: a valid compressed secp256k1 public key for KEY,
+    //     or a 32-byte hash for EXTERNAL.
     if (idType === 'KEY') {
       try {
         new CompressedSecp256k1PublicKey(genesisBytes);
       } catch {
         throw new IdentifierError(`Invalid genesisBytes: ${genesisBytes}`, INVALID_DID, { identifier });
       }
+    } else if (genesisBytes.length !== 32) {
+      throw new IdentifierError(`Invalid genesisBytes: ${genesisBytes}`, INVALID_DID, { identifier });
     }
 
-    // 20. Return idType, version, network, and genesisBytes.
-    return {idType, hrp, version, network, genesisBytes} as DidComponents;
+    // 14. Return idType, hrp, version, network, and genesisBytes.
+    return { idType, hrp, version, network, genesisBytes } as DidComponents;
   }
 
   /**

--- a/packages/method/tests/decode-identifier.spec.ts
+++ b/packages/method/tests/decode-identifier.spec.ts
@@ -1,20 +1,205 @@
 import { bytesToHex } from '@noble/hashes/utils';
+import { bech32m, hex } from '@scure/base';
 import { expect } from 'chai';
 import { Identifier } from '../src/index.js';
 import data from './data/decode-data.js';
 
-/**
- * Decode Identifier Test Cases
- */
+const validKeyBytes = hex.decode('02cb42563b126085e1fea427331583bd69ed87057ea9524a6221272469c8d4c000');
+const validHashBytes = hex.decode('be0db3aeee89da24d50112af74f40c6a27f84fd3ef1a280647f5448f4daf11b1');
+
+// Forge a did:btcr2 identifier by hand. Useful for negative tests where we need
+// to drive specific byte/nibble values that the encoder would never produce.
+function forge(hrp: 'k' | 'x', firstByte: number, tail: Uint8Array): string {
+  const dataBytes = new Uint8Array([firstByte, ...tail]);
+  return `did:btcr2:${bech32m.encodeFromBytes(hrp, dataBytes)}`;
+}
+
 describe('Decode Identifier', () => {
-  it('should properly decode each identifier into its respective components', () => {
-    for(const { did, components } of data) {
-      const decoded = Identifier.decode(did);
-      expect(decoded.hrp).to.equal(components.hrp);
-      expect(decoded.idType).to.equal(components.idType);
-      expect(decoded.version).to.equal(components.version);
-      expect(decoded.network).to.equal(components.network);
-      expect(bytesToHex(decoded.genesisBytes)).to.equal(components.genesisBytes);
-    }
+  describe('happy path', () => {
+    it('decodes each fixture into its expected components', () => {
+      for(const { did, components } of data) {
+        const decoded = Identifier.decode(did);
+        expect(decoded.hrp).to.equal(components.hrp);
+        expect(decoded.idType).to.equal(components.idType);
+        expect(decoded.version).to.equal(components.version);
+        expect(decoded.network).to.equal(components.network);
+        expect(bytesToHex(decoded.genesisBytes)).to.equal(components.genesisBytes);
+      }
+    });
+  });
+
+  describe('format validation', () => {
+    it('rejects strings without "did:" prefix', () => {
+      expect(() => Identifier.decode('btcr2:k1qqpvksjk8vfxpp0pl6jzwvc4sw7knmv8q4l2j5j2vgsjwfrfer2vqqqvgmw6r'))
+        .to.throw();
+    });
+
+    it('rejects unknown DID methods', () => {
+      expect(() => Identifier.decode('did:foo:k1qqpvksjk8vfxpp0pl6jzwvc4sw7knmv8q4l2j5j2vgsjwfrfer2vqqqvgmw6r'))
+        .to.throw(/method/i);
+    });
+
+    it('rejects identifiers with fewer than 3 colon-separated components', () => {
+      expect(() => Identifier.decode('did:btcr2')).to.throw();
+    });
+
+    it('rejects identifiers with empty method-specific-id', () => {
+      expect(() => Identifier.decode('did:btcr2:')).to.throw();
+    });
+
+    it('rejects malformed bech32m payloads', () => {
+      expect(() => Identifier.decode('did:btcr2:k1notavalidbech32m')).to.throw();
+    });
+  });
+
+  describe('hrp validation', () => {
+    it('rejects unknown hrp', () => {
+      // 'z' is not a valid hrp for did:btcr2
+      const forged = `did:btcr2:${bech32m.encodeFromBytes('z', new Uint8Array([0x00, ...validKeyBytes]))}`;
+      expect(() => Identifier.decode(forged)).to.throw(/hrp/i);
+    });
+  });
+
+  describe('btcr2_version validation', () => {
+    // The leading nibble (btcr2_version) MUST be 0. The previous decoder only checked the version inside
+    // a `while (nibble === 0xF)` loop, so a forged leading nibble of 0x1-0xE never tripped the guard and
+    // was silently accepted as a higher version. These tests pin the flat single-nibble check.
+
+    it('rejects btcr2_version 1 (first nibble 0x1, network nibble 0x0)', () => {
+      // byte 0 = 0x10  =>  btcr2_version=1, network_value=0
+      expect(() => Identifier.decode(forge('k', 0x10, validKeyBytes))).to.throw(/version/i);
+    });
+
+    it('rejects btcr2_version 2 (first nibble 0x2)', () => {
+      expect(() => Identifier.decode(forge('k', 0x20, validKeyBytes))).to.throw(/version/i);
+    });
+
+    it('rejects btcr2_version 0xE (first nibble 0xE)', () => {
+      expect(() => Identifier.decode(forge('k', 0xE0, validKeyBytes))).to.throw(/version/i);
+    });
+
+    it('rejects btcr2_version 0xF (first nibble 0xF)', () => {
+      // F is reserved for the future version-extension scheme; v1 rejects it.
+      expect(() => Identifier.decode(forge('k', 0xF0, validKeyBytes))).to.throw(/version/i);
+    });
+  });
+
+  describe('network_value validation', () => {
+    it('rejects reserved network_value 6', () => {
+      expect(() => Identifier.decode(forge('k', 0x06, validKeyBytes))).to.throw(/network/i);
+    });
+
+    it('rejects reserved network_value 7', () => {
+      expect(() => Identifier.decode(forge('k', 0x07, validKeyBytes))).to.throw(/network/i);
+    });
+
+    it('rejects reserved network_value 8', () => {
+      expect(() => Identifier.decode(forge('k', 0x08, validKeyBytes))).to.throw(/network/i);
+    });
+
+    it('rejects reserved network_value 11', () => {
+      expect(() => Identifier.decode(forge('k', 0x0B, validKeyBytes))).to.throw(/network/i);
+    });
+
+    it('rejects out-of-range network_value 15', () => {
+      expect(() => Identifier.decode(forge('k', 0x0F, validKeyBytes))).to.throw(/network/i);
+    });
+
+    it('accepts custom network_value 12 (returns numeric 1)', () => {
+      const decoded = Identifier.decode(forge('k', 0x0C, validKeyBytes));
+      expect(decoded.network).to.equal(1);
+    });
+
+    it('accepts custom network_value 13 (returns numeric 2)', () => {
+      const decoded = Identifier.decode(forge('k', 0x0D, validKeyBytes));
+      expect(decoded.network).to.equal(2);
+    });
+
+    it('accepts custom network_value 14 (returns numeric 3)', () => {
+      const decoded = Identifier.decode(forge('k', 0x0E, validKeyBytes));
+      expect(decoded.network).to.equal(3);
+    });
+  });
+
+  describe('genesisBytes validation', () => {
+    it('rejects KEY with non-pubkey trailing bytes', () => {
+      // 33 zero bytes - not a valid compressed pubkey (leading byte must be 0x02 or 0x03)
+      expect(() => Identifier.decode(forge('k', 0x00, new Uint8Array(33))))
+        .to.throw(/genesisBytes/i);
+    });
+
+    it('rejects KEY with too-short trailing bytes', () => {
+      expect(() => Identifier.decode(forge('k', 0x00, new Uint8Array(20))))
+        .to.throw(/genesisBytes/i);
+    });
+
+    it('accepts EXTERNAL with exact 32 trailing bytes', () => {
+      expect(() => Identifier.decode(forge('x', 0x00, validHashBytes))).to.not.throw();
+    });
+
+    it('rejects EXTERNAL with too-short trailing bytes (31)', () => {
+      expect(() => Identifier.decode(forge('x', 0x00, new Uint8Array(31))))
+        .to.throw(/genesisBytes/i);
+    });
+
+    it('rejects EXTERNAL with too-long trailing bytes (33)', () => {
+      expect(() => Identifier.decode(forge('x', 0x00, new Uint8Array(33))))
+        .to.throw(/genesisBytes/i);
+    });
+  });
+
+  describe('roundtrip', () => {
+    it('encode -> decode preserves components for every fixture', () => {
+      for(const { did, components } of data) {
+        const decoded = Identifier.decode(did);
+        expect(decoded.idType).to.equal(components.idType);
+        expect(decoded.version).to.equal(components.version);
+        expect(decoded.network).to.equal(components.network);
+        expect(bytesToHex(decoded.genesisBytes)).to.equal(components.genesisBytes);
+
+        // Re-encode the decoded components and verify we get the original DID back.
+        const reEncoded = Identifier.encode(decoded.genesisBytes, {
+          idType  : decoded.idType as 'KEY' | 'EXTERNAL',
+          version : decoded.version,
+          network : decoded.network as never,
+        });
+        expect(reEncoded).to.equal(did);
+      }
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns true for every valid fixture', () => {
+      for(const { did } of data) {
+        expect(Identifier.isValid(did)).to.equal(true);
+      }
+    });
+
+    it('returns false for malformed DIDs', () => {
+      expect(Identifier.isValid('not a did')).to.equal(false);
+      expect(Identifier.isValid('did:btcr2:')).to.equal(false);
+      expect(Identifier.isValid('did:foo:abcdef')).to.equal(false);
+    });
+
+    it('returns false for forged DIDs with btcr2_version != 0', () => {
+      expect(Identifier.isValid(forge('k', 0x10, validKeyBytes))).to.equal(false);
+    });
+
+    it('returns false for forged DIDs with reserved network_value', () => {
+      expect(Identifier.isValid(forge('k', 0x06, validKeyBytes))).to.equal(false);
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('extracts the compressed public key from a KEY DID', () => {
+      const keyDid = data.find(d => d.components.idType === 'KEY')!.did;
+      const pubkey = Identifier.getPublicKey(keyDid);
+      expect(pubkey.compressed.length).to.equal(33);
+    });
+
+    it('throws for EXTERNAL DIDs', () => {
+      const externalDid = data.find(d => d.components.idType === 'EXTERNAL')!.did;
+      expect(() => Identifier.getPublicKey(externalDid)).to.throw(/EXTERNAL/i);
+    });
   });
 });

--- a/packages/method/tests/encode-identifier.spec.ts
+++ b/packages/method/tests/encode-identifier.spec.ts
@@ -1,15 +1,133 @@
 import { expect } from 'chai';
+import { hex } from '@scure/base';
 import { Identifier } from '../src/index.js';
 import data from './data/encode-data.js';
 
-/**
- * Encode Identifier Test Cases
- */
+const validKeyBytes = hex.decode('02cb42563b126085e1fea427331583bd69ed87057ea9524a6221272469c8d4c000');
+const validHashBytes = hex.decode('be0db3aeee89da24d50112af74f40c6a27f84fd3ef1a280647f5448f4daf11b1');
+
 describe('Encode Identifier', () => {
-  it('should properly encode each components into the respective identifier', () => {
-    for(const { did, genesisBytes, options } of data) {
-      const encoded = Identifier.encode(genesisBytes, options);
-      expect(encoded).to.equal(did);
-    }
+  describe('happy path', () => {
+    it('encodes each fixture into its expected identifier string', () => {
+      for(const { did, genesisBytes, options } of data) {
+        expect(Identifier.encode(genesisBytes, options)).to.equal(did);
+      }
+    });
+  });
+
+  describe('idType validation', () => {
+    it('rejects lowercase "key"', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'key' as never, version : 1, network : 'bitcoin'
+      })).to.throw(/idType/i);
+    });
+
+    it('rejects unknown idType', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'INVALID' as never, version : 1, network : 'bitcoin'
+      })).to.throw(/idType/i);
+    });
+
+    it('rejects undefined idType', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : undefined as never, version : 1, network : 'bitcoin'
+      })).to.throw();
+    });
+  });
+
+  describe('version validation', () => {
+    it('rejects version 0', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 0, network : 'bitcoin'
+      })).to.throw(/version/i);
+    });
+
+    it('rejects version 2', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 2, network : 'bitcoin'
+      })).to.throw(/version/i);
+    });
+
+    it('rejects negative version', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : -1, network : 'bitcoin'
+      })).to.throw(/version/i);
+    });
+
+    it('rejects NaN version', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : NaN, network : 'bitcoin'
+      })).to.throw(/version/i);
+    });
+
+    it('rejects non-numeric version', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : '1' as never, network : 'bitcoin'
+      })).to.throw(/version/i);
+    });
+  });
+
+  describe('network validation', () => {
+    it('rejects unknown network name', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 1, network : 'unknown' as never
+      })).to.throw(/network/i);
+    });
+
+    it('defaults undefined network to bitcoin', () => {
+      // network is optional at the encoder layer and defaults to "bitcoin", matching DidBtcr2.create.
+      const withUndefined = Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 1, network : undefined as never
+      });
+      const withBitcoin = Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 1, network : 'bitcoin'
+      });
+      expect(withUndefined).to.equal(withBitcoin);
+    });
+
+    it('rejects null network', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 1, network : null as never
+      })).to.throw(/network/i);
+    });
+
+    it('rejects empty string network', () => {
+      expect(() => Identifier.encode(validKeyBytes, {
+        idType : 'KEY', version : 1, network : '' as never
+      })).to.throw(/network/i);
+    });
+  });
+
+  describe('genesisBytes validation', () => {
+    it('rejects KEY with wrong-length bytes', () => {
+      expect(() => Identifier.encode(new Uint8Array(32), {
+        idType : 'KEY', version : 1, network : 'bitcoin'
+      })).to.throw(/compressed secp256k1/i);
+    });
+
+    it('rejects KEY with bytes that are not a valid compressed pubkey', () => {
+      // 33 bytes of zeros - wrong leading byte (must be 0x02 or 0x03)
+      expect(() => Identifier.encode(new Uint8Array(33), {
+        idType : 'KEY', version : 1, network : 'bitcoin'
+      })).to.throw(/compressed secp256k1/i);
+    });
+
+    it('rejects EXTERNAL with non-32-byte bytes (too short)', () => {
+      expect(() => Identifier.encode(new Uint8Array(31), {
+        idType : 'EXTERNAL', version : 1, network : 'bitcoin'
+      })).to.throw(/32-byte/i);
+    });
+
+    it('rejects EXTERNAL with non-32-byte bytes (too long)', () => {
+      expect(() => Identifier.encode(new Uint8Array(33), {
+        idType : 'EXTERNAL', version : 1, network : 'bitcoin'
+      })).to.throw(/32-byte/i);
+    });
+
+    it('accepts EXTERNAL with exact 32 bytes', () => {
+      expect(() => Identifier.encode(validHashBytes, {
+        idType : 'EXTERNAL', version : 1, network : 'bitcoin'
+      })).to.not.throw();
+    });
   });
 });


### PR DESCRIPTION
* chore(release): bump method 0.49.0, api 0.13.8, cli 0.12.13
* fix(method): harden Identifier encode/decode and reject forged btcr2_version
* docs(adr): add ADR 062 (identifier encoding/decoding hardening)