### PR TITLE
resolve DIDs with duplicate update history

### DIFF
--- a/docs/adr/067-resolver-duplicate-confirmation.md
+++ b/docs/adr/067-resolver-duplicate-confirmation.md
@@ -1,0 +1,196 @@
+---
+title: "ADR 067: Resolver Duplicate-Update Confirmation - Conditional Increment and Compare-Only History"
+---
+
+# ADR 067: Resolver Duplicate-Update Confirmation - Conditional Increment and Compare-Only History
+
+**Status:** Accepted
+
+**Date:** 2026-07-02
+
+**Branch / PR:** `fix/resolver-duplicate-handling`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 055](055-resolver-provide-trust-boundary.md), [ADR 060](060-resolver-cross-round-version-continuity.md), [did:btcr2 Resolve](https://dcdpr.github.io/did-btcr2/operations/resolve.html), [W3C DID Resolution](https://w3c.github.io/did-resolution/)
+
+## Context
+
+The did:btcr2 read algorithm processes beacon signals in a loop, keeping two pieces of
+loop-invariant state: a monotonic `current_version_id` (starting at 1) and an
+`update_hash_history`. For each signal's update it compares `targetVersionId` against
+`current_version_id`:
+
+- `targetVersionId <= current_version_id`: the update re-announces a version that was
+  already applied. It is a **duplicate**. The "Confirm Duplicate Update" step re-derives the
+  unsigned-update hash and checks it against the history, then moves on. A duplicate is not
+  an error: the same update can legitimately appear more than once on chain.
+- `targetVersionId == current_version_id + 1`: the next update in the linear history. Apply it.
+- `targetVersionId > current_version_id + 1`: a version was skipped, which indicates late
+  publishing. Raise `LATE_PUBLISHING_ERROR`.
+
+Duplicates are readily reachable, and not only through a non-conformant writer. A deterministic
+KEY (k1) DID derives three Singleton beacons (P2PKH, P2WPKH, P2TR) from its one key, at
+distinct, publicly-derivable addresses. Announcing the same update on two of a controller's own
+beacons is a plausible redundancy pattern; a third party can also replay a 32-byte update hash
+in an `OP_RETURN` at a second derivable beacon address. Signal discovery has no per-update
+dedup and `SingletonBeacon.processSignals` emits one tuple per signal, so each announcement
+reaches the update loop as a genuine duplicate whose content-hash binding ([ADR 055](055-resolver-provide-trust-boundary.md)) is satisfied - the duplicate really is the update.
+
+Two questions decide how a duplicate is handled, and the specification, its reference
+implementation, and this implementation disagreed on both:
+
+| point | current spec prose | reference Rust impl | this impl (before this change) |
+|---|---|---|---|
+| (a) increment the version counter after a confirmed duplicate | unconditional (a flat "Process updates Array" list whose "Increment current_version_id" is a sibling step of the duplicate/apply check) | conditional (increments only inside the apply branch) | unconditional |
+| (b) append to `update_hash_history` in the duplicate branch | compare-only, no append (the history is defined to hold unsigned-update hashes only) | pushes the contemporary document hash | pushed the contemporary document hash |
+
+This implementation was a broken hybrid: the spec's unconditional increment (a) combined with
+the reference impl's contemporary-hash push (b).
+
+The provenance explains the split. The duplicate push descends from the predecessor did:btc1
+method, where the increment was conditional and the duplicate branch did push. The did:btcr2
+rewrite reversed **both** in the prose (unconditional increment, compare-only history), but the
+reference Rust implementation kept the did:btc1 shape. This implementation adopted the spec's
+(a) and the reference impl's (b), taking the one combination that is wrong on both counts.
+
+### Why the hybrid is wrong, with traces
+
+Trace `[v2, v2-dup, v3]` (a v2 update, a duplicate of v2, then a genuine v3):
+
+- v2 applies; `current_version_id` becomes 2.
+- v2-dup enters the duplicate branch. The unconditional increment (a) then advances
+  `current_version_id` to 3, and the push (b) appends the current document hash to the history.
+- v3 arrives with `targetVersionId` 3. Because the counter was inflated to 3, `3 <= 3` routes
+  v3 into the duplicate branch. Confirmation reads a history slot that holds a document hash,
+  not v3's unsigned-update hash, so it raises a **false** `LATE_PUBLISHING_ERROR`. A perfectly
+  linear history is bricked by one duplicate.
+
+Observable effects, both reproduced against the compiled build: `metadata.versionId` inflates
+by one per duplicate (a v2 document reported as v3), and the next genuine update fails to
+resolve. The failure also survives across discovery rounds: a v3 announced on a beacon that v2
+added (discovered a round later) fails the same way when v2 is redundantly re-announced there.
+
+Neither maintainer combination is fully correct either. The spec prose (unconditional increment
++ compare-only) still bricks `[v2, v2-dup, v3]`, because the increment alone inflates the
+counter. The reference impl (conditional increment + contemporary-hash push) instead bricks
+`[v2, v2-dup, v3, v3-dup]`, because the pushed document hashes misalign the history index once
+duplicates of two different non-final versions appear.
+
+[ADR 060](060-resolver-cross-round-version-continuity.md) deliberately left this question open
+under its "Out of scope": it carried the version counter and history across discovery rounds
+without changing how they respond to a duplicate. This ADR is that change.
+
+## Decision
+
+Adopt the one combination that handles every duplicate pattern - conditional increment plus
+compare-only history:
+
+### 1. Increment the version counter only on the apply path
+
+A confirmed duplicate calls the confirmation step and then continues to the next tuple. It does
+**not** advance `current_version_id`. The increment, and the `metadata.versionId` it produces,
+run only when an update is actually applied. This removes the version inflation and the false
+`LATE_PUBLISHING_ERROR` that followed it, both in a single discovery round and across rounds
+(the counter and history carried by [ADR 060](060-resolver-cross-round-version-continuity.md)
+now stay correct when a later round re-encounters an already-applied version).
+
+### 2. Confirm duplicates against the history without appending to it
+
+The duplicate branch compares the unsigned-update hash against
+`update_hash_history[targetVersionId - 2]` and appends nothing. That slot already holds the
+applied update for the duplicated version - the apply path recorded it - so the historical
+contemporary-hash push is unnecessary and, as the traces show, harmful. The history holds
+unsigned-update hashes only, matching the spec's definition.
+
+Together, (1) and (2) are the increment fix from the reference implementation combined with the
+compare-only history from the specification prose. This is a deliberate deviation from the
+current spec text on point (a): the spec's "Increment current_version_id" is treated as
+belonging to the apply branch, not to every tuple. The deviation is being pursued as an erratum
+to the did:btcr2 specification (move the increment into the apply step) and as a fix to the
+reference implementation (drop the duplicate-branch push); until those land, this implementation
+carries the traced deviation, with a code comment at the site pointing here.
+
+### 3. Scope: the document-metadata timestamps are left unchanged
+
+`metadata.updated` and `metadata.confirmations` continue to be set from each processed signal's
+block, exactly as before this change. Only the version counter and `metadata.versionId` are
+gated to the apply path. This keeps the change confined to the duplicate-confirmation defect and
+avoids a regression in the sans-I/O resolver's multi-round design (see Rejected alternatives).
+As a consequence, `metadata.updated`/`confirmations` still reflect the block of the last signal
+processed, which for a resolution ending on a duplicate is that duplicate's block. Refining
+those fields to track only real state changes is a separate, larger change and is left out of
+scope.
+
+### Verification
+
+The behavior is proven in both directions. The regression tests resolve `[v2, v2-dup, v3]`,
+`[v2, v2-dup, v3, v3-dup]`, and `[v2, v3, v3-dup]` to the correct final version, assert a
+duplicate does not inflate `versionId`, exercise one update announced on two of a k1 DID's own
+beacons, and exercise a cross-round duplicate re-announced on a beacon an earlier update added.
+As a negative control, the same tests were run against the pre-change `updates()` and six of the
+seven fail (versionId inflation and thrown false `LATE_PUBLISHING_ERROR`), which confirms they
+exercise the defect rather than passing vacuously. The confirmation guard still rejects a genuine
+mismatch: an update that claims an already-used `targetVersionId` but carries different content
+is still rejected as invalid (the seventh test, which passes under both old and new code).
+
+## Consequences
+
+- A linear history that includes a duplicate re-announcement now resolves, instead of failing
+  with a false `LATE_PUBLISHING_ERROR`, in a single round and across discovery rounds. This is
+  the headline fix.
+- `metadata.versionId` reports the document's true version regardless of how many times updates
+  were re-announced; a duplicate no longer inflates it.
+- The `update_hash_history` holds only unsigned-update hashes, matching the spec's definition
+  and making duplicate confirmation index-correct for duplicates of any non-final version.
+- `metadata.updated` and `metadata.confirmations` are unchanged by this fix; their existing
+  behavior (reflecting the block of the last processed signal) is preserved.
+- This is a behavior change to resolution output for inputs that contain duplicates. Under
+  semantic versioning on a `0.x` line it is released as a minor bump.
+- The implementation now deviates from the current did:btcr2 spec prose on point (a) by design.
+  The deviation, its rationale, and the traces are recorded here, and the code comment at the
+  duplicate branch references this ADR so the deviation is discoverable at the site.
+
+## Rejected alternatives
+
+- **Keep the spec prose exactly (unconditional increment + compare-only).** Rejected: it bricks
+  `[v2, v2-dup, v3]`. The unconditional increment inflates the counter on the duplicate, so the
+  next genuine update is misread as a duplicate against an index that does not hold its hash.
+- **Match the reference implementation exactly (conditional increment + contemporary-hash push).**
+  Rejected: it bricks `[v2, v2-dup, v3, v3-dup]`. Once duplicates of two different non-final
+  versions appear, the pushed document hashes shift the history index out of alignment with the
+  `targetVersionId - 2` read.
+- **Drop only the duplicate-branch push, keep the unconditional increment.** This is the shape a
+  prior local audit reached. Rejected: removing the push alone is insufficient, because the
+  unconditional increment on a duplicate still inflates the counter and false-trips
+  `LATE_PUBLISHING_ERROR` on the following genuine update. The two changes are needed together.
+- **Set `metadata.updated`/`confirmations` only on the apply path, so a duplicate cannot move
+  them.** This looks more faithful to the W3C meaning of `updated` (the last operation that
+  changed the document), and it was tried. Rejected for this change: the sans-I/O resolver runs
+  `updates()` once per discovery round with a freshly initialized response, so a discovery round
+  that processes only duplicates applies nothing and returns empty `updated`/zero `confirmations`,
+  discarding the real last-apply metadata carried from an earlier round. This was reproduced: a
+  two-round resolution whose second round is a duplicate-only re-announcement returned
+  `updated: ""`, `confirmations: 0`. Making the apply-only placement correct would require
+  carrying the timestamp and confirmation metadata across rounds, a larger change orthogonal to
+  the duplicate-confirmation defect. It is left as a possible follow-up (see Out of scope).
+
+## Out of scope
+
+- **Document-metadata timestamp semantics.** As above, `metadata.updated`/`confirmations` are
+  left as-is. A follow-up could carry them across discovery rounds and set them only on real
+  applies so a duplicate or third-party replay cannot move them.
+- **`versionTime` interaction with an out-of-order duplicate.** Updates are sorted by
+  `targetVersionId` first, so a duplicate of an early version that was mined *after* a genuine
+  later update sorts *before* that later update. Under a `versionTime` query, the duplicate's
+  block can trip the `versionTime` early-return before the genuine in-window update is applied,
+  returning an earlier version than the one valid at `versionTime`. This is pre-existing (present
+  before and after this change) and left for a separate review.
+- **`confirmDuplicate` index underflow.** `confirmDuplicate` reads
+  `update_hash_history[targetVersionId - 2]` directly. A malformed update crafted with
+  `targetVersionId` below 2 would index before the start of the history; conformant updates
+  (whose `targetVersionId` is at least 2) never reach it, and hardening that index is left to a
+  separate change.
+
+This ADR does not alter cross-round version continuity
+([ADR 060](060-resolver-cross-round-version-continuity.md)) or the `provide()` trust boundary
+([ADR 055](055-resolver-provide-trust-boundary.md)); it changes only how a confirmed duplicate
+affects the version counter and the update-hash history.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -67,6 +67,7 @@ children:
   - ./064-foss-coverage-and-dependency-audit-gate.md
   - ./065-changesets-for-changelogs-manual-release.md
   - ./066-x1-transport-authentication.md
+  - ./067-resolver-duplicate-confirmation.md
 ---
 
 # Architecture Decision Records
@@ -141,3 +142,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 064 | 2026-07-02 | [FOSS In-Repo Coverage Reporting and a Dependency-Audit Gate](064-foss-coverage-and-dependency-audit-gate.md) |
 | 065 | 2026-07-02 | [Adopt Changesets for Per-Package Changelogs with Manual Publishing](065-changesets-for-changelogs-manual-release.md) |
 | 066 | 2026-07-02 | [Trustless Transport Authentication for EXTERNAL (x1) DIDs via In-Band Genesis Documents](066-x1-transport-authentication.md) |
+| 067 | 2026-07-02 | [Resolver Duplicate-Update Confirmation - Conditional Increment and Compare-Only History](067-resolver-duplicate-confirmation.md) |

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @did-btcr2/api
 
+## 0.13.11
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.52.0
+
 ## 0.13.10
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.10",
+    "version": "0.13.11",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @did-btcr2/cli
 
+## 0.12.16
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.52.0
+  - @did-btcr2/api@0.13.11
+
 ## 0.12.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @did-btcr2/method
 
+## 0.52.0
+
+### Minor Changes
+
+- Fix resolver duplicate-update confirmation so a re-announced update no longer bricks resolution (ADR 067)
+
+  A confirmed duplicate update (the same version announced more than once on chain, for
+  example on two of a k1 DID's own beacons or replayed by a third party at another derivable
+  beacon address) no longer advances the version counter. `Resolver.updates()` now increments
+  `current_version_id`, and the `versionId` it reports, only on the apply path, and confirms a
+  duplicate against the update-hash history without appending to it. This removes a `versionId`
+  inflation that mis-classified the next genuine update and raised a false `LATE_PUBLISHING_ERROR`,
+  bricking an otherwise-valid linear history in a single discovery round and across rounds. The
+  duplicate-confirmation guard still rejects an update that claims an already-used version but
+  carries different content. This is a deliberate, traced deviation from the current spec prose on
+  when the counter increments, pursued upstream as a spec erratum; see ADR 067.
+
 ## 0.51.0
 
 ### Minor Changes

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.51.0",
+    "version": "0.52.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -419,15 +419,23 @@ export class Resolver {
         }
       }
 
-      // Check update.targetVersionId against currentVersionId
-      // If update.targetVersionId <= currentVersionId, confirm duplicate update
+      // Check update.targetVersionId against currentVersionId.
+      // If update.targetVersionId <= currentVersionId, this update re-announces a version
+      // that has already been applied. Confirm it is a true duplicate, then skip it: a
+      // duplicate does not advance the version counter (the increment and the
+      // metadata.versionId it sets run only on the apply path below), and confirmation
+      // compares against the update-hash history without appending to it, because the
+      // history already holds the applied update at updateHashHistory[targetVersionId - 2].
+      // Holding the increment off the duplicate path is the deliberate did:btcr2 deviation
+      // recorded in ADR 067: the read algorithm's "Increment current_version_id" belongs
+      // to the apply branch, not to every tuple.
       if(update.targetVersionId <= currentVersionId) {
-        updateHashHistory.push(currentDocumentHash);
         this.confirmDuplicate(update, updateHashHistory);
+        continue;
       }
 
       // If update.targetVersionId == currentVersionId + 1, apply the update
-      else if (update.targetVersionId === currentVersionId + 1) {
+      if (update.targetVersionId === currentVersionId + 1) {
         // Check if update.sourceHash !== currentDocumentHash (byte comparison)
         const sourceHashBytes = decodeHash(update.sourceHash, 'base64urlnopad');
         if (!equalBytes(sourceHashBytes, currentDocumentHash)) {
@@ -448,11 +456,12 @@ export class Resolver {
         updateHashHistory.push(canonicalHashBytes(unsignedUpdate));
       }
 
-      // If update.targetVersionId > currentVersionId + 1, throw LATE_PUBLISHING error
-      else if(update.targetVersionId > currentVersionId + 1) {
+      // Otherwise update.targetVersionId > currentVersionId + 1: a version was skipped,
+      // so throw LATE_PUBLISHING error. The duplicate case already continued above.
+      else {
         throw new ResolveError(
           `Version Id Mismatch: targetVersionId cannot be > currentVersionId + 1`,
-          'LATE_PUBLISHING_ERROR', {
+          LATE_PUBLISHING_ERROR, {
             targetVersionId  : update.targetVersionId,
             currentVersionId : currentVersionId + 1
           }
@@ -462,7 +471,7 @@ export class Resolver {
       // Increment currentVersionId
       currentVersionId++;
 
-      // Set response.versionId to be the new  currentVersionId
+      // Set response.versionId to be the new currentVersionId
       response.metadata.versionId = `${currentVersionId}`;
 
       // If resolutionOptions.versionId is defined and <= currentVersionId, return currentDocument

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { randomBytes } from 'crypto';
-import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, JSONPatch } from '@did-btcr2/common';
+import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
 import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner } from '@did-btcr2/keypair';
@@ -182,6 +182,42 @@ function driveSingleBeacon(
     tx            : {} as any,
     signalBytes   : canonicalHash(update, { encoding: 'hex' }),
     blockMetadata : { height: 100 + i, time: options?.times?.[i] ?? (1700000000 + i), confirmations: 6 }
+  })));
+  resolver.provide(need, signals);
+  state = resolver.resolve();
+  if(state.status !== 'resolved') throw new Error('expected resolved');
+  return state.result;
+}
+
+/**
+ * Drive resolution delivering an explicit, ordered list of signals on the single
+ * genesis beacon in one round. `signalUpdates` may repeat an update to model a
+ * duplicate re-announcement (SingletonBeacon.processSignals does not dedup, so each
+ * signal becomes its own update tuple). Every update the resolver may need is placed
+ * in the sidecar. Per-signal block metadata lets a duplicate carry a later time and a
+ * different confirmation depth than the apply it duplicates. Returns the resolved
+ * response or propagates whatever the resolver throws.
+ */
+function driveSignalSequence(
+  did: string,
+  sidecarUpdates: Array<SignedBTCR2Update>,
+  signalUpdates: Array<SignedBTCR2Update>,
+  blocks?: Array<{ height?: number; time?: number; confirmations?: number }>
+): DidResolutionResponse {
+  const resolver = DidBtcr2.resolve(did, { sidecar: { updates: sidecarUpdates } });
+  let state = resolver.resolve();
+  if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+  const need = state.needs[0] as NeedBeaconSignals;
+  const genesis = need.beaconServices[0] as BeaconService;
+  const signals = new Map<BeaconService, Array<BeaconSignal>>();
+  signals.set(genesis, signalUpdates.map((update, i) => ({
+    tx            : {} as any,
+    signalBytes   : canonicalHash(update, { encoding: 'hex' }),
+    blockMetadata : {
+      height        : blocks?.[i]?.height ?? (100 + i),
+      time          : blocks?.[i]?.time ?? (1700000000 + i),
+      confirmations : blocks?.[i]?.confirmations ?? 6
+    }
   })));
   resolver.provide(need, signals);
   state = resolver.resolve();
@@ -1239,6 +1275,170 @@ describe('Resolver', () => {
       // Two hops applied exactly once each despite the stale re-provide: v3, +2 services.
       expect(state.result.metadata.versionId).to.equal('3');
       expect(state.result.didDocument.service.length).to.equal(source.service.length + 2);
+    });
+  });
+
+  describe('duplicate update handling (Path C, ADR 067)', () => {
+    // A confirmed duplicate re-announces an already-applied version. Under Path C it
+    // advances neither the version counter nor the document, and it leaves the response
+    // metadata (updated / confirmations / versionId) on the last update that actually
+    // changed the document. These reproduce the finding-resolver-duplicate-handling
+    // traces end-to-end through the resolver loop. Before Path C the version counter
+    // incremented on every tuple, which inflated versionId and false-tripped
+    // LATE_PUBLISHING_ERROR on the next genuine update.
+    const fixture = deterministicData[2]; // regtest - has a known secretKey
+
+    it('resolves [v2, v2-dup, v3]: a duplicate no longer bricks the next genuine update', () => {
+      const source = resolveDeterministic(fixture.did);
+      // Two genuine benign hops (v1->v2, v2->v3), both discoverable on the genesis beacon.
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // Deliver v2 twice (the second is the duplicate), then v3.
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u2, u3 ]);
+      // Before Path C the unconditional increment drove currentVersionId to 3 on the
+      // duplicate, so genuine v3 was misread as a duplicate and confirmDuplicate read an
+      // empty history slot, throwing a false LATE_PUBLISHING_ERROR. Now it resolves to v3.
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('a confirmed duplicate does not inflate versionId', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [ benignPatch(fixture.did) ]);
+      // v2 announced twice, no v3: the duplicate must not advance the counter to 3.
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2 ], [ u2, u2 ]);
+      expect(metadata.versionId).to.equal('2');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 1);
+    });
+
+    it('resolves [v2, v2-dup, v3, v3-dup]: duplicates of two different non-final versions', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // This is the pattern the reference-impl's contemporary-hash push mishandles; Path C
+      // (compare-only) handles it because the history holds only applied-update hashes.
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u2, u3, u3 ]);
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('resolves [v2, v3, v3-dup]: a duplicate of the latest version is confirmed, not misread', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // updateHashHistory[targetVersionId - 2] holds the applied v3 update once v3 is
+      // applied, so the duplicate confirms without the removed contemporary-hash push.
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u3, u3 ]);
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('confirms a cross-round duplicate re-announced on a beacon an earlier update added', () => {
+      const source = resolveDeterministic(fixture.did);
+      // Genuine two-hop history: u2 (v1->v2) adds beacon B0 and is announced on the genesis
+      // beacon; u3 (v2->v3) is announced on B0 and so is only discovered a round later.
+      const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, source, fixture.secretKey, 2);
+      const [ u2 ] = updates;
+      const u2hash = canonicalHash(u2, { encoding: 'hex' });
+      // Recompute B0's address the way buildDiscoveryChain derives it (secret byte i+1),
+      // so round 2 can re-announce u2 there as a redundant duplicate.
+      const secret = new Uint8Array(32);
+      secret[31] = 1;
+      const addedBeaconAddress = p2wpkh(secp256k1.getPublicKey(secret, true), getNetwork('regtest')).address!;
+
+      const resolver = DidBtcr2.resolve(fixture.did, { sidecar: { updates } });
+      let height = 100;
+      let state = resolver.resolve();
+      while(state.status === 'action-required') {
+        const need = state.needs[0] as NeedBeaconSignals;
+        const signals = new Map<BeaconService, Array<BeaconSignal>>();
+        for(const service of need.beaconServices) {
+          const address = BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string);
+          const sigs: Array<BeaconSignal> = [];
+          const primary = signalByAddress.get(address);
+          if(primary) sigs.push({ tx: {} as any, signalBytes: primary, blockMetadata: { height: height++, time: 1700000000, confirmations: 6 } });
+          // Redundantly re-announce u2 on the beacon it added; this signal is discovered a
+          // round after u2 was applied, so confirmDuplicate must confirm it against the
+          // update-hash history carried across discovery rounds (ADR 060), not misread it.
+          if(address === addedBeaconAddress) sigs.push({ tx: {} as any, signalBytes: u2hash, blockMetadata: { height: height++, time: 1700000050, confirmations: 6 } });
+          signals.set(service as BeaconService, sigs);
+        }
+        resolver.provide(need, signals);
+        state = resolver.resolve();
+      }
+      if(state.status !== 'resolved') throw new Error('expected resolved');
+      // Before Path C the cross-round duplicate false-tripped LATE_PUBLISHING_ERROR; now the
+      // history resolves to v3 with both added beacons present.
+      expect(state.result.metadata.versionId).to.equal('3');
+      expect(state.result.didDocument.service.length).to.equal(source.service.length + 2);
+    });
+
+    it('still rejects a false duplicate whose unsigned hash does not match history', () => {
+      const source = resolveDeterministic(fixture.did);
+      const vm = source.verificationMethod![0]!;
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      // Two distinct v1->v2 updates (both targetVersionId 2) with different patches, so
+      // their unsigned-update hashes differ.
+      const applied = Updater.sign(
+        fixture.did, Updater.construct(source, benignPatch(fixture.did), 1), vm, signer
+      );
+      const forgedDuplicate = Updater.sign(
+        fixture.did,
+        Updater.construct(
+          source,
+          [{ op: 'add' as const, path: '/capabilityDelegation/-', value: `${fixture.did}#initialKey` }],
+          1
+        ),
+        vm, signer
+      );
+      // `applied` applies first (v1->v2); `forgedDuplicate` then enters the duplicate
+      // branch (targetVersionId 2 <= currentVersionId 2) but fails confirmation because
+      // its unsigned hash does not match the applied update recorded in the history.
+      let thrown: any;
+      try {
+        driveSignalSequence(fixture.did, [ applied, forgedDuplicate ], [ applied, forgedDuplicate ]);
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected a false duplicate to throw').to.exist;
+      expect(thrown.type).to.equal(LATE_PUBLISHING_ERROR);
+      expect(thrown.message).to.match(/invalid duplicate/i);
+    });
+
+    it('confirms a duplicate arriving on a second beacon the DID controls (redundant announcement)', () => {
+      const source = resolveDeterministic(fixture.did);
+      // A deterministic k1 DID exposes three beacons (p2pkh/p2wpkh/p2tr) derived from the
+      // one key. Announcing the same real update on two of them is a plausible redundancy
+      // pattern; both signals reach Resolver.updates() as the same update, one applied and
+      // one confirmed as a duplicate.
+      const [ u2 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [ benignPatch(fixture.did) ]);
+      const updateHashHex = canonicalHash(u2, { encoding: 'hex' });
+
+      const resolver = DidBtcr2.resolve(fixture.did, { sidecar: { updates: [ u2 ] } });
+      let state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+      const need = state.needs[0] as NeedBeaconSignals;
+      expect(need.beaconServices.length).to.equal(3);
+
+      // Deliver u2 on the first two beacons, empty on the third.
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      need.beaconServices.forEach((service, i) => {
+        signals.set(service as BeaconService, i < 2
+          ? [{ tx: {} as any, signalBytes: updateHashHex, blockMetadata: { height: 100 + i, time: 1700000000, confirmations: 6 } }]
+          : []
+        );
+      });
+      resolver.provide(need, signals);
+
+      state = resolver.resolve();
+      expect(state.status).to.equal('resolved');
+      if(state.status !== 'resolved') return;
+      // Applied once, confirmed once: version 2 (not inflated to 3), patch landed once.
+      expect(state.result.metadata.versionId).to.equal('2');
+      expect(state.result.didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 1);
     });
   });
 });


### PR DESCRIPTION
* chore(release): bump method 0.52.0, api 0.13.11, cli 0.12.16
* test(method): duplicate traces, cross-round + multi-beacon duplicates, false-duplicate guard
* fix(method): confirm duplicate updates sans-version inflation + update-hash history corruption
* docs(adr): add ADR 067 (resolver duplicate confirmation)