### PR TITLE
authenticate x1 DIDs on the aggregation HTTP transport

### DIFF
--- a/docs/adr/066-x1-transport-authentication.md
+++ b/docs/adr/066-x1-transport-authentication.md
@@ -1,0 +1,334 @@
+---
+title: "ADR 066: Trustless Transport Authentication for EXTERNAL (x1) DIDs via In-Band Genesis Documents"
+---
+
+# ADR 066: Trustless Transport Authentication for EXTERNAL (x1) DIDs via In-Band Genesis Documents
+
+**Status:** Accepted
+
+**Date:** 2026-07-02
+
+**Branch / PR:** `feat/x1-k1-transport-auth`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 028](028-http-transport-additive.md), [ADR 046](046-extract-aggregation-package.md), [ADR 050](050-split-aggregation-packages.md), [ADR 051](051-update-verifies-signing-key.md), [ADR 054](054-cryptosuite-method-agnostic.md), [ADR 062](062-identifier-encoding-hardening.md)
+
+## Context
+
+An aggregation cohort is a set of DID controllers who coordinate a single on-chain
+beacon transaction. To join a cohort over a transport that authenticates inbound
+messages (today, HTTP/REST), a participant sends a signed opt-in envelope, and the
+service verifies that envelope against a communication public key it resolves from the
+participant's DID.
+
+did:btcr2 has two identifier types (ADR 062). A **KEY** (`k1`) identifier is a Bech32m
+encoding of a 33-byte compressed secp256k1 public key: the DID string *is* the key. An
+**EXTERNAL** (`x1`) identifier is a Bech32m encoding of the SHA-256 hash of a genesis DID
+document: the DID string is a cryptographic commitment to a document, not a key.
+
+The HTTP transport resolves the sender key through an injected callback that method
+supplies, `resolveBtcr2SenderPk` (`packages/method/src/core/did-sender-resolver.ts`). That
+callback only handled the KEY case:
+
+```ts
+const components = Identifier.decode(did);
+if (components.idType === 'KEY') {
+  return new CompressedSecp256k1PublicKey(components.genesisBytes); // k1: DID is the key
+}
+return undefined; // x1: genesisBytes are a document hash, not a key
+```
+
+For an `x1` sender the callback returns `undefined`, so
+`HttpServerTransport.#handleMessagesPost` rejects the opt-in `401 unknown_sender` before
+any handler runs. The service *does* already learn a participant's communication key from
+the opt-in body and register it (`service-runner.ts`, `registerPeer(msg.from,
+optIn.communicationPk)`), but that code never executes for an `x1` sender because the
+envelope is rejected before the runner sees it. This is a chicken-and-egg deadlock: the
+peer registry is populated from the opt-in, but the opt-in cannot be authenticated until
+the registry is populated.
+
+The functional requirement is that **both `k1` and `x1` identifiers participate as
+first-class cohort members over every transport** (`http`, `nostr`, `in-memory`, and any
+future transport). Today only `k1` works over HTTP.
+
+### Why the gap is HTTP-specific
+
+`NostrTransport` never resolves `did -> pk` to authenticate inbound messages: each message
+is a self-signed Nostr event, authenticity rides the event signature, and the DID is merely
+asserted in the content. Its peer registry is used only to encrypt and route outbound
+messages, so the population timing does not gate authentication. `in-memory` enforces no
+inbound auth at all. The HTTP transport made the opposite, stricter choice (verify a
+detached envelope against a resolved key), which is why only it rejects an unregistered
+`x1` sender. The fix targets how and when the peer registry is populated, and trusted, for
+`x1` senders on transports that authenticate inbound.
+
+### The insight that makes a trustless fix possible
+
+An `x1` DID is a commitment to its genesis document: `x1 = bech32m('x', [versionNetworkByte,
+...sha256(canonical genesis document)])` (`Identifier.encode`, EXTERNAL branch). A genesis
+document supplied by an untrusted party is therefore **self-verifying**: recompute its
+canonical SHA-256 hash and compare to the `genesisBytes` decoded from the DID; if they
+match, the document authentically belongs to that DID. The genesis document declares the
+DID's verification methods, so the authoritative communication key can be extracted from it
+with zero trust, exactly as a `k1` key is extracted from the DID string with zero trust.
+This means no trust-on-first-use is needed. Two things are required: (a) get the `x1`
+controller's genesis document to the verifier, and (b) define which verification method in
+it is the communication key.
+
+## Decision
+
+Keep `k1` behavior byte-identical. Add an `x1` path that is trustless and backward-compatible.
+The design is captured by four locked decisions (labelled A through D, from the source
+specification) plus the implementation-level decisions this ADR records (D1 through D9).
+
+### A. Synchronous, genesis-in-hand sender resolution (`@did-btcr2/method`)
+
+`resolveBtcr2SenderPk` gains an optional second parameter and stays synchronous:
+
+```ts
+export function resolveBtcr2SenderPk(
+  did: string,
+  opts?: { genesisDocument?: object },
+): CompressedSecp256k1PublicKey | undefined;
+```
+
+- `k1`: unchanged. The genesis document is ignored; the key is decoded from the DID.
+- `x1`: if `opts.genesisDocument` is supplied and it hashes to the DID, return the
+  designated communication verification method's public key (rule B). Otherwise
+  `undefined`, which preserves the exact one-argument behavior when no genesis is supplied.
+
+The hash check and document resolution reuse `Resolver.external(Identifier.decode(did),
+genesisDocument)` verbatim (D3): that method already recomputes `canonicalHashBytes(genesis)`,
+compares it to the identifier's `genesisBytes` with `equalBytes` (throwing on mismatch),
+re-encodes the DID, and returns a resolved `DidDocument` with the `did:btcr2:_` placeholder
+replaced by the absolute DID (so string references in `capabilityInvocation` become absolute
+verification-method ids). Any throw from that path is caught and mapped to `undefined`, so a
+mismatched or malformed genesis behaves exactly like "no genesis supplied."
+
+A genesis-*fetching* resolver (one that resolves the DID or reads a store to obtain the
+genesis itself) is deliberately deferred: the genesis is always carried in-band on the
+opt-in (decision C), so the resolver is handed the bytes and never performs I/O. Keeping it
+synchronous means no change to the existing synchronous `#resolveSenderPk` call sites.
+
+### B. The communication key is `capabilityInvocation[0]`
+
+The aggregation communication key for a DID is the verification method referenced by
+`capabilityInvocation[0]`, resolved to its public key. For `k1` the deterministic document's
+single key is already the sole `capabilityInvocation` entry, so this rule is a no-op for KEY
+DIDs and preserves their behavior. For `x1`, `capabilityInvocation[0]` is resolved against
+the genesis document (a string reference dereferenced by id in `verificationMethod`, or an
+embedded verification method used directly), and its `publicKeyMultibase` (`zQ3s...`) is
+decoded to the key.
+
+**No `verificationMethod[0]` fallback.** If `capabilityInvocation` is absent, the `x1`
+participant is **rejected**. A document without `capabilityInvocation` cannot be updated at
+all (the update path requires a `capabilityInvocation` verification method: construct and
+sign check the signing method is in `capabilityInvocation`, the proof is built with
+`proofPurpose: 'capabilityInvocation'`, and resolve verifies it against that same
+relationship), so it is useless for aggregation, and binding to any other verification
+method would break the invariant below.
+
+Binding the transport communication key to `capabilityInvocation` (rather than
+`authentication`, the DID-core-orthodox choice for sender authentication) yields the
+invariant **transport-authenticated as D implies control of a `capabilityInvocation` key of
+D implies authorized to update D**. An impostor who cannot update D is rejected at opt-in
+time rather than later at update-submit time, and the rule stays consistent with how `k1`
+already behaves. `authentication[0]` was considered and rejected: it would permit a separate
+cold update key and weaken the binding.
+
+This is a new normative rule, and it must be identical on all three sides: the participant
+(the key it signs envelopes with and declares as `communicationPk`), the resolver (the key
+`resolveBtcr2SenderPk` returns), and the service (which cross-checks the declared
+`communicationPk` against it). It is implemented once as an exported helper,
+`getAggregationCommunicationKey(document)`, so the three sides cannot drift.
+
+### C. Deliver the genesis in-band on the opt-in
+
+`CohortOptInBody` gains an optional `genesisDocument` field (typed
+`Record<string, unknown>`, D5). It is populated when the joining identity is `x1` and omitted
+for `k1`. This is the least protocol churn and is symmetric with how the service already
+learns `communicationPk` from the opt-in. A dedicated registration endpoint or handshake
+message was rejected (see below).
+
+### D. Trustless only; no trust-on-first-use
+
+The genesis is self-verifying against the `x1` DID, so the communication key is extracted
+with zero trust. The service never registers a self-asserted key on faith. Trust-on-first-use
+(registering whatever `communicationPk` an unauthenticated opt-in declares, then trusting it
+thereafter) is rejected for a public, self-hostable aggregator: it would let anyone occupy a
+cohort slot as any `x1` DID and grief or deny service to a cohort, even though they still
+could not produce a valid signed update. A deployment that ever wants that behavior can gate
+it behind an explicit, default-off flag; it is not the default.
+
+### Server bootstrap ordering (D4)
+
+The cross-check happens at the transport boundary, in
+`HttpServerTransport.#handleMessagesPost`, replacing the bare `401` that previously fired
+when `#resolveSenderPk` returned `undefined`. The bootstrap derives and verifies a key but
+registers nothing itself; registration is deferred until the request clears every downstream
+gate. The order is strict and every failure keeps the `401` (no trust-on-first-use, no
+partial registration):
+
+1. Revive and flatten the still-untrusted envelope's message; require it to be a
+   `COHORT_OPT_IN` carrying a `genesisDocument`. (A non-opt-in from an unknown sender, or an
+   opt-in with no genesis, stays `401` as before.)
+2. Derive the key: `resolveSenderPk(from, { genesisDocument })`. A genesis that does not hash
+   to `from`, or a document with no usable `capabilityInvocation` key, yields `undefined` and
+   stays `401`.
+3. Cross-check the derived key against the opt-in's declared `communicationPk`
+   (`equalBytes`); a mismatch stays `401`. This prevents a controller from authenticating
+   with one key while advertising a different signing key to the cohort.
+4. Verify the envelope signature against the derived key (`verifyEnvelope`). Failure is a
+   `401` and, crucially, mutates no state (the bootstrap holds the derived key in a local, not
+   the peer registry).
+5. Continue through the normal gates on the same request: replay/nonce (`409`),
+   rate-limit (`429`), recipient present and a registered actor (`400` / `404`), and the
+   sender-binding check below.
+6. Only after all of the above pass, `registerPeer(from, derivedKey)` using the
+   **genesis-derived** key, never the self-asserted one, then dispatch. A request that is
+   rejected at any gate leaves no peer-registry entry behind, so an unauthenticated party
+   cannot grow the (unbounded) registry by replaying self-minted `x1` opt-ins to a
+   nonexistent recipient.
+
+### Bind the inner message to the authenticated envelope
+
+The envelope signature authenticates `envelope.from`, but the dispatched message carries its
+own `from`, and the runner trusts that inner `from` (it records the opt-in and registers a
+peer under `message.from`). The transport therefore rejects (`401 sender_mismatch`) any
+request whose flattened `message.from` differs from the authenticated `envelope.from`, before
+dispatch or registration. Without this bind, a party authenticated as its own DID `A` could
+carry an inner `COHORT_OPT_IN` claiming `from: x1:Victim`, and the runner would seat `Victim`
+into the cohort under `A`'s key and poison the peer registry `Victim -> A`'s key, defeating
+the whole point of authenticating the sender. This binding is not specific to `x1` (a `k1`
+`A` could spoof any inner `from` the same way); it is a general transport-auth property that
+this change adds so the invariant "transport-authenticated as `D`" actually holds for the DID
+the cohort acts on. With the bind in place, `message.from == envelope.from`, so the runner's
+existing `registerPeer(msg.from, optIn.communicationPk)` re-registers the same
+genesis-derived key the transport just registered (an idempotent no-op for the `x1` peer) and
+needs no functional change (D9); it is left in place with a clarifying comment.
+
+### D6. Bound the bootstrap body size
+
+Genesis verification is a hash plus a few field checks, but the genesis arrives from an
+unauthenticated party before that check runs. A new optional `maxBodyBytes` transport config
+(default 64 KiB, comfortably above a real genesis document) bounds the parsed body of the
+authenticated POST routes and returns `413` before the body is read, so a large fake genesis
+cannot exhaust memory ahead of the hash check.
+
+### D1, D2, D7: placement and participant coupling
+
+- **D1.** The `getAggregationCommunicationKey` helper lives in
+  `did-sender-resolver.ts` alongside `resolveBtcr2SenderPk`, so it is exported through the
+  existing barrel and stays coupled to the resolver that consumes it.
+- **D2.** The helper decodes `publicKeyMultibase` through the existing
+  `SchnorrMultikey.fromVerificationMethod(vm).publicKey` path (the same canonical `zQ3s`
+  to 33-byte decode the resolver already uses to verify update proofs), rather than an
+  inline base58 decoder. It dereferences `capabilityInvocation[0]` with a small local lookup
+  by id against `verificationMethod`, not `getSigningMethod`, which defaults to `#initialKey`
+  and does not resolve embedded methods.
+- **D7.** For an `x1` participant, the caller supplies the `capabilityInvocation[0]`
+  verification method's keypair as the participant's signing keys and registers that same key
+  as the transport actor. This makes `communicationPk == participant public key == envelope
+  signing key == genesis-derived key`, so the server cross-check passes. This is a documented
+  caller contract; the server cross-check enforces it rather than trusting it.
+
+### D8: out of scope, deferred
+
+Client-side bootstrap (a participant authenticating an `x1` *service*), `x1` on the
+inbox-subscribe GET, and any async genesis-fetching resolver are out of scope for this change
+and left as follow-ups. The participant-side and service-side HTTP `resolveSenderPk` type is
+widened symmetrically (D5) so both compile against the genesis-aware signature, but only the
+server performs the bootstrap.
+
+### Transport symmetry (D9)
+
+`in-memory` and `nostr` need no code change: `in-memory` enforces no inbound auth, and
+`nostr` authenticates by event signature, so an `x1` participant already completes a cohort
+on both once the participant emits its genesis-derived signing key. Both gain symmetry tests.
+The `didcomm` stub gains a comment noting the same `x1` requirement for when it is
+implemented.
+
+### Method-agnosticism preserved (ADR 046, ADR 054)
+
+`@did-btcr2/aggregation` still does not depend on `@did-btcr2/method` (method remains a
+dev-only dependency for its tests). The `genesisDocument` field is typed
+`Record<string, unknown>` on the wire, matching the sibling opt-in body fields, and the
+genesis-aware resolver stays injected: the only in-repo injector is the aggregation e2e
+harness, which stands in for an external application. The transport learns nothing about
+did:btcr2 beyond "the injected resolver may consume a `genesisDocument` hint from a bootstrap
+opt-in."
+
+## Security analysis
+
+- **Trustless binding.** Because `x1 = commit(hash(genesis))`, a supplied genesis that hashes
+  to the DID authenticates the DID's key set with zero trust, equivalent to `k1`'s
+  decode-the-key. An attacker cannot register `x1:Victim -> attackerKey`: they would need a
+  genesis that hashes to `x1:Victim` yet authorizes `attackerKey`, i.e. a SHA-256 second
+  preimage of the victim's genesis. So `x1` is exactly as squat-resistant as `k1`.
+- **Impersonation with the real genesis.** An attacker who replays the victim's real genesis
+  derives the victim's key `Kv`, but `verifyEnvelope` then fails because the attacker cannot
+  sign with `Kv`'s secret. Rejected `401`.
+- **Advertised-vs-authenticated key split.** The `communicationPk` cross-check (step 3)
+  guarantees the key a controller authenticates with is the key it advertises to the cohort,
+  closing a split where a controller could authenticate as one key and have the cohort
+  encrypt or attribute to another.
+- **Inner/outer sender confusion.** The transport authenticates `envelope.from` but the runner
+  acts on the inner `message.from`. Binding the two (`message.from == envelope.from`, else
+  `401 sender_mismatch`) is what makes the trustless `x1` bootstrap meaningful: without it a
+  party authenticated as its own DID could carry an inner opt-in claiming `x1:Victim` and poison
+  the registry `Victim -> attacker key` (a hole that predates this change and applies equally to
+  `k1`). The bind closes it for both identifier types.
+- **No trust-on-first-use, no state mutation on failure.** Registration happens only with the
+  genesis-derived key and only after every gate (verify, replay, rate-limit, recipient,
+  sender-binding) passes, so an unauthenticated or otherwise-rejected opt-in cannot seat itself
+  in the registry. In particular a self-minted `x1` opt-in addressed to a nonexistent recipient
+  is rejected `404` with no registry write, so it cannot be replayed to grow the (unbounded)
+  peer map.
+- **Denial of service.** The `maxBodyBytes` cap bounds the pre-hash memory an unauthenticated
+  genesis can consume. Replay, nonce, and rate-limit paths are unchanged: the bootstrap only
+  supplies the key consumed by the existing verify pipeline. The genesis hash is computed
+  before the per-`from` rate limiter (as `verifyEnvelope` already hashes the envelope), so a
+  flood of fresh self-minted `x1` DIDs is throttled only by the body cap, not the per-`from`
+  limiter; a deployment exposed to that can add a per-IP limit at its own proxy.
+
+## Consequences
+
+- An `x1` participant completes a cohort over HTTP, in-memory, and nostr, and a mixed
+  `k1` + `x1` cohort produces a valid aggregate signature.
+- `resolveBtcr2SenderPk(did)` with no second argument is unchanged (`k1` to key, `x1` to
+  `undefined`); every existing call site compiles and behaves identically. The new
+  `getAggregationCommunicationKey` and the widened resolver signature become part of the
+  method package's public surface via the existing barrel.
+- `CohortOptInBody.genesisDocument` is optional; existing `k1` opt-ins and older participants
+  are unaffected. No change to MuSig2, cohort finalization, beacon-tx construction, or DID
+  resolution.
+- The communication-key selection rule is defined once and shared, so participant, resolver,
+  and service cannot disagree about which key authenticates an `x1` DID.
+- `@did-btcr2/method` and `@did-btcr2/aggregation` both take a minor bump under 0.x semantics:
+  the change is additive (a new optional parameter, a new optional wire field, a new exported
+  helper, a new transport config) and this ADR serves as the release note. `api` and `cli`
+  have no functional change (neither injects the resolver).
+
+## Rejected alternatives
+
+- **Trust-on-first-use.** Register whatever `communicationPk` an unauthenticated opt-in
+  declares. Rejected: it lets anyone occupy a cohort slot as any `x1` DID and grief a cohort.
+  The genesis makes a fully trustless binding available, so there is no reason to accept a
+  weaker one by default.
+- **A dedicated `/v1/register` route or `PEER_HELLO` message.** Carry `{ did, genesisDocument
+  }` in a separate self-signed step that populates the registry before the opt-in. Cleaner
+  transport layering, but it adds a route and an onboarding round-trip. Rejected in favor of
+  carrying the genesis on the opt-in, which reuses the existing "learn the key from the
+  opt-in" flow with no new endpoint.
+- **`authentication[0]` as the communication key.** DID-core-orthodox for sender
+  authentication and would allow a separate cold update key. Rejected in favor of
+  `capabilityInvocation[0]`, which gives the stronger transport-authenticated-implies-
+  authorized-to-update invariant and matches `k1`.
+- **A `verificationMethod[0]` fallback when `capabilityInvocation` is absent.** Rejected: such
+  a document cannot be updated and is useless for aggregation, and any fallback verification
+  method would break the update-authorization invariant. Absent `capabilityInvocation` is a
+  hard rejection.
+- **An async, genesis-fetching resolver.** Resolve the DID or read a store to obtain the
+  genesis server-side. Rejected for now: it would make `#resolveSenderPk` asynchronous and add
+  an I/O dependency to the transport. The genesis is already in hand on the opt-in, so a
+  synchronous resolver is sufficient. Deferred as a follow-up if a non-in-band delivery is
+  ever needed.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -66,6 +66,7 @@ children:
   - ./063-beacon-utxo-selection-hardening.md
   - ./064-foss-coverage-and-dependency-audit-gate.md
   - ./065-changesets-for-changelogs-manual-release.md
+  - ./066-x1-transport-authentication.md
 ---
 
 # Architecture Decision Records
@@ -139,3 +140,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 063 | 2026-07-01 | [Harden Beacon UTXO Selection (Confirmed, Non-Dust, Deepest-First, Deterministic)](063-beacon-utxo-selection-hardening.md) |
 | 064 | 2026-07-02 | [FOSS In-Repo Coverage Reporting and a Dependency-Audit Gate](064-foss-coverage-and-dependency-audit-gate.md) |
 | 065 | 2026-07-02 | [Adopt Changesets for Per-Package Changelogs with Manual Publishing](065-changesets-for-changelogs-manual-release.md) |
+| 066 | 2026-07-02 | [Trustless Transport Authentication for EXTERNAL (x1) DIDs via In-Band Genesis Documents](066-x1-transport-authentication.md) |

--- a/packages/aggregation/CHANGELOG.md
+++ b/packages/aggregation/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @did-btcr2/aggregation
+
+## 0.4.0
+
+### Minor Changes
+
+- Authenticate EXTERNAL (x1) did:btcr2 identifiers on the aggregation HTTP transport (ADR 066)
+
+  EXTERNAL (x1) DIDs can now join aggregation cohorts as first-class members over the HTTP
+  transport, the way KEY (k1) DIDs already do. An x1 DID commits to the hash of its genesis
+  document, so the controller carries that self-verifying genesis in-band on the cohort opt-in;
+  the service recomputes the hash, derives the communication key from `capabilityInvocation[0]`
+  (no `verificationMethod[0]` fallback), cross-checks it against the advertised
+  `communicationPk`, verifies the envelope signature, and only then registers the peer. There
+  is no trust-on-first-use.
+
+  - `@did-btcr2/method`: `resolveBtcr2SenderPk(did, { genesisDocument })` is now genesis-aware
+    (the one-argument form is unchanged: k1 to key, x1 to undefined), and a new exported
+    `getAggregationCommunicationKey(document)` derives the aggregation communication key from
+    `capabilityInvocation[0]`.
+  - `@did-btcr2/aggregation`: the cohort opt-in body carries an optional `genesisDocument`; the
+    HTTP server bootstraps an unregistered x1 sender from it, binds the inner `message.from` to
+    the authenticated `envelope.from`, registers a bootstrapped peer only after the request
+    clears every gate, and accepts a new `maxBodyBytes` transport option (413 on oversize). The
+    package remains method-agnostic.
+
+  Backward compatible: existing k1 opt-ins, one-argument resolver callers, and older
+  participants are unaffected.

--- a/packages/aggregation/lib/operations/aggregation/e2e-http-transport.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-http-transport.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * E2E Demo: HTTP/REST Transport (Runner API)
  *
@@ -38,8 +38,11 @@ const PORT    = Number(process.env.PORT ?? 8080);
 const BASE_URL = `http://localhost:${PORT}/`;
 
 // ────────────────────────────────────────────────
-// Keys + DIDs (all KEY DIDs; pubkeys derive from the DID string so no
-// pre-registerPeer dance is needed - see ADR-002)
+// Keys + DIDs. Service and Alice are KEY (k1) DIDs: the pubkey derives from the
+// DID string, so no pre-registerPeer dance is needed. Bob is an EXTERNAL (x1) DID:
+// its DID commits to the hash of a genesis document and its capabilityInvocation[0]
+// key is bobKeys. The genesis rides in-band on Bob's opt-in so the service can
+// bootstrap-authenticate him with zero trust (ADR 066).
 // ────────────────────────────────────────────────
 
 const serviceKeys = SchnorrKeyPair.generate();
@@ -49,7 +52,26 @@ const aliceKeys   = SchnorrKeyPair.generate();
 const aliceDid    = DidBtcr2.create(aliceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
 const bobKeys     = SchnorrKeyPair.generate();
-const bobDid      = DidBtcr2.create(bobKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+const bobGenesis: Record<string, unknown> = {
+  'id'                 : 'did:btcr2:_',
+  '@context'           : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+  'verificationMethod' : [{
+    'id'                 : 'did:btcr2:_#key-0',
+    'type'               : 'Multikey',
+    'controller'         : 'did:btcr2:_',
+    'publicKeyMultibase' : bobKeys.publicKey.multibase.encoded,
+  }],
+  'authentication'       : ['did:btcr2:_#key-0'],
+  'assertionMethod'      : ['did:btcr2:_#key-0'],
+  'capabilityInvocation' : ['did:btcr2:_#key-0'],
+  'capabilityDelegation' : ['did:btcr2:_#key-0'],
+  'service'              : [{
+    'id'              : 'did:btcr2:_#service-0',
+    'type'            : 'SingletonBeacon',
+    'serviceEndpoint' : 'bitcoin:mhME7XiWpho6Ft4pvT3U3h6X8hHtE58ZDJ',
+  }],
+};
+const bobDid      = DidBtcr2.create(GenesisDocument.toGenesisBytes(bobGenesis), { idType: 'EXTERNAL', network: 'mutinynet' });
 
 // ────────────────────────────────────────────────
 // Service-side HTTP server (node:http adapter + HttpServerTransport)
@@ -148,14 +170,18 @@ bobTransport.registerActor(bobDid, bobKeys);
 // Signed update helper (same as Nostr E2E demos)
 // ────────────────────────────────────────────────
 
-function buildSignedUpdate(did: string, kp: SchnorrKeyPair, beaconAddress: string) {
-  const doc = Resolver.deterministic({
-    genesisBytes : kp.publicKey.compressed,
-    hrp          : 'k',
-    idType       : 'KEY',
-    version      : 1,
-    network      : 'mutinynet',
-  });
+function buildSignedUpdate(did: string, kp: SchnorrKeyPair, beaconAddress: string, genesisDocument?: Record<string, unknown>) {
+  // KEY (k1) DIDs resolve deterministically from the pubkey; an EXTERNAL (x1) DID
+  // resolves from its (self-verifying) genesis document.
+  const doc = genesisDocument
+    ? Resolver.external(Identifier.decode(did), genesisDocument)
+    : Resolver.deterministic({
+      genesisBytes : kp.publicKey.compressed,
+      hrp          : 'k',
+      idType       : 'KEY',
+      version      : 1,
+      network      : 'mutinynet',
+    });
   const vm = doc.verificationMethod![0];
   const unsigned = Updater.construct(doc, [{
     op    : 'add',
@@ -206,13 +232,14 @@ service.on('validation-received', ({ participantDid, approved }) => console.log(
 service.on('signing-complete', ({ signature }) => console.log(`[service] signature: ${bytesToHex(signature)}`));
 service.on('error', (err) => console.error('[service] error:', err.message));
 
-function makeParticipantRunner(name: string, did: string, keys: SchnorrKeyPair, transport: Transport) {
+function makeParticipantRunner(name: string, did: string, keys: SchnorrKeyPair, transport: Transport, genesisDocument?: Record<string, unknown>) {
   const runner = new AggregationParticipantRunner({
     transport,
     did,
     keys,
+    genesisDocument,
     shouldJoin      : async () => true,
-    onProvideUpdate : async ({ beaconAddress }) => buildSignedUpdate(did, keys, beaconAddress),
+    onProvideUpdate : async ({ beaconAddress }) => buildSignedUpdate(did, keys, beaconAddress, genesisDocument),
   });
 
   runner.on('cohort-discovered', (advert) => console.log(`[${name}] discovered cohort ${advert.cohortId}`));
@@ -227,7 +254,7 @@ function makeParticipantRunner(name: string, did: string, keys: SchnorrKeyPair, 
 }
 
 const alice = makeParticipantRunner('alice', aliceDid, aliceKeys, aliceTransport);
-const bob   = makeParticipantRunner('bob',   bobDid,   bobKeys,   bobTransport);
+const bob   = makeParticipantRunner('bob',   bobDid,   bobKeys,   bobTransport, bobGenesis);
 
 // ────────────────────────────────────────────────
 // Wire everything up and run

--- a/packages/aggregation/package.json
+++ b/packages/aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/aggregation",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Multi-party coordination for did:btcr2 aggregate beacons: sans-I/O AggregationService and AggregationParticipant state machines, MuSig2 (BIP-327) signing sessions, cohort conditions, and pluggable transports (Nostr, HTTP, in-memory).",
   "main": "./dist/cjs/index.js",

--- a/packages/aggregation/src/core/messages/base.ts
+++ b/packages/aggregation/src/core/messages/base.ts
@@ -34,6 +34,13 @@ export type BaseBody = Partial<CohortConditions> & {
   prevOutValue?: string;
   communicationPk?: Uint8Array;
   data?: string;
+  /**
+   * An EXTERNAL (`x1`) sender's genesis DID document, carried in-band on a bootstrap
+   * opt-in so the service can derive and verify the sender's communication key before
+   * the sender is a registered peer. Omitted for KEY (`k1`) senders. Typed as a plain
+   * record to keep the transport DID-method-agnostic.
+   */
+  genesisDocument?: Record<string, unknown>;
   signedUpdate?: Record<string, unknown>;
   casAnnouncement?: Record<string, string>;
   smtProof?: Record<string, unknown>;

--- a/packages/aggregation/src/core/messages/bodies.ts
+++ b/packages/aggregation/src/core/messages/bodies.ts
@@ -45,6 +45,12 @@ export interface CohortOptInBody {
   cohortId: string;
   participantPk: Uint8Array;
   communicationPk: Uint8Array;
+  /**
+   * An EXTERNAL (`x1`) sender's genesis DID document, carried in-band so the service can
+   * bootstrap-verify the sender's communication key. Omitted for KEY (`k1`) senders;
+   * {@link isCohortOptInMessage} stays tolerant of its absence.
+   */
+  genesisDocument?: Record<string, unknown>;
 }
 
 export interface CohortOptInAcceptBody {

--- a/packages/aggregation/src/core/messages/factories.ts
+++ b/packages/aggregation/src/core/messages/factories.ts
@@ -34,6 +34,8 @@ type CohortOptInMessage = {
   cohortId: string;
   participantPk: Uint8Array;
   communicationPk: Uint8Array;
+  /** An EXTERNAL (`x1`) sender's genesis DID document (see {@link CohortOptInBody}). */
+  genesisDocument?: Record<string, unknown>;
 };
 type CohortOptInAcceptMessage = {
   from: string;

--- a/packages/aggregation/src/core/transport/didcomm.ts
+++ b/packages/aggregation/src/core/transport/didcomm.ts
@@ -24,6 +24,10 @@ export class DidCommTransport implements Transport {
     throw new NotImplementedError('DidCommTransport not implemented.');
   }
 
+  // When implemented, this transport must authenticate an EXTERNAL (x1) did:btcr2 sender
+  // the same way the HTTP transport does: an x1 DID's key is not in the DID string, so it
+  // is derived from a self-verifying genesis document carried in-band on a bootstrap opt-in
+  // and registered here (see ADR 066).
   public registerPeer(_did: string, _communicationPk: Uint8Array): void {
     throw new NotImplementedError('DidCommTransport not implemented.');
   }

--- a/packages/aggregation/src/participant/http-client.ts
+++ b/packages/aggregation/src/participant/http-client.ts
@@ -30,10 +30,15 @@ export interface HttpClientTransportConfig {
   /**
    * Resolve a sender's communication public key from its DID when the sender is not a
    * registered peer. Lets the transport stay DID-method-agnostic: the caller supplies
-   * the decode (for example, a did:btcr2 KEY identifier yields its genesis key). When
-   * omitted, sender resolution is limited to registered peers.
+   * the decode (for example, a did:btcr2 KEY identifier yields its genesis key). The
+   * optional `genesisDocument` mirrors the server transport's genesis-aware signature so a
+   * single injected resolver serves both; the client does not itself bootstrap senders.
+   * When omitted, sender resolution is limited to registered peers.
    */
-  resolveSenderPk?: (did: string) => CompressedSecp256k1PublicKey | undefined;
+  resolveSenderPk?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 }
 
 /** Default exponential backoff: 1s, 2s, 4s, ..., capped at 30s, 20% jitter. */
@@ -63,7 +68,10 @@ export class HttpClientTransport implements Transport {
   readonly #logger:       Logger;
   readonly #backoff:      (attempt: number) => number;
   readonly #clockSkewSec: number;
-  readonly #resolveSenderPkFn?: (did: string) => CompressedSecp256k1PublicKey | undefined;
+  readonly #resolveSenderPkFn?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 
   readonly #actors: Map<string, ActorEntry>   = new Map();
   readonly #peers:  Map<string, Uint8Array>   = new Map();
@@ -362,13 +370,16 @@ export class HttpClientTransport implements Transport {
     if(handler) await handler(flat);
   }
 
-  #resolveSenderPk(did: string): CompressedSecp256k1PublicKey | undefined {
+  #resolveSenderPk(
+    did: string,
+    opts?: { genesisDocument?: object },
+  ): CompressedSecp256k1PublicKey | undefined {
     const peerBytes = this.#peers.get(did);
     if(peerBytes) {
       try { return new CompressedSecp256k1PublicKey(peerBytes); }
       catch { /* fall through to the injected resolver */ }
     }
-    return this.#resolveSenderPkFn?.(did);
+    return this.#resolveSenderPkFn?.(did, opts);
   }
 }
 

--- a/packages/aggregation/src/participant/participant-runner.ts
+++ b/packages/aggregation/src/participant/participant-runner.ts
@@ -69,6 +69,15 @@ export interface AggregationParticipantRunnerOptions {
    * Default: approve.
    */
   onApproveSigning?: OnApproveSigning;
+
+  /**
+   * The identity's genesis DID document. Required for an EXTERNAL (x1) did:btcr2 identifier
+   * so the service can bootstrap-authenticate this participant from a self-verifying opt-in;
+   * omitted for a KEY (k1) identifier. When present, `keys` MUST be the keypair of the
+   * genesis document's `capabilityInvocation[0]` verification method (see
+   * {@link AggregationParticipantParams.genesisDocument}).
+   */
+  genesisDocument?: Record<string, unknown>;
 }
 
 /**
@@ -131,8 +140,9 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
     this.#onApproveSigning = options.onApproveSigning ?? (async () => ({ approved: true }));
 
     this.session = new AggregationParticipant({
-      did    : options.did,
-      signer : new KeyPairAggregationSigner(options.keys),
+      did             : options.did,
+      signer          : new KeyPairAggregationSigner(options.keys),
+      genesisDocument : options.genesisDocument,
     });
   }
 

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -147,6 +147,17 @@ export interface AggregationParticipantParams {
    * pass a {@link KeyPairAggregationSigner} to back it with an in-memory keypair.
    */
   signer: AggregationSigner;
+  /**
+   * The joining identity's genesis DID document. Required for an EXTERNAL (x1) did:btcr2
+   * identifier, whose key is not in the DID string: it is attached to every cohort opt-in
+   * this participant sends so the service can bootstrap-authenticate the participant from
+   * the self-verifying genesis. Omitted for a KEY (k1) identifier. When present, the
+   * participant's `signer` MUST be the keypair of the genesis document's
+   * `capabilityInvocation[0]` verification method, so the advertised `communicationPk`
+   * matches the genesis-derived key the service verifies against. Typed as a plain record
+   * to keep the aggregation package DID-method-agnostic.
+   */
+  genesisDocument?: Record<string, unknown>;
 }
 
 /**
@@ -165,12 +176,16 @@ export class AggregationParticipant {
   /** MuSig2 signing capability. The raw secret never lives as a field here. */
   readonly #signer: AggregationSigner;
 
+  /** EXTERNAL (x1) genesis document attached to opt-ins for bootstrap auth; undefined for k1. */
+  readonly #genesisDocument?: Record<string, unknown>;
+
   /** Per-cohort state, keyed by cohortId. */
   #cohortStates: Map<string, ParticipantCohortState> = new Map();
 
-  constructor({ did, signer }: AggregationParticipantParams) {
+  constructor({ did, signer, genesisDocument }: AggregationParticipantParams) {
     this.did = did;
     this.#signer = signer;
+    this.#genesisDocument = genesisDocument;
   }
 
   /** The participant's compressed (33-byte) MuSig2 public key. Not secret. */
@@ -289,6 +304,9 @@ export class AggregationParticipant {
       cohortId,
       participantPk   : this.publicKey,
       communicationPk : this.publicKey,
+      // Attach the genesis so an EXTERNAL (x1) sender can be bootstrap-authenticated by
+      // the service; omitted for a KEY (k1) sender.
+      ...(this.#genesisDocument ? { genesisDocument: this.#genesisDocument } : {}),
     });
 
     return [optInMessage];

--- a/packages/aggregation/src/service/http-server.ts
+++ b/packages/aggregation/src/service/http-server.ts
@@ -1,9 +1,11 @@
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { equalBytes } from '@noble/curves/utils.js';
 
 import type { Logger } from '../core/logger.js';
 import { CONSOLE_LOGGER } from '../core/logger.js';
 import type { BaseMessage } from '../core/messages/base.js';
+import { COHORT_OPT_IN } from '../core/messages/constants.js';
 import type { MessageHandler, Transport } from '../core/transport/transport.js';
 import { reviveFromWire, signEnvelope, verifyEnvelope } from '../core/transport/http/envelope.js';
 import { HttpTransportError } from '../core/transport/http/errors.js';
@@ -79,12 +81,26 @@ export interface HttpServerTransportConfig {
   /** Clock injection point for tests. Returns unix milliseconds. */
   now?: () => number;
   /**
+   * Maximum accepted request-body size for the authenticated POST routes, measured as the
+   * body string length. Bounds the work an unauthenticated party can force before the
+   * genesis-bootstrap hash check runs, so a large fake genesis cannot be parsed and hashed.
+   * A request larger than this receives 413 before its body is parsed. Default 65536 (64
+   * KiB), well above a real genesis document.
+   */
+  maxBodyBytes?: number;
+  /**
    * Resolve a sender's communication public key from its DID when the sender is not a
    * registered peer. Lets the transport stay DID-method-agnostic: the caller supplies
-   * the decode (for example, a did:btcr2 KEY identifier yields its genesis key). When
+   * the decode (for example, a did:btcr2 KEY identifier yields its genesis key). The
+   * optional `genesisDocument` is passed through on a bootstrap opt-in from an as-yet
+   * unregistered sender (for example a did:btcr2 EXTERNAL identifier, whose key is not in
+   * the DID string but is derivable from its self-verifying genesis document). When
    * omitted, sender resolution is limited to registered peers.
    */
-  resolveSenderPk?: (did: string) => CompressedSecp256k1PublicKey | undefined;
+  resolveSenderPk?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 }
 
 interface ActorEntry {
@@ -118,6 +134,7 @@ const INBOX_PATH_SUFFIX = '/inbox';
 
 const DEFAULT_ADVERT_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_HEARTBEAT_MS  = 20_000;
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
 
 /**
  * Server-side HTTP transport. Sans-I/O - the caller mounts
@@ -141,7 +158,11 @@ export class HttpServerTransport implements Transport {
   readonly #rateLimiter:        RateLimiter;
   readonly #nonceCache:         NonceCache;
   readonly #now:                () => number;
-  readonly #resolveSenderPkFn?: (did: string) => CompressedSecp256k1PublicKey | undefined;
+  readonly #maxBodyBytes:       number;
+  readonly #resolveSenderPkFn?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 
   readonly #actors:   Map<string, ActorEntry> = new Map();
   readonly #peers:    Map<string, Uint8Array> = new Map();
@@ -162,6 +183,7 @@ export class HttpServerTransport implements Transport {
     this.#rateLimiter     = config.rateLimiter ?? new RateLimiter();
     this.#nonceCache      = config.nonceCache ?? new NonceCache();
     this.#now             = config.now ?? (() => Date.now());
+    this.#maxBodyBytes    = config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
     this.#resolveSenderPkFn = config.resolveSenderPk;
   }
 
@@ -343,19 +365,31 @@ export class HttpServerTransport implements Transport {
   // ----------------------------------------------------------------
 
   async #handleMessagesPost(req: HttpRequestLike): Promise<HttpResponseLike> {
+    const tooLarge = this.#enforceBodySize(req);
+    if(tooLarge) return tooLarge;
+
     const envelope = parseJsonBody<SignedEnvelope>(req.body);
     if(!envelope) return this.#respondJson(400, { error: 'invalid_json' }, req);
 
     const senderPk = this.#resolveSenderPk(envelope.from);
-    if(!senderPk) {
-      return this.#respondJson(401, { error: 'unknown_sender' }, req);
-    }
-
-    try {
-      verifyEnvelope(envelope, senderPk, { clockSkewSec: this.#clockSkewSec });
-    } catch(err) {
-      this.#logger.debug('POST /v1/messages: envelope verification failed:', err);
-      return this.#respondJson(401, { error: 'invalid_envelope' }, req);
+    let bootstrappedPk: CompressedSecp256k1PublicKey | undefined;
+    if(senderPk) {
+      try {
+        verifyEnvelope(envelope, senderPk, { clockSkewSec: this.#clockSkewSec });
+      } catch(err) {
+        this.#logger.debug('POST /v1/messages: envelope verification failed:', err);
+        return this.#respondJson(401, { error: 'invalid_envelope' }, req);
+      }
+    } else {
+      // The sender is not a registered peer and its DID does not decode to a key on its
+      // own (an EXTERNAL x1 DID commits to a genesis-document hash, not a key). The only
+      // way to authenticate is a self-verifying bootstrap opt-in carrying that genesis
+      // document; #bootstrapSenderPk derives the key, cross-checks the advertised
+      // communicationPk, and verifies the envelope. The derived key is not registered
+      // until the request clears every gate below (there is no trust-on-first-use, and a
+      // request that is later rejected leaves no peer-registry state behind).
+      bootstrappedPk = this.#bootstrapSenderPk(envelope);
+      if(!bootstrappedPk) return this.#respondJson(401, { error: 'unknown_sender' }, req);
     }
 
     if(!this.#nonceCache.store(envelope.from, envelope.nonce, envelope.timestamp)) {
@@ -376,6 +410,24 @@ export class HttpServerTransport implements Transport {
 
     const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
     const flat = flattenMessage(revived);
+
+    // Bind the inner message to the authenticated envelope: a sender may only speak as
+    // itself. The envelope signature authenticates envelope.from, but the dispatched
+    // message carries its own `from` that the runner trusts (it registers a peer and
+    // records an opt-in under message.from). Without this check a sender authenticated as
+    // its own DID could carry an inner message claiming a different `from`, spoofing that
+    // DID into the cohort and poisoning the peer registry for it.
+    if(flat.from !== envelope.from) {
+      return this.#respondJson(401, { error: 'sender_mismatch' }, req);
+    }
+
+    // The request has cleared every gate; only now register a bootstrapped x1 peer, so its
+    // later messages resolve from the registry without re-deriving from the genesis. This
+    // is the sole point that mutates peer state, and only for a fully-validated request.
+    if(bootstrappedPk) {
+      this.registerPeer(envelope.from, bootstrappedPk.compressed);
+    }
+
     const messageType = typeof flat.type === 'string' ? flat.type : undefined;
     if(!messageType) return this.#respondJson(400, { error: 'missing_message_type' }, req);
 
@@ -390,6 +442,9 @@ export class HttpServerTransport implements Transport {
   }
 
   async #handleAdvertsPost(req: HttpRequestLike): Promise<HttpResponseLike> {
+    const tooLarge = this.#enforceBodySize(req);
+    if(tooLarge) return tooLarge;
+
     const envelope = parseJsonBody<SignedEnvelope>(req.body);
     if(!envelope) return this.#respondJson(400, { error: 'invalid_json' }, req);
 
@@ -516,13 +571,70 @@ export class HttpServerTransport implements Transport {
     return inbox;
   }
 
-  #resolveSenderPk(did: string): CompressedSecp256k1PublicKey | undefined {
+  #resolveSenderPk(
+    did: string,
+    opts?: { genesisDocument?: object },
+  ): CompressedSecp256k1PublicKey | undefined {
     const peerBytes = this.#peers.get(did);
     if(peerBytes) {
       try { return new CompressedSecp256k1PublicKey(peerBytes); }
       catch { /* fall through to the injected resolver */ }
     }
-    return this.#resolveSenderPkFn?.(did);
+    return this.#resolveSenderPkFn?.(did, opts);
+  }
+
+  /**
+   * Bootstrap-authenticate a sender that {@link #resolveSenderPk} could not resolve, from a
+   * self-verifying COHORT_OPT_IN. An EXTERNAL (x1) did:btcr2 DID commits to the hash of its
+   * genesis document, so a genesis carried in-band on the opt-in authenticates the sender's
+   * communication key with zero trust. This derives the key through the injected
+   * genesis-aware resolver (which rejects a genesis that does not hash to the DID),
+   * cross-checks it against the advertised `communicationPk` (so a controller cannot
+   * authenticate with one key while advertising another), and verifies the envelope
+   * signature against it. Returns the derived key on success, or `undefined` on any
+   * failure. It performs no registration and mutates no state: the caller registers the
+   * returned key only after the request clears its remaining gates (there is no
+   * trust-on-first-use).
+   */
+  #bootstrapSenderPk(envelope: SignedEnvelope): CompressedSecp256k1PublicKey | undefined {
+    if(!this.#resolveSenderPkFn) return undefined;
+
+    // Inspect the still-untrusted message only to derive a candidate key; nothing is
+    // trusted until the envelope verifies against that key below.
+    const flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    if(flat.type !== COHORT_OPT_IN) return undefined;
+
+    const genesisDocument = flat.genesisDocument;
+    if(!genesisDocument || typeof genesisDocument !== 'object') return undefined;
+
+    const derived = this.#resolveSenderPkFn(envelope.from, { genesisDocument: genesisDocument as object });
+    if(!derived) return undefined;
+
+    const communicationPk = flat.communicationPk;
+    if(!(communicationPk instanceof Uint8Array) || !equalBytes(communicationPk, derived.compressed)) {
+      return undefined;
+    }
+
+    try {
+      verifyEnvelope(envelope, derived, { clockSkewSec: this.#clockSkewSec });
+    } catch(err) {
+      this.#logger.debug('POST /v1/messages: bootstrap envelope verification failed:', err);
+      return undefined;
+    }
+
+    return derived;
+  }
+
+  /**
+   * Reject an over-large request body before it is parsed, so a large fake genesis cannot be
+   * parsed and hashed. Returns a 413 response when the body exceeds {@link #maxBodyBytes},
+   * or `undefined` to continue.
+   */
+  #enforceBodySize(req: HttpRequestLike): HttpResponseLike | undefined {
+    if(req.body !== undefined && req.body.length > this.#maxBodyBytes) {
+      return this.#respondJson(413, { error: 'payload_too_large' }, req);
+    }
+    return undefined;
   }
 
   #safeWrite(stream: SseStream, event: string, data: string, id?: string): void {

--- a/packages/aggregation/src/service/service-runner.ts
+++ b/packages/aggregation/src/service/service-runner.ts
@@ -665,7 +665,12 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       // PendingOptIn already carries cohortId, so this event is cohort-identified.
       this.emit('opt-in-received', optIn);
 
-      // Register peer key for encrypted messaging
+      // Register peer key for encrypted messaging. For an EXTERNAL (x1) sender over an
+      // authenticating transport (HTTP), the transport already registered the
+      // genesis-derived key during its bootstrap and cross-checked that it equals this
+      // self-declared communicationPk, so this call re-registers the identical key (an
+      // idempotent no-op). For KEY (k1) senders and non-authenticating transports it is the
+      // sole registration.
       if(optIn.communicationPk) {
         this.#transport.registerPeer(msg.from, optIn.communicationPk);
       }

--- a/packages/aggregation/tests/aggregation-x1-transport-auth.spec.ts
+++ b/packages/aggregation/tests/aggregation-x1-transport-auth.spec.ts
@@ -1,0 +1,440 @@
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex } from '@noble/hashes/utils';
+import { p2tr, Script, Transaction } from '@scure/btc-signer';
+import * as musig2 from '@scure/btc-signer/musig2';
+import { expect } from 'chai';
+
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update, GenesisDocumentLike } from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, resolveBtcr2SenderPk } from '@did-btcr2/method';
+
+import {
+  AggregationParticipant,
+  AggregationParticipantRunner,
+  AggregationServiceRunner,
+  BaseMessage,
+  COHORT_ADVERT,
+  COHORT_OPT_IN,
+  HTTP_ROUTE,
+  HttpServerTransport,
+  KeyPairAggregationSigner,
+  SILENT_LOGGER,
+  signEnvelope,
+  type BaseBody,
+  type HttpRequestLike,
+} from '../src/index.js';
+import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+
+/**
+ * Trustless transport authentication for EXTERNAL (x1) did:btcr2 identifiers (ADR 066).
+ */
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+
+const hexOf = (b: Uint8Array): string => bytesToHex(b);
+
+/** An x1 identity: a signing keypair, a genesis document whose capabilityInvocation[0]
+ *  is that keypair, and the x1 DID minted from the canonical hash of that document. */
+function makeExternalIdentity(network = 'mutinynet'): {
+  keys: SchnorrKeyPair;
+  did: string;
+  genesisDocument: Record<string, unknown>;
+} {
+  const keys = SchnorrKeyPair.generate();
+  const genesisDocument: Record<string, unknown> = {
+    'id'                 : 'did:btcr2:_',
+    '@context'           : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+    'verificationMethod' : [{
+      'id'                 : 'did:btcr2:_#key-0',
+      'type'               : 'Multikey',
+      'controller'         : 'did:btcr2:_',
+      'publicKeyMultibase' : keys.publicKey.multibase.encoded,
+    }],
+    'authentication'       : ['did:btcr2:_#key-0'],
+    'assertionMethod'      : ['did:btcr2:_#key-0'],
+    'capabilityInvocation' : ['did:btcr2:_#key-0'],
+    'capabilityDelegation' : ['did:btcr2:_#key-0'],
+    'service'              : [{
+      'id'              : 'did:btcr2:_#service-0',
+      'type'            : 'SingletonBeacon',
+      'serviceEndpoint' : 'bitcoin:mhME7XiWpho6Ft4pvT3U3h6X8hHtE58ZDJ',
+    }],
+  };
+  const genesisBytes = GenesisDocument.toGenesisBytes(genesisDocument as GenesisDocumentLike);
+  const did = DidBtcr2.create(genesisBytes, { idType: 'EXTERNAL', network });
+  return { keys, did, genesisDocument };
+}
+
+function req(method: string, url: string, headers: Record<string, string> = {}, body?: string): HttpRequestLike {
+  return { method, url, headers, body };
+}
+
+/** Cryptographically valid SignedBTCR2Update, verifiable against the sender's own key
+ *  (the service checks the update proof against the opt-in participantPk). */
+function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const verificationMethodId = `${did}#initialKey`;
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [
+      { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } },
+    ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : version,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : verificationMethodId,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(verificationMethodId, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+function buildDummyTx(outputScript: Uint8Array, prevOutValue: bigint, signal?: Uint8Array): Transaction {
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: prevOutValue, script: outputScript } });
+  tx.addOutput({ script: outputScript, amount: prevOutValue - 500n });
+  if(signal) tx.addOutput({ script: Script.encode(['RETURN', signal]), amount: 0n });
+  return tx;
+}
+
+describe('x1 transport authentication (ADR 066)', () => {
+  let serverKeys: SchnorrKeyPair;
+  let serverDid:  string;
+  let server:     HttpServerTransport;
+
+  beforeEach(() => {
+    serverKeys = SchnorrKeyPair.generate();
+    serverDid  = DidBtcr2.create(serverKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+  });
+
+  afterEach(() => {
+    server?.stop();
+  });
+
+  const makeServer = (overrides: Partial<ConstructorParameters<typeof HttpServerTransport>[0]> = {}): HttpServerTransport =>
+    new HttpServerTransport({
+      logger              : SILENT_LOGGER,
+      heartbeatIntervalMs : 0,
+      resolveSenderPk     : resolveBtcr2SenderPk,
+      ...overrides,
+    });
+
+  const optInEnvelope = (
+    from: string,
+    signWith: SchnorrKeyPair,
+    body: Record<string, unknown>,
+  ): string => {
+    const msg = new BaseMessage({ type: COHORT_OPT_IN, from, to: serverDid, body: body as BaseBody });
+    return JSON.stringify(signEnvelope(msg, { did: from, keys: signWith }, { to: serverDid }));
+  };
+
+  const post = (body: string): Promise<{ status: number }> =>
+    server.handleRequest(req('POST', HTTP_ROUTE.MESSAGES, { 'content-type': 'application/json' }, body));
+
+  describe('HttpServerTransport bootstrap', () => {
+    it('accepts an x1 opt-in with a matching genesis and registers the genesis-derived key', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+
+      const res = await post(optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+        genesisDocument : x1.genesisDocument,
+      }));
+
+      expect(res.status).to.equal(202);
+      const derived = resolveBtcr2SenderPk(x1.did, { genesisDocument: x1.genesisDocument })!;
+      expect(hexOf(server.getPeerPk(x1.did)!)).to.equal(hexOf(derived.compressed));
+      expect(hexOf(derived.compressed)).to.equal(hexOf(x1.keys.publicKey.compressed));
+    });
+
+    it('rejects an x1 opt-in that carries no genesis document (401)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+
+      const res = await post(optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+      }));
+
+      expect(res.status).to.equal(401);
+      expect(server.getPeerPk(x1.did)).to.equal(undefined);
+    });
+
+    it('rejects an x1 opt-in whose genesis does not hash to the DID (401)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const victim = makeExternalIdentity();
+      const other  = makeExternalIdentity();
+
+      // victim DID, but carrying another identity's genesis: the hash commitment fails.
+      const res = await post(optInEnvelope(victim.did, victim.keys, {
+        cohortId        : 'c1',
+        participantPk   : victim.keys.publicKey.compressed,
+        communicationPk : victim.keys.publicKey.compressed,
+        genesisDocument : other.genesisDocument,
+      }));
+
+      expect(res.status).to.equal(401);
+      expect(server.getPeerPk(victim.did)).to.equal(undefined);
+    });
+
+    it('rejects an x1 opt-in whose communicationPk disagrees with the genesis-derived key (401)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+      const stranger = SchnorrKeyPair.generate();
+
+      const res = await post(optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : stranger.publicKey.compressed, // advertises a different key
+        genesisDocument : x1.genesisDocument,
+      }));
+
+      expect(res.status).to.equal(401);
+      expect(server.getPeerPk(x1.did)).to.equal(undefined);
+    });
+
+    it('rejects an x1 opt-in signed by a key other than the genesis key (401)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+      const attacker = SchnorrKeyPair.generate();
+
+      // Real genesis + honest communicationPk, but the envelope is signed by an attacker
+      // who does not control the genesis key: cross-check passes, signature verify fails.
+      const res = await post(optInEnvelope(x1.did, attacker, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+        genesisDocument : x1.genesisDocument,
+      }));
+
+      expect(res.status).to.equal(401);
+      expect(server.getPeerPk(x1.did)).to.equal(undefined);
+    });
+
+    it('lets a bootstrapped x1 peer send a later message with no genesis (registered peer)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+
+      const first = await post(optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+        genesisDocument : x1.genesisDocument,
+      }));
+      expect(first.status).to.equal(202);
+
+      // A distinct follow-up message (fresh nonce), no genesis: resolves via the registry.
+      const second = await post(optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c2',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+      }));
+      expect(second.status).to.equal(202);
+    });
+
+    it('rejects an over-large body before parsing it (413) on /v1/messages and /v1/adverts', async () => {
+      server = makeServer({ maxBodyBytes: 100 });
+      server.registerActor(serverDid, serverKeys);
+      const x1 = makeExternalIdentity();
+
+      const body = optInEnvelope(x1.did, x1.keys, {
+        cohortId        : 'c1',
+        participantPk   : x1.keys.publicKey.compressed,
+        communicationPk : x1.keys.publicKey.compressed,
+        genesisDocument : x1.genesisDocument,
+      });
+      expect(body.length).to.be.greaterThan(100);
+
+      const messages = await server.handleRequest(req('POST', HTTP_ROUTE.MESSAGES, {}, body));
+      expect(messages.status).to.equal(413);
+      const adverts = await server.handleRequest(req('POST', HTTP_ROUTE.ADVERTS, {}, body));
+      expect(adverts.status).to.equal(413);
+    });
+
+    it('rejects an inner message.from that differs from the authenticated envelope.from (no poisoning)', async () => {
+      server = makeServer();
+      server.registerActor(serverDid, serverKeys);
+      // The attacker controls their own resolvable k1 DID and signs the envelope with it,
+      // but the inner opt-in claims to come from a victim x1 DID. The transport must not
+      // let the attacker seat the victim into the cohort or poison the registry for it.
+      const attackerKeys = SchnorrKeyPair.generate();
+      const attackerDid  = DidBtcr2.create(attackerKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+      const victim = makeExternalIdentity();
+
+      const msg = new BaseMessage({
+        type : COHORT_OPT_IN,
+        from : victim.did, // spoofed inner sender
+        to   : serverDid,
+        body : {
+          cohortId        : 'c1',
+          participantPk   : attackerKeys.publicKey.compressed,
+          communicationPk : attackerKeys.publicKey.compressed,
+        } as BaseBody,
+      });
+      const env = signEnvelope(msg, { did: attackerDid, keys: attackerKeys }, { to: serverDid });
+
+      const res = await server.handleRequest(
+        req('POST', HTTP_ROUTE.MESSAGES, { 'content-type': 'application/json' }, JSON.stringify(env)));
+      expect(res.status).to.equal(401);
+      expect(server.getPeerPk(victim.did)).to.equal(undefined);
+      expect(server.getPeerPk(attackerDid)).to.equal(undefined);
+    });
+
+    it('does not register a bootstrapped x1 peer when the request is rejected downstream (404)', async () => {
+      server = makeServer();
+      // No actor is registered for the recipient, so the request is rejected 404 after the
+      // bootstrap authenticates the sender. No peer-registry state must survive.
+      const nonexistent = DidBtcr2.create(SchnorrKeyPair.generate().publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+      const x1 = makeExternalIdentity();
+
+      const msg = new BaseMessage({
+        type : COHORT_OPT_IN,
+        from : x1.did,
+        to   : nonexistent,
+        body : {
+          cohortId        : 'c1',
+          participantPk   : x1.keys.publicKey.compressed,
+          communicationPk : x1.keys.publicKey.compressed,
+          genesisDocument : x1.genesisDocument,
+        } as BaseBody,
+      });
+      const env = signEnvelope(msg, { did: x1.did, keys: x1.keys }, { to: nonexistent });
+
+      const res = await server.handleRequest(
+        req('POST', HTTP_ROUTE.MESSAGES, { 'content-type': 'application/json' }, JSON.stringify(env)));
+      expect(res.status).to.equal(404);
+      expect(server.getPeerPk(x1.did)).to.equal(undefined);
+    });
+  });
+
+  describe('AggregationParticipant opt-in', () => {
+    const advertFor = (participantDid: string): BaseMessage => new BaseMessage({
+      type : COHORT_ADVERT,
+      from : serverDid,
+      to   : participantDid,
+      body : {
+        cohortId         : 'c1',
+        minParticipants  : 2,
+        beaconType       : 'CASBeacon',
+        network          : 'mutinynet',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+        communicationPk  : serverKeys.publicKey.compressed,
+      },
+    });
+
+    it('an x1 participant attaches its genesis and advertises the genesis-derived key', () => {
+      const x1 = makeExternalIdentity();
+      const participant = new AggregationParticipant({
+        did             : x1.did,
+        signer          : new KeyPairAggregationSigner(x1.keys),
+        genesisDocument : x1.genesisDocument,
+      });
+      participant.receive(advertFor(x1.did));
+      const [optIn] = participant.joinCohort('c1');
+
+      expect(optIn.body?.genesisDocument).to.deep.equal(x1.genesisDocument);
+      expect(hexOf(optIn.body!.communicationPk!)).to.equal(hexOf(x1.keys.publicKey.compressed));
+
+      // Comm-key parity: the participant signs/advertises exactly the key the resolver
+      // derives from the genesis (ADR 066 section 4.4).
+      const derived = resolveBtcr2SenderPk(x1.did, { genesisDocument: x1.genesisDocument })!;
+      expect(hexOf(derived.compressed)).to.equal(hexOf(participant.publicKey));
+    });
+
+    it('a k1 participant omits the genesis document', () => {
+      const keys = SchnorrKeyPair.generate();
+      const did  = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+      const participant = new AggregationParticipant({ did, signer: new KeyPairAggregationSigner(keys) });
+      participant.receive(advertFor(did));
+      const [optIn] = participant.joinCohort('c1');
+
+      expect(optIn.body?.genesisDocument).to.equal(undefined);
+    });
+  });
+
+  describe('full cohort (symmetry)', () => {
+    it('completes a mixed k1 + x1 cohort over the in-memory transport with a valid aggregate signature', async () => {
+      const serviceKeys = SchnorrKeyPair.generate();
+      const serviceDid  = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+      const aliceKeys   = SchnorrKeyPair.generate();
+      const aliceDid    = DidBtcr2.create(aliceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+      const bob         = makeExternalIdentity('mutinynet'); // x1
+
+      const bus = new MessageBus();
+      const serviceTransport = new MockTransport(bus);
+      const aliceTransport   = new MockTransport(bus);
+      const bobTransport     = new MockTransport(bus);
+      serviceTransport.registerActor(serviceDid, serviceKeys);
+      aliceTransport.registerActor(aliceDid, aliceKeys);
+      bobTransport.registerActor(bob.did, bob.keys);
+
+      const service = new AggregationServiceRunner({
+        transport       : serviceTransport,
+        did             : serviceDid,
+        keys            : serviceKeys,
+        config          : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: TEST_RECOVERY_KEY, recoverySequence: TEST_RECOVERY_SEQUENCE },
+        onProvideTxData : async () => {
+          const cohort = service.session.cohorts[0];
+          const aggPk  = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
+          const payment = p2tr(aggPk);
+          const prevOutValue = 100000n;
+          const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
+          return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+        },
+      });
+
+      const aliceRunner = new AggregationParticipantRunner({
+        transport       : aliceTransport,
+        did             : aliceDid,
+        keys            : aliceKeys,
+        shouldJoin      : async () => true,
+        onProvideUpdate : async () => createSignedUpdate(aliceDid, aliceKeys),
+      });
+      const bobRunner = new AggregationParticipantRunner({
+        transport       : bobTransport,
+        did             : bob.did,
+        keys            : bob.keys,
+        genesisDocument : bob.genesisDocument,
+        shouldJoin      : async () => true,
+        onProvideUpdate : async () => createSignedUpdate(bob.did, bob.keys),
+      });
+
+      // The x1 participant reaches Complete when it processes the aggregated nonce and
+      // sends its partial signature; await that event rather than sampling it after
+      // service.run() resolves (the participant completion flushes on its own microtask).
+      const bobComplete = new Promise<string>((resolve) =>
+        bobRunner.on('cohort-complete', () => resolve('cohort-complete')));
+
+      await aliceRunner.start();
+      await bobRunner.start();
+      const [result, bobStatus] = await Promise.all([service.run(), bobComplete]);
+
+      expect(result.signature.length).to.equal(64);
+      expect(result.signedTx).to.exist;
+      expect(bobStatus).to.equal('cohort-complete');
+    });
+  });
+});

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @did-btcr2/api
+
+## 0.13.10
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.51.0

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.9",
+    "version": "0.13.10",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @did-btcr2/cli
+
+## 0.12.15
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.51.0
+  - @did-btcr2/api@0.13.10

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @did-btcr2/method
+
+## 0.51.0
+
+### Minor Changes
+
+- Authenticate EXTERNAL (x1) did:btcr2 identifiers on the aggregation HTTP transport (ADR 066)
+
+  EXTERNAL (x1) DIDs can now join aggregation cohorts as first-class members over the HTTP
+  transport, the way KEY (k1) DIDs already do. An x1 DID commits to the hash of its genesis
+  document, so the controller carries that self-verifying genesis in-band on the cohort opt-in;
+  the service recomputes the hash, derives the communication key from `capabilityInvocation[0]`
+  (no `verificationMethod[0]` fallback), cross-checks it against the advertised
+  `communicationPk`, verifies the envelope signature, and only then registers the peer. There
+  is no trust-on-first-use.
+
+  - `@did-btcr2/method`: `resolveBtcr2SenderPk(did, { genesisDocument })` is now genesis-aware
+    (the one-argument form is unchanged: k1 to key, x1 to undefined), and a new exported
+    `getAggregationCommunicationKey(document)` derives the aggregation communication key from
+    `capabilityInvocation[0]`.
+  - `@did-btcr2/aggregation`: the cohort opt-in body carries an optional `genesisDocument`; the
+    HTTP server bootstraps an unregistered x1 sender from it, binds the inner `message.from` to
+    the authenticated `envelope.from`, registers a bootstrapped peer only after the request
+    clears every gate, and accepts a new `maxBodyBytes` transport option (413 on oversize). The
+    package remains method-agnostic.
+
+  Backward compatible: existing k1 opt-ins, one-argument resolver callers, and older
+  participants are unaffected.

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/did-sender-resolver.ts
+++ b/packages/method/src/core/did-sender-resolver.ts
@@ -1,25 +1,106 @@
+import { DidDocumentError, INVALID_DID_DOCUMENT } from '@did-btcr2/common';
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import type { DidDocument, DidVerificationMethod } from '../utils/did-document.js';
 import { Identifier } from './identifier.js';
+import { Resolver } from './resolver.js';
+
+/**
+ * Derive the aggregation communication public key from a resolved did:btcr2 DID Document.
+ *
+ * The communication key is the verification method referenced by
+ * `capabilityInvocation[0]`, resolved to its public key. This is the exact relationship
+ * the method already enforces for DID updates (construct and sign require the signing
+ * method to be in `capabilityInvocation`, the update proof is built and verified with
+ * `proofPurpose: 'capabilityInvocation'`), so binding the transport communication key to
+ * it yields the invariant "transport-authenticated as D implies authorized to update D."
+ * For a KEY (`k1`) document the single deterministic key is already the sole
+ * `capabilityInvocation` entry, so this is a no-op for KEY DIDs.
+ *
+ * There is deliberately no `verificationMethod[0]` fallback: a document without
+ * `capabilityInvocation` cannot be updated at all, so it is useless for aggregation and is
+ * rejected here rather than bound to an unrelated key.
+ *
+ * @param {DidDocument} document The resolved DID Document (placeholder id already replaced).
+ * @returns {CompressedSecp256k1PublicKey} The compressed public key of the communication method.
+ * @throws {DidDocumentError} If `capabilityInvocation` is absent or its first entry does not
+ *   resolve to a verification method in the document.
+ */
+export function getAggregationCommunicationKey(
+  document: DidDocument,
+): CompressedSecp256k1PublicKey {
+  const invocation = document.capabilityInvocation?.[0];
+  if(invocation === undefined) {
+    throw new DidDocumentError(
+      'Cannot derive aggregation communication key: capabilityInvocation is absent',
+      INVALID_DID_DOCUMENT, { id: document.id }
+    );
+  }
+
+  // Resolve capabilityInvocation[0] to a verification method: a string reference is
+  // dereferenced by id against verificationMethod; an embedded method is used directly.
+  // A local id lookup is used rather than getSigningMethod, which defaults to #initialKey
+  // and does not resolve embedded methods.
+  const vm: DidVerificationMethod | undefined = typeof invocation === 'string'
+    ? document.verificationMethod?.find(method => method.id === invocation)
+    : invocation;
+
+  if(!vm) {
+    throw new DidDocumentError(
+      `Cannot derive aggregation communication key: capabilityInvocation[0] "${invocation}" `
+        + 'does not resolve to a verification method',
+      INVALID_DID_DOCUMENT, { id: document.id, invocation }
+    );
+  }
+
+  return SchnorrMultikey.fromVerificationMethod(vm).publicKey;
+}
 
 /**
  * Resolve a did:btcr2 sender's communication public key from its DID, for the
- * aggregation HTTP transport's `resolveSenderPk` option: a KEY identifier decodes to
- * its genesis public key. The aggregation transport is DID-method-agnostic and does
- * not name `Identifier`; method supplies this resolver when it wires the transport so
- * a sender that is not a pre-registered peer can still be authenticated from its DID.
+ * aggregation HTTP transport's `resolveSenderPk` option.
  *
- * @param did The sender's DID.
- * @returns The sender's compressed public key, or `undefined` when the DID is not a
- *   decodable did:btcr2 KEY identifier (resolution then falls back to registered peers).
+ * A KEY (`k1`) identifier decodes directly to its genesis public key: the DID string is
+ * the key. An EXTERNAL (`x1`) identifier is a commitment to the hash of a genesis
+ * document, so there is no key in the DID string. When the genesis document is supplied
+ * in-band (via `opts.genesisDocument`), it is self-verifying against the DID: `Resolver`'s
+ * external path recomputes its canonical hash, compares it to the identifier's genesis
+ * bytes (throwing on mismatch), and resolves it, after which the communication key is
+ * derived from `capabilityInvocation[0]` ({@link getAggregationCommunicationKey}). Without
+ * a genesis document, an `x1` DID still resolves to `undefined`, so callers that pass no
+ * second argument behave exactly as before.
+ *
+ * The aggregation transport is DID-method-agnostic and does not name `Identifier`; method
+ * supplies this resolver when it wires the transport so a sender that is not a
+ * pre-registered peer can still be authenticated from its DID.
+ *
+ * @param {string} did The sender's DID.
+ * @param {object} [opts] Optional resolution inputs.
+ * @param {object} [opts.genesisDocument] The `x1` sender's genesis document, carried in-band
+ *   on the bootstrap opt-in. Ignored for KEY identifiers.
+ * @returns {CompressedSecp256k1PublicKey | undefined} The sender's compressed public key, or
+ *   `undefined` when the DID is not a decodable did:btcr2 identifier, is an `x1` identifier
+ *   with no (or a non-matching) genesis document, or has no usable communication key.
  */
-export function resolveBtcr2SenderPk(did: string): CompressedSecp256k1PublicKey | undefined {
+export function resolveBtcr2SenderPk(
+  did: string,
+  opts?: { genesisDocument?: object },
+): CompressedSecp256k1PublicKey | undefined {
   try {
     const components = Identifier.decode(did);
     if(components.idType === 'KEY') {
       return new CompressedSecp256k1PublicKey(components.genesisBytes);
     }
+    // EXTERNAL (x1): the DID commits to the hash of a genesis document. With the genesis
+    // supplied in-band, verify it hashes to the DID and derive the communication key from
+    // it; without it, there is no key to return.
+    if(opts?.genesisDocument) {
+      const document = Resolver.external(components, opts.genesisDocument);
+      return getAggregationCommunicationKey(document);
+    }
   } catch {
-    // Not a decodable did:btcr2 KEY identifier.
+    // Not a decodable did:btcr2 identifier, the genesis does not hash to the DID, or the
+    // document has no usable capabilityInvocation communication key.
   }
   return undefined;
 }

--- a/packages/method/tests/did-sender-resolver.spec.ts
+++ b/packages/method/tests/did-sender-resolver.spec.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import { hex } from '@scure/base';
+import { CompressedSecp256k1PublicKey, SchnorrKeyPair } from '@did-btcr2/keypair';
+import { DidBtcr2 } from '../src/did-btcr2.js';
+import { getAggregationCommunicationKey, resolveBtcr2SenderPk } from '../src/core/did-sender-resolver.js';
+import { GenesisDocument, type DidDocument, type GenesisDocumentLike } from '../src/utils/did-document.js';
+import externalData from './data/external-data.js';
+import deterministicData from './data/deterministic-data.js';
+
+/**
+ * Sender-key resolution for the aggregation transport, for both KEY (k1) and
+ * EXTERNAL (x1) did:btcr2 identifiers (ADR 066).
+ */
+
+/** Public key (compressed, hex) derived independently from a secret key hex. */
+const derivePkHex = (secretKey: string): string =>
+  hex.encode(SchnorrKeyPair.fromSecret(secretKey).publicKey.compressed);
+
+const external = externalData[0];
+
+describe('resolveBtcr2SenderPk', () => {
+  it('resolves a KEY (k1) DID to its genesis public key, ignoring any genesis document', () => {
+    for(const { did, genesisBytes } of deterministicData) {
+      const resolved = resolveBtcr2SenderPk(did);
+      expect(resolved, did).to.be.instanceOf(CompressedSecp256k1PublicKey);
+      expect(hex.encode(resolved!.compressed), did).to.equal(hex.encode(genesisBytes));
+
+      // A genesisDocument argument is ignored for a KEY identifier.
+      const withGenesis = resolveBtcr2SenderPk(did, { genesisDocument: external.genesisDocument });
+      expect(hex.encode(withGenesis!.compressed), did).to.equal(hex.encode(genesisBytes));
+    }
+  });
+
+  it('resolves an EXTERNAL (x1) DID to its capabilityInvocation[0] key when the genesis matches', () => {
+    for(const { did, secretKey, genesisDocument } of externalData) {
+      const resolved = resolveBtcr2SenderPk(did, { genesisDocument });
+      expect(resolved, did).to.be.instanceOf(CompressedSecp256k1PublicKey);
+      expect(hex.encode(resolved!.compressed), did).to.equal(derivePkHex(secretKey));
+    }
+  });
+
+  it('returns undefined for an EXTERNAL (x1) DID with no genesis document (1-arg unchanged)', () => {
+    for(const { did } of externalData) {
+      expect(resolveBtcr2SenderPk(did), did).to.equal(undefined);
+    }
+  });
+
+  it('returns undefined when the supplied genesis does not hash to the x1 DID', () => {
+    // fixture[0]'s DID paired with fixture[1]'s genesis document: the hash commitment fails.
+    const resolved = resolveBtcr2SenderPk(externalData[0].did, { genesisDocument: externalData[1].genesisDocument });
+    expect(resolved).to.equal(undefined);
+  });
+
+  it('returns undefined for an x1 DID whose genesis has no capabilityInvocation', () => {
+    // Build a genesis that is well-formed but lacks capabilityInvocation, then mint the DID
+    // that commits to exactly that document so the hash check passes and only the missing
+    // communication key rejects it.
+    const genesis: Record<string, unknown> = structuredClone(external.genesisDocument);
+    delete genesis.capabilityInvocation;
+    const genesisBytes = GenesisDocument.toGenesisBytes(genesis as GenesisDocumentLike);
+    const did = DidBtcr2.create(genesisBytes, { idType: 'EXTERNAL', network: external.network });
+    expect(resolveBtcr2SenderPk(did, { genesisDocument: genesis })).to.equal(undefined);
+  });
+
+  it('returns undefined for a non-did:btcr2 or undecodable identifier', () => {
+    expect(resolveBtcr2SenderPk('did:example:123')).to.equal(undefined);
+    expect(resolveBtcr2SenderPk('not-a-did', { genesisDocument: external.genesisDocument })).to.equal(undefined);
+  });
+});
+
+describe('getAggregationCommunicationKey', () => {
+  const controller = 'did:btcr2:x1example';
+  const vmId = `${controller}#key-0`;
+  const publicKeyMultibase = external.genesisDocument.verificationMethod[0].publicKeyMultibase;
+  const vm = { id: vmId, type: 'Multikey', controller, publicKeyMultibase };
+  const expectedPkHex = derivePkHex(external.secretKey);
+
+  it('resolves a string capabilityInvocation reference against verificationMethod', () => {
+    const doc = { id: controller, verificationMethod: [vm], capabilityInvocation: [vmId] } as unknown as DidDocument;
+    expect(hex.encode(getAggregationCommunicationKey(doc).compressed)).to.equal(expectedPkHex);
+  });
+
+  it('uses an embedded capabilityInvocation verification method directly', () => {
+    const doc = { id: controller, verificationMethod: [], capabilityInvocation: [vm] } as unknown as DidDocument;
+    expect(hex.encode(getAggregationCommunicationKey(doc).compressed)).to.equal(expectedPkHex);
+  });
+
+  it('throws when capabilityInvocation is absent (no verificationMethod[0] fallback)', () => {
+    const doc = { id: controller, verificationMethod: [vm] } as unknown as DidDocument;
+    expect(() => getAggregationCommunicationKey(doc)).to.throw(/capabilityInvocation/);
+  });
+
+  it('throws when the capabilityInvocation reference does not resolve to a verification method', () => {
+    const doc = { id: controller, verificationMethod: [], capabilityInvocation: [vmId] } as unknown as DidDocument;
+    expect(() => getAggregationCommunicationKey(doc)).to.throw(/verification method/);
+  });
+});
+
+describe('x1 genesis hash commitment (round-trip)', () => {
+  it('the DID re-encodes from the canonical hash of its genesis document', () => {
+    for(const { did, network, genesisBytes, genesisDocument } of externalData) {
+      const hashed = GenesisDocument.toGenesisBytes(genesisDocument as GenesisDocumentLike);
+      expect(hex.encode(hashed), did).to.equal(hex.encode(genesisBytes));
+      expect(DidBtcr2.create(hashed, { idType: 'EXTERNAL', network }), did).to.equal(did);
+    }
+  });
+});


### PR DESCRIPTION
* chore(release): method 0.51.0, aggregation 0.4.0, api 0.13.10, cli 0.12.15
* test: x1 sender-resolver unit tests + HTTP bootstrap/binding/DoS + full mixed k1+x1 cohort
* feat(method): genesis-aware resolveBtcr2SenderPk + getAggregationCommunicationKey
* feat(aggregation): genesis on opt-in + bootstrap + maxBodyBytes
* docs(adr): add ADR 066 (trustless x1 transport authentication)