### PR TITLE
harden beacon UTXO selection to confirmed, non-dust, deepest-first

### DIFF
--- a/docs/adr/063-beacon-utxo-selection-hardening.md
+++ b/docs/adr/063-beacon-utxo-selection-hardening.md
@@ -1,0 +1,163 @@
+---
+title: "ADR 063: Harden Beacon UTXO Selection (Confirmed, Non-Dust, Deepest-First, Deterministic)"
+---
+
+# ADR 063: Harden Beacon UTXO Selection (Confirmed, Non-Dust, Deepest-First, Deterministic)
+
+**Status:** Accepted
+
+**Date:** 2026-07-01
+
+**Branch / PR:** `fix/beacon-utxo-selection`
+
+**References:** [ADR 018](018-beacon-hierarchy.md), [ADR 037](037-single-party-beacon-and-two-axis-model.md), [ADR 044](044-beacon-change-output-address.md), [ADR 056](056-beacon-signal-format-validation.md)
+
+## Context
+
+Every beacon broadcast, single-party and aggregated, funds its signal transaction from a
+UTXO at the beacon address. That input was chosen by an internal helper,
+`fetchSpendableUtxo` (`packages/method/src/core/beacon/beacon.ts`), shared by
+`SinglePartyBeacon.buildSignAndBroadcast` and `buildAggregationBeaconTx`. It selected the
+input like this:
+
+```ts
+const utxos = await bitcoin.rest.address.getUtxos(bitcoinAddress);
+if (!utxos.length) throw new BeaconError('No UTXOs found, please fund address!', 'UNFUNDED_BEACON_ADDRESS', ...);
+const utxo = utxos.sort((a, b) => b.status.block_height - a.status.block_height).shift();
+```
+
+This picks the **newest** confirmed-or-unconfirmed UTXO (highest block height first) and has
+three problems:
+
+1. **It can spend an unconfirmed UTXO.** The Esplora `getUtxos` response includes UTXOs still
+   in the mempool (`status.confirmed === false`). A signal built on an unconfirmed input can be
+   orphaned by a reorg or invalidated by an RBF replacement of the parent, silently un-anchoring
+   the beacon transaction. Nothing filtered these out. The helper's own JSDoc claimed it returned
+   "the most recent confirmed UTXO," which the code did not actually do.
+2. **It is non-deterministic.** `sort` by block height alone leaves ties (multiple UTXOs in the
+   same block, common when an address is funded and used repeatedly) in whatever order the REST
+   API happened to return them, and "newest first" changes every time a newer UTXO appears. Two
+   independent callers, or the same caller on a retry, could pick different inputs for the same
+   address state. For a system whose value proposition is reproducible, verifiable resolution,
+   input selection should be a pure function of the address's UTXO set.
+3. **It can select a dust UTXO.** A trivially small output (for example the residue of a prior
+   change output) could be the newest UTXO and would be selected, then rejected downstream by the
+   `value <= feeSats` fee check, even when a larger, older, spendable UTXO was available.
+
+### Specification position
+
+The did:btcr2 specification is silent on beacon UTXO selection and on any confirmation-depth
+requirement. This was verified against the beacon construction text (`src/beacons.md`), the
+update / broadcast algorithms (`src/operations/update.md`), and the security considerations
+(`src/appendix/security-considerations.md`). Only the security considerations touch the subject,
+and only to observe that deeper confirmations reduce reorg risk; they set no rule and mandate no
+depth. Selection is therefore an implementation policy decision, made here for safety and
+reproducibility, not a conformance requirement. (Per the project's source-of-truth convention,
+a policy is chosen locally only where the specification is genuinely silent.)
+
+## Decision
+
+### Extract a pure, exported `selectSpendableUtxo`
+
+Selection moves out of the I/O helper into a pure function
+`selectSpendableUtxo(utxos, address?): AddressUtxo`, alongside the already-exported
+`beaconTxVsize` and `resolveChangeAddress`. `fetchSpendableUtxo` now only performs I/O (fetch
+the UTXO set, then fetch the chosen UTXO's parent transaction) and delegates the choice. The pure
+function is directly unit-testable with crafted arrays, no Bitcoin mock required, and is the unit
+the regression net exercises.
+
+### Require at least one confirmation
+
+`selectSpendableUtxo` keeps only UTXOs with `status.confirmed === true` (a strict equality, so a
+UTXO with the flag absent, as Esplora returns for mempool entries, is treated as unconfirmed). A
+fixed one-confirmation floor, not a configurable depth, is the meaningful safety line: it is the
+boundary between "can be reorganised or RBF-replaced out of existence" and "is in a block." A
+deeper, tunable policy is deliberately not added (see rejected alternatives).
+
+### Filter dust with a fixed, conservative floor
+
+UTXOs at or below `SPENDABLE_DUST_LIMIT_SATS` are discarded. This is a **new** exported constant
+set to 546, the standard Bitcoin Core P2PKH dust threshold and the largest of the three singleton
+beacon script kinds' dust limits (P2PKH 546, P2TR 330, P2WPKH 294), so a surviving UTXO is
+non-dust under any beacon address kind. It is a coarse, script-kind-agnostic, fee-estimator-
+independent pre-filter that skips trivially small inputs so selection can find a usable one rather
+than fixating on a dust output; it is **not** the fee-coverage boundary. Whether a selected UTXO
+actually covers the transaction fee remains a separate check against the live `FeeEstimator`, the
+`value <= feeSats` guard in `buildSinglePartyTx` and `buildAggregationBeaconTx`, which is
+unchanged. At the default 5 sat/vB rate that fee (roughly 775 to 1200 sats across the three
+kinds) sits above the dust floor, so the two checks are independent by design.
+
+The pre-existing per-kind `DUST_LIMIT_SATS` record is left untouched; it sizes the *outgoing
+change output* by script kind (ADR 044) and is a different concern from bounding the *incoming*
+funding UTXO. The new scalar is named `SPENDABLE_DUST_LIMIT_SATS` to keep the two distinct rather
+than overloading one symbol.
+
+### Select deepest-first, deterministically
+
+Among the confirmed, non-dust survivors, selection sorts by ascending `block_height` (so the
+most-confirmed UTXO comes first), breaking ties by ascending `txid` (`localeCompare`) and then by
+ascending `vout`. The result is both the safest input (maximum confirmations) and a total,
+stable order: the same address state always yields the same input, independent of REST response
+ordering, across retries and across independent resolvers. The function copies the array before
+sorting, so the caller's array is not mutated.
+
+### Distinguish "no spendable UTXO" from "unfunded"
+
+An empty UTXO set still throws `BeaconError` with type `UNFUNDED_BEACON_ADDRESS` ("please fund
+address"). A non-empty set with no confirmed, non-dust survivor throws a **new** type,
+`NO_SPENDABLE_BEACON_UTXO`, whose message distinguishes the all-unconfirmed case from the
+all-dust case and whose data carries the counts (`total`, `confirmed`, `dustLimit`). This
+replaces the prior code's second, misleadingly-typed `UNFUNDED_BEACON_ADDRESS` throw
+("Beacon bitcoin address unfunded or utxos unconfirmed"), which conflated "you have no money"
+with "your money is not yet spendable." `BeaconError.type` is a freeform string, so no error-type
+union changes.
+
+### Treat the change as a breaking, minor-version change
+
+The helper now rejects inputs it previously accepted: an unconfirmed UTXO, or a UTXO at or below
+the dust floor, that the old code would have selected now yields a thrown `BeaconError` instead of
+a (frequently doomed) broadcast attempt. Under 0.x semantics (breaking changes signalled by a
+minor bump) and the precedent of prior beacon and validation-tightening ADRs, `@did-btcr2/method`
+takes a minor bump and this ADR serves as the release note.
+
+## Consequences
+
+- Beacon broadcasts no longer build on unconfirmed inputs, removing a reorg / RBF hazard that
+  could silently un-anchor a signal.
+- Input selection is a pure, deterministic function of the address's UTXO set. Retries and
+  independent resolvers converge on the same input; selection is now unit-testable without a
+  Bitcoin mock.
+- A caller whose beacon address holds only unconfirmed UTXOs, or only dust, now receives an
+  explicit `NO_SPENDABLE_BEACON_UTXO` error (with the reason and counts) instead of a newest-first
+  pick that fails later, or a mis-typed "unfunded" error. A genuinely empty address still reports
+  `UNFUNDED_BEACON_ADDRESS`.
+- `selectSpendableUtxo` and `SPENDABLE_DUST_LIMIT_SATS` become part of the package's public
+  surface (via the existing `export *` barrel), giving callers a reusable, testable selector and a
+  named dust floor.
+- The dust floor is a coarse pre-filter, independent of the fee estimator; the actual fee-coverage
+  decision is unchanged and still lives in the transaction builders.
+- The aggregation broadcast path (`buildAggregationBeaconTx`) inherits the same hardened selection
+  for free, since it shares `fetchSpendableUtxo`.
+
+## Rejected alternatives
+
+- **A configurable confirmation depth (N-confirmations).** The specification mandates no depth,
+  and the security-relevant threshold is the step from zero to one confirmation (mempool to
+  block). A tunable depth adds API surface and a policy question the method layer should not own; a
+  caller that wants a deeper floor can source or pre-filter UTXOs itself. One confirmation is the
+  right default and the right fixed rule here.
+- **Newest-first or largest-first selection.** Newest-first is what the code did and is
+  non-reproducible (a newer UTXO changes the choice) and links each spend to the freshest change
+  output. Largest-first optimises fee headroom but is likewise unstable under ties and unrelated to
+  safety. Deepest-first maximises confirmations (the safest input) and, with the txid/vout
+  tie-break, is fully deterministic.
+- **Reusing the per-kind `DUST_LIMIT_SATS` record for input filtering.** That record is keyed by
+  the *change output's* script kind and encodes a different decision (whether to emit change).
+  Selection is kind-agnostic (it sees only `value`), so a single conservative scalar, the largest
+  of the three limits, is clearer and guarantees the survivor is non-dust under any beacon kind.
+  Overloading one symbol for both the incoming-UTXO floor and the outgoing-change floor would
+  couple two unrelated policies.
+- **No dust filter, relying solely on the downstream fee check.** Without an upfront skip, a
+  deepest dust UTXO would be selected and the broadcast would throw `INSUFFICIENT_FUNDS` even when
+  a shallower, spendable UTXO existed at the same address. The dust filter lets selection pass over
+  trivially small inputs and find a usable one.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -63,6 +63,7 @@ children:
   - ./060-resolver-cross-round-version-continuity.md
   - ./061-remove-dead-document-class.md
   - ./062-identifier-encoding-hardening.md
+  - ./063-beacon-utxo-selection-hardening.md
 ---
 
 # Architecture Decision Records
@@ -133,3 +134,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 060 | 2026-06-29 | [Carry the Version Counter and Update-Hash History Across Resolver Discovery Rounds](060-resolver-cross-round-version-continuity.md) |
 | 061 | 2026-06-30 | [Remove the Unused Public Document Wrapper Class](061-remove-dead-document-class.md) |
 | 062 | 2026-06-30 | [Harden did:btcr2 Identifier Encoding and Decoding](062-identifier-encoding-hardening.md) |
+| 063 | 2026-07-01 | [Harden Beacon UTXO Selection (Confirmed, Non-Dust, Deepest-First, Deterministic)](063-beacon-utxo-selection-hardening.md) |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.8",
+    "version": "0.13.9",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.49.0",
+    "version": "0.50.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -229,27 +229,97 @@ export function opReturnScript(signalBytes: Uint8Array): Uint8Array {
 }
 
 /**
- * Fetch the most recent confirmed UTXO at `bitcoinAddress` + the raw bytes of its
- * parent transaction (needed by PSBT inputs). Throws if unfunded.
+ * Minimum value (sats) a beacon UTXO must exceed for {@link selectSpendableUtxo} to
+ * treat it as spendable. This is a fixed, conservative, script-kind-agnostic floor:
+ * an output at or below it is too small to be worth spending, so selection discards
+ * it in favor of a larger confirmed UTXO. Keeping the floor a constant (rather than
+ * deriving it from a fee estimate) keeps selection pure and fee-estimator-independent.
+ *
+ * The floor is a coarse pre-filter, not the fee-coverage boundary: whether a selected
+ * UTXO actually covers the transaction fee is a separate check, enforced against the
+ * live {@link FeeEstimator} by the builders' `value <= feeSats` guard
+ * ({@link SinglePartyBeacon.buildSinglePartyTx} and {@link buildAggregationBeaconTx}).
+ * At the default 5 sat/vB rate that fee (roughly 775 to 1200 sats across the three
+ * script kinds) sits above this floor, so a UTXO can clear the dust filter and still
+ * be rejected as insufficient; conversely, at a very low fee rate an output near the
+ * floor could cover the fee. The floor's job is only to skip trivially small inputs.
+ *
+ * The value is the standard Bitcoin Core P2PKH dust threshold, the largest of the
+ * three singleton beacon script kinds (P2PKH 546, P2TR 330, P2WPKH 294 per
+ * {@link DUST_LIMIT_SATS}): a UTXO above it is non-dust under any beacon address kind.
+ * Distinct from {@link DUST_LIMIT_SATS}, which sizes the outgoing change output by
+ * kind; this bounds the incoming UTXO chosen to fund the transaction.
+ */
+export const SPENDABLE_DUST_LIMIT_SATS = 546;
+
+/**
+ * Deterministic ordering for spendable UTXO selection: deepest first (ascending
+ * block height, so the most-confirmed UTXO sorts first), tie-broken by `txid` then
+ * `vout`. The tie-break makes the winner independent of the order the REST API
+ * returns UTXOs in, so retries and independent resolvers converge on the same input.
+ */
+function byDepthThenId(a: AddressUtxo, b: AddressUtxo): number {
+  if(a.status.block_height !== b.status.block_height) {
+    return a.status.block_height - b.status.block_height;
+  }
+  const txidOrder = a.txid.localeCompare(b.txid);
+  return txidOrder !== 0 ? txidOrder : a.vout - b.vout;
+}
+
+/**
+ * Select the beacon UTXO to fund a signal transaction from the set of UTXOs at a
+ * beacon address. Pure and deterministic: the same address state always yields the
+ * same input, across broadcast retries and across independent resolvers.
+ *
+ * Filters to confirmed UTXOs (an unconfirmed input is reorg- and RBF-unsafe: a
+ * signal built on it can be orphaned or double-spent before it confirms), then drops
+ * dust at or below {@link SPENDABLE_DUST_LIMIT_SATS}, then picks the deepest via
+ * {@link byDepthThenId}. The did:btcr2 spec does not mandate a selection rule or a
+ * confirmation depth (only the security considerations favor deeper confirmations),
+ * so this is an implementation policy: prefer safety and reproducibility over
+ * spending the newest or largest output.
+ *
+ * @param utxos UTXOs reported at the beacon address.
+ * @param address Beacon address, used only to annotate thrown errors.
+ * @returns The confirmed, non-dust, deepest UTXO.
+ * @throws {BeaconError} `UNFUNDED_BEACON_ADDRESS` when no UTXOs exist at all;
+ *   `NO_SPENDABLE_BEACON_UTXO` when UTXOs exist but none are both confirmed and above
+ *   the dust limit (the message distinguishes all-unconfirmed from all-dust).
+ */
+export function selectSpendableUtxo(utxos: Array<AddressUtxo>, address?: string): AddressUtxo {
+  if(!utxos.length) {
+    throw new BeaconError(
+      'No UTXOs found, please fund address!',
+      'UNFUNDED_BEACON_ADDRESS', { address }
+    );
+  }
+  const confirmed = utxos.filter(utxo => utxo.status.confirmed === true);
+  const spendable = confirmed.filter(utxo => utxo.value > SPENDABLE_DUST_LIMIT_SATS);
+  if(!spendable.length) {
+    const reason = confirmed.length === 0
+      ? `all ${utxos.length} UTXO(s) are unconfirmed`
+      : `all ${confirmed.length} confirmed UTXO(s) are at or below the ${SPENDABLE_DUST_LIMIT_SATS}-sat dust limit`;
+    throw new BeaconError(
+      `No spendable UTXO at beacon address: ${reason}.`,
+      'NO_SPENDABLE_BEACON_UTXO',
+      { address, total: utxos.length, confirmed: confirmed.length, dustLimit: SPENDABLE_DUST_LIMIT_SATS }
+    );
+  }
+  return [ ...spendable ].sort(byDepthThenId)[0]!;
+}
+
+/**
+ * Fetch the deepest confirmed, non-dust spendable UTXO at `bitcoinAddress` plus the
+ * raw bytes of its parent transaction (needed by PSBT inputs). Selection is delegated
+ * to {@link selectSpendableUtxo}; throws {@link BeaconError} when the address is
+ * unfunded or has no confirmed, non-dust UTXO.
  */
 async function fetchSpendableUtxo(
   bitcoinAddress: string,
   bitcoin: BitcoinConnection,
 ): Promise<{ utxo: AddressUtxo; prevTxBytes: Uint8Array }> {
   const utxos = await bitcoin.rest.address.getUtxos(bitcoinAddress);
-  if(!utxos.length) {
-    throw new BeaconError(
-      'No UTXOs found, please fund address!',
-      'UNFUNDED_BEACON_ADDRESS', { address: bitcoinAddress }
-    );
-  }
-  const utxo = utxos.sort((a, b) => b.status.block_height - a.status.block_height).shift();
-  if(!utxo) {
-    throw new BeaconError(
-      'Beacon bitcoin address unfunded or utxos unconfirmed.',
-      'UNFUNDED_BEACON_ADDRESS', { address: bitcoinAddress }
-    );
-  }
+  const utxo = selectSpendableUtxo(utxos, bitcoinAddress);
   const prevTxHex = await bitcoin.rest.transaction.getHex(utxo.txid);
   return { utxo, prevTxBytes: hexToBytes(prevTxHex) };
 }

--- a/packages/method/tests/beacon-change-output.spec.ts
+++ b/packages/method/tests/beacon-change-output.spec.ts
@@ -30,7 +30,7 @@ function mockBitcoin(beaconAddress: string, value: number): BitcoinConnection {
   prevTx.addOutput({ amount: BigInt(value), script: beaconScript });
   prevTx.addInput({ txid: new Uint8Array(32), index: 0xffffffff, finalScriptSig: new Uint8Array([0x00]) });
   const prevTxBytes = prevTx.toBytes();
-  const utxo: AddressUtxo = { txid: prevTx.id, vout: 0, value, status: { block_height: 100 } as never };
+  const utxo: AddressUtxo = { txid: prevTx.id, vout: 0, value, status: { confirmed: true, block_height: 100 } as never };
   return {
     data : network,
     rest : {

--- a/packages/method/tests/beacon-utxo-selection.spec.ts
+++ b/packages/method/tests/beacon-utxo-selection.spec.ts
@@ -1,0 +1,151 @@
+import type { AddressUtxo } from '@did-btcr2/bitcoin';
+import { expect } from 'chai';
+import { selectSpendableUtxo, SPENDABLE_DUST_LIMIT_SATS } from '../src/core/beacon/beacon.js';
+
+/**
+ * Build an AddressUtxo carrying only the fields selection reads (txid, vout, value,
+ * status.confirmed, status.block_height). block_hash / block_time are unused here.
+ */
+function utxo(opts: {
+  txid?: string;
+  vout?: number;
+  value?: number;
+  confirmed?: boolean;
+  height?: number;
+}): AddressUtxo {
+  return {
+    txid   : opts.txid ?? 'a'.repeat(64),
+    vout   : opts.vout ?? 0,
+    value  : opts.value ?? 100_000,
+    status : {
+      confirmed    : opts.confirmed ?? true,
+      block_height : opts.height ?? 100,
+    },
+  } as unknown as AddressUtxo;
+}
+
+/** Return every permutation of an array (small inputs only). */
+function permutations<T>(items: Array<T>): Array<Array<T>> {
+  if(items.length <= 1) return [ items ];
+  const out: Array<Array<T>> = [];
+  for(let i = 0; i < items.length; i++) {
+    const rest = [ ...items.slice(0, i), ...items.slice(i + 1) ];
+    for(const p of permutations(rest)) out.push([ items[i]!, ...p ]);
+  }
+  return out;
+}
+
+describe('selectSpendableUtxo', () => {
+  describe('confirmation filter', () => {
+    it('ignores unconfirmed UTXOs even when they are deeper or larger', () => {
+      const unconfirmedDeep = utxo({ txid: 'b'.repeat(64), height: 1, value: 1_000_000, confirmed: false });
+      const confirmed = utxo({ txid: 'c'.repeat(64), height: 500, value: 10_000, confirmed: true });
+      expect(selectSpendableUtxo([ unconfirmedDeep, confirmed ])).to.equal(confirmed);
+    });
+
+    it('treats a missing confirmed flag as unconfirmed (strict === true)', () => {
+      // Esplora omits block fields on unconfirmed UTXOs; a missing flag is not spendable.
+      const noFlag = { txid: 'd'.repeat(64), vout: 0, value: 100_000, status: { block_height: 100 } } as unknown as AddressUtxo;
+      expect(() => selectSpendableUtxo([ noFlag ])).to.throw(/unconfirmed/);
+    });
+  });
+
+  describe('dust filter', () => {
+    it('excludes a UTXO exactly at the dust limit and includes one just above it', () => {
+      const atLimit = utxo({ txid: 'a'.repeat(64), value: SPENDABLE_DUST_LIMIT_SATS });
+      const aboveLimit = utxo({ txid: 'b'.repeat(64), value: SPENDABLE_DUST_LIMIT_SATS + 1 });
+      expect(selectSpendableUtxo([ atLimit, aboveLimit ])).to.equal(aboveLimit);
+    });
+
+    it('prefers a deeper non-dust UTXO over a dust UTXO that is deeper still', () => {
+      const dustDeepest = utxo({ txid: 'a'.repeat(64), height: 1, value: SPENDABLE_DUST_LIMIT_SATS });
+      const spendable = utxo({ txid: 'b'.repeat(64), height: 50, value: 100_000 });
+      expect(selectSpendableUtxo([ dustDeepest, spendable ])).to.equal(spendable);
+    });
+  });
+
+  describe('deepest-first ordering', () => {
+    it('picks the lowest block height (most confirmations)', () => {
+      const shallow = utxo({ txid: 'a'.repeat(64), height: 900 });
+      const deep = utxo({ txid: 'b'.repeat(64), height: 100 });
+      const mid = utxo({ txid: 'c'.repeat(64), height: 500 });
+      expect(selectSpendableUtxo([ shallow, deep, mid ])).to.equal(deep);
+    });
+
+    it('breaks a block-height tie by ascending txid', () => {
+      const higherTxid = utxo({ txid: 'f'.repeat(64), height: 100, vout: 0 });
+      const lowerTxid = utxo({ txid: '0'.repeat(64), height: 100, vout: 0 });
+      expect(selectSpendableUtxo([ higherTxid, lowerTxid ])).to.equal(lowerTxid);
+    });
+
+    it('breaks a height + txid tie by ascending vout', () => {
+      const sameTxid = 'a'.repeat(64);
+      const vout2 = utxo({ txid: sameTxid, height: 100, vout: 2 });
+      const vout0 = utxo({ txid: sameTxid, height: 100, vout: 0 });
+      expect(selectSpendableUtxo([ vout2, vout0 ])).to.equal(vout0);
+    });
+
+    it('is deterministic across every input ordering', () => {
+      const a = utxo({ txid: 'a'.repeat(64), height: 100, vout: 1, value: 100_000 });
+      const b = utxo({ txid: 'a'.repeat(64), height: 100, vout: 0, value: 200_000 });
+      const c = utxo({ txid: 'b'.repeat(64), height: 100, vout: 0, value: 300_000 });
+      const d = utxo({ txid: 'c'.repeat(64), height: 50, vout: 5, value: 500 }); // dust, excluded
+      const e = utxo({ txid: 'd'.repeat(64), height: 300, vout: 0, value: 999_999 });
+      // Winner is b: deepest tier (height 100) shared with a/c; txid 'aaaa' < 'bbbb', vout 0 < 1.
+      for(const order of permutations([ a, b, c, d, e ])) {
+        expect(selectSpendableUtxo(order)).to.equal(b);
+      }
+    });
+
+    it('does not mutate the caller-supplied array order', () => {
+      const first = utxo({ txid: 'z'.repeat(64), height: 900 });
+      const second = utxo({ txid: 'a'.repeat(64), height: 100 });
+      const input = [ first, second ];
+      selectSpendableUtxo(input);
+      expect(input[0]).to.equal(first);
+      expect(input[1]).to.equal(second);
+    });
+  });
+
+  describe('error cases', () => {
+    it('throws UNFUNDED_BEACON_ADDRESS on an empty UTXO set', () => {
+      try {
+        selectSpendableUtxo([], 'bc1qbeacon');
+        expect.fail('expected selectSpendableUtxo to throw');
+      } catch(err) {
+        expect((err as { type: string }).type).to.equal('UNFUNDED_BEACON_ADDRESS');
+        expect((err as { data: { address: string } }).data.address).to.equal('bc1qbeacon');
+      }
+    });
+
+    it('throws NO_SPENDABLE_BEACON_UTXO naming unconfirmed when every UTXO is unconfirmed', () => {
+      const utxos = [
+        utxo({ txid: 'a'.repeat(64), confirmed: false, value: 100_000 }),
+        utxo({ txid: 'b'.repeat(64), confirmed: false, value: 200_000 }),
+      ];
+      try {
+        selectSpendableUtxo(utxos, 'bc1qbeacon');
+        expect.fail('expected selectSpendableUtxo to throw');
+      } catch(err) {
+        expect((err as { type: string }).type).to.equal('NO_SPENDABLE_BEACON_UTXO');
+        expect((err as Error).message).to.match(/unconfirmed/);
+        expect((err as { data: { confirmed: number } }).data.confirmed).to.equal(0);
+      }
+    });
+
+    it('throws NO_SPENDABLE_BEACON_UTXO naming dust when every confirmed UTXO is dust', () => {
+      const utxos = [
+        utxo({ txid: 'a'.repeat(64), confirmed: true, value: SPENDABLE_DUST_LIMIT_SATS }),
+        utxo({ txid: 'b'.repeat(64), confirmed: true, value: 100 }),
+      ];
+      try {
+        selectSpendableUtxo(utxos, 'bc1qbeacon');
+        expect.fail('expected selectSpendableUtxo to throw');
+      } catch(err) {
+        expect((err as { type: string }).type).to.equal('NO_SPENDABLE_BEACON_UTXO');
+        expect((err as Error).message).to.match(/dust limit/);
+        expect((err as { data: { confirmed: number } }).data.confirmed).to.equal(2);
+      }
+    });
+  });
+});


### PR DESCRIPTION
* chore(release): bump method 0.50.0, api 0.13.9, cli 0.12.14
* test(method): cover selectSpendableUtxo confirmation/dust filters, ordering, and error cases
* fix(method): select confirmed, non-dust beacon UTXOs deepest-first and deterministically
* docs(adr): add ADR 063 (beacon UTXO selection hardening)