### PR TITLE
resolve versionTime correctly w/ dupe updates histories

### DIFF
--- a/docs/adr/068-resolver-versiontime-duplicate-order.md
+++ b/docs/adr/068-resolver-versiontime-duplicate-order.md
@@ -1,0 +1,185 @@
+---
+title: "ADR 068: versionTime Evaluation Order for Duplicates and Guarded Duplicate Confirmation"
+---
+
+# ADR 068: versionTime Evaluation Order for Duplicates and Guarded Duplicate Confirmation
+
+**Status:** Accepted
+
+**Date:** 2026-07-06
+
+**Branch / PR:** `fix/resolver-duplicate-edges`
+
+**References:** [ADR 055](055-resolver-provide-trust-boundary.md), [ADR 060](060-resolver-cross-round-version-continuity.md), [ADR 067](067-resolver-duplicate-confirmation.md), [did:btcr2 Resolve](https://dcdpr.github.io/did-btcr2/operations/resolve.html), [W3C DID Resolution](https://w3c.github.io/did-resolution/)
+
+## Context
+
+[ADR 067](067-resolver-duplicate-confirmation.md) fixed how a confirmed duplicate update
+affects the version counter and the update-hash history, and recorded two adjacent
+pre-existing edges as out of scope. This ADR closes both. Each was reproduced empirically
+against the published build before being fixed, and each traces back to the specification
+text, so both extend the erratum conversation ADR 067 opened.
+
+### Edge 1: an out-of-order duplicate truncates a versionTime query
+
+The read algorithm sorts the updates array by `targetVersionId` first, block height second.
+A duplicate re-announcement of an early version that was mined *after* the queried
+`versionTime` therefore sorts *ahead of* a genuine later update mined *before* it. The
+spec's "Process updates Array" evaluates the versionTime early-return as step 3, before
+step 4 dispatches to duplicate-confirmation / apply / late-publishing, so the over-window
+duplicate ends resolution before the genuine in-window update is ever processed.
+
+Reproduced trace: version 2 applied November 2023; a duplicate of that update re-announced
+in 2030; a genuine version 3 mined December 2024; `versionTime: 2025-01-01`. The resolver
+returned version **2** instead of the correct **3**, silently dropping the in-window update,
+and stamped `metadata.updated` with the duplicate's 2030 blocktime, itself past the
+requested versionTime. No error is raised; the answer is simply wrong.
+
+This contradicts the spec's own definition of `versionTime` ("the most recent version of
+the DID document that was valid for the DID before the specified versionTime"): an
+announcement mined after the query point cannot change which versions were valid before
+it. The spec has no language about how versionTime interacts with duplicates; the
+implementation faithfully transcribed the step order and inherited the defect. The same
+redundancy and replay patterns that make duplicates reachable (ADR 067's context: one
+update announced on two of a DID's own derivable beacons, or a third-party OP_RETURN
+replay) make this reachable for any resolver offering versionTime queries.
+
+### Edge 2: duplicate confirmation crashes on a crafted targetVersionId
+
+"Confirm Duplicate Update" indexes `update_hash_history[targetVersionId - 2]` with no
+bound check, in the spec and in this implementation. The duplicate branch admits any
+`targetVersionId <= current_version_id`, and the update data structure never restates
+that `targetVersionId` must be an integer of at least 2 (it is only implied by "MUST be
+one more than the versionId of the DID document being updated"). A crafted update object
+carrying `targetVersionId: 1` (or 0, a negative, or a fractional value below the current
+version) enters the duplicate branch, reads an undefined history slot, and crashes the
+byte comparison with a raw `TypeError: Cannot read properties of undefined (reading
+'length')` - not the typed `ResolveError` resolver callers handle. Reproduced with a
+sidecar entry plus a single beacon signal carrying the crafted update's hash; the
+content-hash binding of [ADR 055](055-resolver-provide-trust-boundary.md) is satisfied
+because the signal commits to the crafted update itself.
+
+## Decision
+
+### 1. Confirm duplicates before evaluating versionTime
+
+The duplicate branch now runs before the versionTime early-return. A tuple that
+re-announces an already-applied version is confirmed against the update-hash history and
+skipped whatever its blocktime; the versionTime check gates only the state-changing paths
+(apply and late-publishing). The reproduced trace now resolves to version 3.
+
+The rule this encodes: **versionTime is a view over the history, not an integrity
+waiver.** Confirming over-window duplicates rather than skipping them keeps late-publishing
+detection intact: a *false* duplicate (different content claiming an already-applied
+version) mined after versionTime now fails resolution with `LATE_PUBLISHING_ERROR`, where
+the previous order silently hid the equivocation evidence behind the early return. That
+strengthening is deliberate, and it is scoped to the window: evidence that an
+already-applied portion of the history is equivocal taints every answer about that
+portion, including answers about the past. Equivocation confined entirely to
+announcements after versionTime (competing updates for a version never applied in the
+window, or an over-window gap update) remains outside the view: only tuples that reach
+the duplicate branch are integrity-checked past versionTime, and every other over-window
+tuple still ends resolution cleanly at the early return, exactly as before.
+
+This is a deviation from the current spec step order (versionTime at step 3, dispatch at
+step 4), taken for the same reason as ADR 067's increment deviation and pursued in the
+same erratum conversation: evaluate the versionTime return after (or scoped to exclude)
+the duplicate branch.
+
+### 2. Guard the duplicate-confirmation history read
+
+`confirmDuplicate` now validates before indexing:
+
+- a `targetVersionId` that is not an integer or is below 2 cannot name an applied update;
+  it is a malformed update, not a duplicate, and raises `INVALID_DID_UPDATE`;
+- an integer `targetVersionId` of at least 2 whose history slot does not exist (reachable
+  only by standalone `Resolver.updates()` callers passing a resolution state whose version
+  counter outruns its history) is an *unconfirmable duplicate*, which is late-publishing
+  evidence, and raises `LATE_PUBLISHING_ERROR`.
+
+Through the resolver's own loop the slot always exists for conformant duplicates: the
+apply path records one history entry per version, so any integer `targetVersionId` between
+2 and the current version indexes a recorded hash. The guard converts the crash into the
+typed errors the API contracts already promise.
+
+### 3. Reject malformed targetVersionId at the provide() boundary
+
+The `provide()` shape guard for signed updates now requires `targetVersionId` to be an
+integer of at least 2, extending the fail-fast validation of
+[ADR 055](055-resolver-provide-trust-boundary.md). Sidecar-supplied updates bypass
+`provide()`, so the `confirmDuplicate` guard above remains the reliable last line; the
+boundary check just fails the interactive path earlier with the existing "not a signed
+BTCR2 update" error.
+
+### Verification
+
+Six regression tests cover the reproduced traces and the guards: the over-window-duplicate
+versionTime query resolves to the correct version; an over-window false duplicate fails as
+late publishing; crafted `targetVersionId` values of 1 and 0.5 raise `INVALID_DID_UPDATE`
+rather than `TypeError`; a standalone `updates()` call with a counter that outruns its
+history raises `LATE_PUBLISHING_ERROR`; and `provide()` rejects the malformed update at
+the boundary. As a negative control the same six tests were run against the previous
+release's resolver: all six fail there (wrong version, hidden equivocation, and raw
+TypeErrors), confirming they exercise the defects rather than passing vacuously. The full
+method suite passes unchanged, including the existing test that a *genuine* update mined
+after versionTime still ends resolution at the version valid before it.
+
+## Consequences
+
+- versionTime queries return the version actually valid at the query point even when the
+  on-chain history contains out-of-order duplicate re-announcements.
+- A false duplicate of an in-window version mined after versionTime now fails resolution
+  with `LATE_PUBLISHING_ERROR` instead of being masked by the early return. Callers that
+  somehow relied on the masking will see a new error; that behavior was hiding
+  equivocation evidence.
+- The strengthened detection does not extend past the window: two competing over-window
+  updates for a version never applied in the window, or an over-window gap update, still
+  end resolution cleanly at the early return, so a versionTime query and a full resolution
+  of the same DID can still disagree about history trustworthiness in that residual case
+  (the same is true of versionId-limited queries, whose early return precedes any later
+  duplicate confirmation). Closing that residual would make every time-scoped query a full
+  resolution and is not attempted here.
+- Malformed `targetVersionId` values surface as typed `ResolveError`s
+  (`INVALID_DID_UPDATE` / `LATE_PUBLISHING_ERROR`) at the duplicate branch and are
+  rejected outright at the `provide()` boundary, instead of crashing with a `TypeError`.
+- The resolution metadata stamping is unchanged: `metadata.updated`/`confirmations` are
+  still set from each processed tuple's block, so a versionTime early-return on a genuine
+  over-window update still reports that update's block metadata. Refining those fields is
+  the still-open follow-up recorded in ADR 067.
+- This is a behavior change to resolution output for versionTime queries over histories
+  containing duplicates. Under semantic versioning on a `0.x` line it is released as a
+  minor bump.
+- Two further erratum points join the ADR 067 conversation upstream: reorder (or scope)
+  the versionTime step relative to duplicate confirmation, and add an existence guard to
+  "Confirm Duplicate Update" together with an explicit integer >= 2 constraint on
+  `targetVersionId`.
+
+## Rejected alternatives
+
+- **Skip over-window duplicates without confirming them.** Preserves a strict "events
+  after versionTime are invisible" reading, but hides equivocation evidence about versions
+  that were applied within the window, evidence a full resolution of the same DID would
+  surface as `LATE_PUBLISHING_ERROR`. A time-scoped view should not report a version when
+  the in-window history it reports on is provably equivocal. (Equivocation confined
+  entirely beyond the window is masked by the retained early return under either design;
+  see Consequences.)
+- **Pre-filter over-window tuples before the loop.** Equivalent for genuine linear
+  histories, but it silently discards over-window false duplicates (same objection as
+  above) and restructures the loop further from the spec text than the one-block move.
+- **A single error code for the confirmDuplicate guard.** Folding both guard failures into
+  `LATE_PUBLISHING_ERROR` would mislabel a malformed field as an integrity finding.
+  A `targetVersionId` below 2 violates the update data structure's construction rule and
+  is `INVALID_DID_UPDATE`; only the missing-history-slot case is genuinely an
+  unconfirmable duplicate.
+- **Guard only at the provide() boundary.** Sidecar-supplied updates never pass through
+  `provide()`, and standalone `updates()` callers bypass the resolver entirely, so a
+  boundary-only guard leaves the crash reachable. The point-of-use guard is the one that
+  cannot be bypassed.
+
+## Out of scope
+
+Carrying `metadata.updated`/`confirmations` across discovery rounds so they track only
+real state changes (the follow-up recorded in [ADR 067](067-resolver-duplicate-confirmation.md))
+remains open; this change does not touch the metadata stamping. The cross-round version
+continuity model ([ADR 060](060-resolver-cross-round-version-continuity.md)) and the
+duplicate counter/history semantics (ADR 067) are unchanged.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -68,6 +68,7 @@ children:
   - ./065-changesets-for-changelogs-manual-release.md
   - ./066-x1-transport-authentication.md
   - ./067-resolver-duplicate-confirmation.md
+  - ./068-resolver-versiontime-duplicate-order.md
 ---
 
 # Architecture Decision Records
@@ -143,3 +144,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 065 | 2026-07-02 | [Adopt Changesets for Per-Package Changelogs with Manual Publishing](065-changesets-for-changelogs-manual-release.md) |
 | 066 | 2026-07-02 | [Trustless Transport Authentication for EXTERNAL (x1) DIDs via In-Band Genesis Documents](066-x1-transport-authentication.md) |
 | 067 | 2026-07-02 | [Resolver Duplicate-Update Confirmation - Conditional Increment and Compare-Only History](067-resolver-duplicate-confirmation.md) |
+| 068 | 2026-07-06 | [versionTime Evaluation Order for Duplicates and Guarded Duplicate Confirmation](068-resolver-versiontime-duplicate-order.md) |

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @did-btcr2/api
 
+## 0.13.12
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.53.0
+
 ## 0.13.11
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.13.11",
+    "version": "0.13.12",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @did-btcr2/cli
 
+## 0.12.17
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.53.0
+  - @did-btcr2/api@0.13.12
+
 ## 0.12.16
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @did-btcr2/method
 
+## 0.53.0
+
+### Minor Changes
+
+- Fix versionTime queries against duplicate-containing histories and guard duplicate confirmation (ADR 068)
+
+  Updates sort by targetVersionId before block height, so a duplicate re-announcement of an
+  early version mined after the queried versionTime used to trip the versionTime early-return
+  before genuine in-window updates were processed, silently resolving to an earlier version
+  than the one valid at the query point. Duplicates are now confirmed before the versionTime
+  check, so a re-announcement (or third-party replay) mined after versionTime can no longer
+  truncate the in-window history, and a false duplicate of an in-window version now fails
+  resolution with `LATE_PUBLISHING_ERROR` instead of being masked by the early return. Separately, the duplicate-confirmation history read is now guarded: a crafted
+  `targetVersionId` that is not an integer of at least 2 raises a typed `INVALID_DID_UPDATE`
+  (and is rejected at the `provide()` boundary), and an unconfirmable duplicate whose history
+  slot does not exist raises `LATE_PUBLISHING_ERROR`, where both previously crashed with a raw
+  `TypeError`. The versionTime reorder is a deliberate, traced deviation from the current spec
+  step order, pursued upstream as an erratum alongside ADR 067's; see ADR 068.
+
 ## 0.52.0
 
 ### Minor Changes

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.52.0",
+    "version": "0.53.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -126,13 +126,18 @@ function isCASAnnouncement(value: unknown): value is CASAnnouncement {
   return isRecord(value) && Object.values(value).every(v => typeof v === 'string');
 }
 
-/** True if `value` has the shape of a signed BTCR2 update. */
+/**
+ * True if `value` has the shape of a signed BTCR2 update. targetVersionId must be an
+ * integer of at least 2: an update targets the version after the one it patches, and
+ * genesis is version 1, so no conformant update can target a lower version (ADR 068).
+ */
 function isSignedBTCR2Update(value: unknown): value is SignedBTCR2Update {
   if(!isRecord(value)) return false;
   return Array.isArray(value.patch)
     && typeof value.sourceHash === 'string'
     && typeof value.targetHash === 'string'
-    && typeof value.targetVersionId === 'number'
+    && Number.isInteger(value.targetVersionId)
+    && (value.targetVersionId as number) >= 2
     && isRecord(value.proof);
 }
 
@@ -411,14 +416,6 @@ export class Resolver {
       // Set confirmations to the block confirmations
       response.metadata.confirmations = block.confirmations;
 
-      // if resolutionOptions.versionTime is defined and the blocktime is more recent, return currentDocument
-      if(versionTime) {
-        // Safely convert versionTime to timestamp
-        if(blocktime > DateUtils.dateStringToTimestamp(versionTime)) {
-          return response;
-        }
-      }
-
       // Check update.targetVersionId against currentVersionId.
       // If update.targetVersionId <= currentVersionId, this update re-announces a version
       // that has already been applied. Confirm it is a true duplicate, then skip it: a
@@ -428,10 +425,26 @@ export class Resolver {
       // history already holds the applied update at updateHashHistory[targetVersionId - 2].
       // Holding the increment off the duplicate path is the deliberate did:btcr2 deviation
       // recorded in ADR 067: the read algorithm's "Increment current_version_id" belongs
-      // to the apply branch, not to every tuple.
+      // to the apply branch, not to every tuple. Duplicates are confirmed whatever their
+      // blocktime, before the versionTime check below, so a re-announcement mined after
+      // versionTime can neither truncate the in-window history nor dodge late-publishing
+      // detection (ADR 068).
       if(update.targetVersionId <= currentVersionId) {
         this.confirmDuplicate(update, updateHashHistory);
         continue;
+      }
+
+      // if resolutionOptions.versionTime is defined and the blocktime is more recent, return
+      // currentDocument. Evaluated only for tuples that would change state (apply or late
+      // publishing). The spec places this check before the duplicate branch, where the sort
+      // by targetVersionId lets a duplicate of an early version mined after versionTime end
+      // resolution before genuine in-window updates are processed; checking it here is the
+      // deliberate deviation recorded in ADR 068.
+      if(versionTime) {
+        // Safely convert versionTime to timestamp
+        if(blocktime > DateUtils.dateStringToTimestamp(versionTime)) {
+          return response;
+        }
       }
 
       // If update.targetVersionId == currentVersionId + 1, apply the update
@@ -501,6 +514,17 @@ export class Resolver {
    * @returns {void} Does not return a value, but throws an error if the update is not a valid duplicate.
    */
   private static confirmDuplicate(update: SignedBTCR2Update, updateHashHistory: HashBytes[]): void {
+    // A conformant update targets the version after the one it patches, so targetVersionId
+    // is an integer of at least 2 (genesis is version 1). Anything else cannot name an
+    // applied update: it is a malformed update, not a duplicate, and without this guard it
+    // would read a nonexistent history slot below and crash on the byte comparison (ADR 068).
+    if (!Number.isInteger(update.targetVersionId) || update.targetVersionId < 2) {
+      throw new ResolveError(
+        `Invalid duplicate: targetVersionId must be an integer >= 2`,
+        INVALID_DID_UPDATE, { targetVersionId: update.targetVersionId }
+      );
+    }
+
     // Create unsigned_update by removing the proof property from update.
     const { proof: _, ...unsignedUpdate } = update;
 
@@ -509,6 +533,20 @@ export class Resolver {
 
     // Let historicalUpdateHash equal updateHashHistory[updateHashIndex].
     const historicalUpdateHash = updateHashHistory[update.targetVersionId - 2];
+
+    // The resolver's own loop records one history entry per applied version, so this slot
+    // always exists on that path; a standalone caller, however, can pass a resolutionState
+    // whose version counter outruns its history. A duplicate that cannot be checked against
+    // an applied update is unconfirmable, which is late-publishing evidence, not a pass.
+    if (historicalUpdateHash === undefined) {
+      throw new ResolveError(
+        `Invalid duplicate: no applied update in history for targetVersionId`,
+        LATE_PUBLISHING_ERROR, {
+          targetVersionId : update.targetVersionId,
+          historyLength   : updateHashHistory.length
+        }
+      );
+    }
 
     // Check if the updateHash matches the historical hash (byte comparison)
     if (!equalBytes(historicalUpdateHash, unsignedUpdateHash)) {

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { randomBytes } from 'crypto';
-import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
+import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, INVALID_DID_UPDATE, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
 import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner } from '@did-btcr2/keypair';
@@ -13,6 +13,7 @@ import { BeaconUtils } from '../src/core/beacon/utils.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
 import type { DidDocument } from '../src/utils/did-document.js';
 import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
+import { Resolver } from '../src/core/resolver.js';
 import type { DidResolutionResponse, NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';
 import { Updater } from '../src/core/updater.js';
 import deterministicData from './data/deterministic-data.js';
@@ -202,9 +203,13 @@ function driveSignalSequence(
   did: string,
   sidecarUpdates: Array<SignedBTCR2Update>,
   signalUpdates: Array<SignedBTCR2Update>,
-  blocks?: Array<{ height?: number; time?: number; confirmations?: number }>
+  blocks?: Array<{ height?: number; time?: number; confirmations?: number }>,
+  versionTime?: string
 ): DidResolutionResponse {
-  const resolver = DidBtcr2.resolve(did, { sidecar: { updates: sidecarUpdates } });
+  const resolver = DidBtcr2.resolve(did, {
+    sidecar : { updates: sidecarUpdates },
+    ...(versionTime ? { versionTime } : {})
+  });
   let state = resolver.resolve();
   if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
   const need = state.needs[0] as NeedBeaconSignals;
@@ -1439,6 +1444,203 @@ describe('Resolver', () => {
       // Applied once, confirmed once: version 2 (not inflated to 3), patch landed once.
       expect(state.result.metadata.versionId).to.equal('2');
       expect(state.result.didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 1);
+    });
+  });
+
+  describe('duplicate edge cases (ADR 068)', () => {
+    // Two edges of duplicate handling: (1) updates sort by targetVersionId before block
+    // height, so a duplicate of an early version mined after a versionTime query point
+    // used to trip the versionTime early-return before genuine in-window updates were
+    // processed; duplicates are now confirmed before the versionTime check. (2) the
+    // duplicate-confirmation history read updateHashHistory[targetVersionId - 2] used to
+    // be unguarded, so a crafted targetVersionId below 2 (or a non-integer) crashed with
+    // a raw TypeError instead of a typed ResolveError.
+    const fixture = deterministicData[2]; // regtest - has a known secretKey
+
+    it('versionTime: an over-window duplicate does not truncate the in-window history', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // u2 mined Nov 2023 (in-window), a duplicate of u2 re-announced in 2030 (over-window),
+      // genuine u3 mined Dec 2024 (in-window). Sorting by targetVersionId puts the 2030
+      // duplicate ahead of u3, so the old check returned v2 and never processed u3.
+      const { metadata, didDocument } = driveSignalSequence(
+        fixture.did, [ u2, u3 ], [ u2, u2, u3 ],
+        [
+          { height: 100, time: 1700000000, confirmations: 6 },
+          { height: 200, time: 1900000000, confirmations: 6 },
+          { height: 150, time: 1735000000, confirmations: 6 }
+        ],
+        '2025-01-01T00:00:00Z'
+      );
+      // The version valid at 2025-01-01 is v3: both genuine updates predate it.
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('versionTime: a skipped over-window duplicate does not extend the view past versionTime', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      // The mirror of the test above: u2 is in-window, but its duplicate AND genuine u3 are
+      // both mined after versionTime. The duplicate is confirmed and skipped; u3 must still
+      // trip the versionTime early-return on its own blocktime, stopping at v2. Pins that
+      // the duplicate branch's continue never carries resolution past the query point.
+      const { metadata, didDocument } = driveSignalSequence(
+        fixture.did, [ u2, u3 ], [ u2, u2, u3 ],
+        [
+          { height: 100, time: 1700000000, confirmations: 6 },
+          { height: 200, time: 1900000000, confirmations: 6 },
+          { height: 210, time: 1910000000, confirmations: 6 }
+        ],
+        '2025-01-01T00:00:00Z'
+      );
+      expect(metadata.versionId).to.equal('2');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 1);
+    });
+
+    it('versionTime: an over-window false duplicate still fails resolution as late publishing', () => {
+      const source = resolveDeterministic(fixture.did);
+      const vm = source.verificationMethod![0]!;
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const applied = Updater.sign(
+        fixture.did, Updater.construct(source, benignPatch(fixture.did), 1), vm, signer
+      );
+      // A different update claiming the already-applied version 2, mined after versionTime.
+      const forged = Updater.sign(
+        fixture.did,
+        Updater.construct(
+          source,
+          [{ op: 'add' as const, path: '/capabilityDelegation/-', value: `${fixture.did}#initialKey` }],
+          1
+        ),
+        vm, signer
+      );
+      // A versionTime query is a view of the history, not an integrity waiver: equivocation
+      // evidence mined after versionTime still fails resolution instead of being hidden by
+      // the early return.
+      let thrown: any;
+      try {
+        driveSignalSequence(
+          fixture.did, [ applied, forged ], [ applied, forged ],
+          [
+            { height: 100, time: 1700000000, confirmations: 6 },
+            { height: 200, time: 1900000000, confirmations: 6 }
+          ],
+          '2025-01-01T00:00:00Z'
+        );
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected the false duplicate to fail resolution').to.exist;
+      expect(thrown.type).to.equal(LATE_PUBLISHING_ERROR);
+      expect(thrown.message).to.match(/invalid duplicate/i);
+    });
+
+    it('a crafted update with targetVersionId 1 throws a typed error, not a TypeError', () => {
+      // Enters the duplicate branch on the first tuple (1 <= 1); the history is empty, so
+      // the unguarded read used to crash with a raw TypeError on the byte comparison.
+      const crafted = {
+        '@context'      : [ 'test' ],
+        patch           : [],
+        sourceHash      : 'x',
+        targetHash      : 'y',
+        targetVersionId : 1,
+        proof           : { type: 'DataIntegrityProof' }
+      } as unknown as SignedBTCR2Update;
+      let thrown: any;
+      try {
+        driveSignalSequence(fixture.did, [ crafted ], [ crafted ]);
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected the crafted duplicate to throw').to.exist;
+      expect(thrown).to.not.be.instanceOf(TypeError);
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/targetVersionId/i);
+    });
+
+    it('a crafted update with a non-integer targetVersionId throws a typed error', () => {
+      // 0.5 <= currentVersionId 1 routes into the duplicate branch; the fractional index
+      // used to read an undefined slot and crash.
+      const crafted = {
+        '@context'      : [ 'test' ],
+        patch           : [],
+        sourceHash      : 'x',
+        targetHash      : 'y',
+        targetVersionId : 0.5,
+        proof           : { type: 'DataIntegrityProof' }
+      } as unknown as SignedBTCR2Update;
+      let thrown: any;
+      try {
+        driveSignalSequence(fixture.did, [ crafted ], [ crafted ]);
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected the crafted duplicate to throw').to.exist;
+      expect(thrown).to.not.be.instanceOf(TypeError);
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+    });
+
+    it('Resolver.updates() with a version counter that outruns its history throws typed late publishing', () => {
+      // A standalone caller can pass a resolutionState whose counter exceeds its history;
+      // a duplicate then names a version with no recorded applied update. Unconfirmable
+      // duplicates are late-publishing evidence, and must not surface as a TypeError.
+      const source = resolveDeterministic(fixture.did);
+      const [ , u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      let thrown: any;
+      try {
+        Resolver.updates(
+          source,
+          [[ u3, { height: 100, time: 1700000000, confirmations: 6 } ]],
+          undefined,
+          undefined,
+          { currentVersionId: 5, updateHashHistory: [] }
+        );
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, 'expected the unconfirmable duplicate to throw').to.exist;
+      expect(thrown).to.not.be.instanceOf(TypeError);
+      expect(thrown.type).to.equal(LATE_PUBLISHING_ERROR);
+      expect(thrown.message).to.match(/no applied update/i);
+    });
+
+    it('provide() rejects a signed update whose targetVersionId is not an integer >= 2', () => {
+      // The crafted update passes every other shape check and matches the signal's hash
+      // binding (the signal IS its hash), so only the tightened targetVersionId guard
+      // rejects it at the provide() boundary.
+      const crafted = {
+        '@context'      : [ 'test' ],
+        patch           : [],
+        sourceHash      : 'x',
+        targetHash      : 'y',
+        targetVersionId : 1,
+        proof           : { type: 'DataIntegrityProof' }
+      };
+      const craftedHashHex = canonicalHash(crafted, { encoding: 'hex' });
+
+      const resolver = DidBtcr2.resolve(fixture.did); // empty sidecar
+      let state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+      const beaconNeed = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      signals.set(beaconNeed.beaconServices[0] as BeaconService, [{
+        tx            : {} as any,
+        signalBytes   : craftedHashHex,
+        blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+      }]);
+      resolver.provide(beaconNeed, signals);
+
+      state = resolver.resolve();
+      if(state.status !== 'action-required') throw new Error('expected NeedSignedUpdate');
+      const updateNeed = state.needs[0] as NeedSignedUpdate;
+      expect(updateNeed.updateHash).to.equal(craftedHashHex);
+      expect(() => resolver.provide(updateNeed, crafted as any)).to.throw(/not a signed BTCR2 update/i);
     });
   });
 });


### PR DESCRIPTION
* chore(release): bump method 0.53.0, api 0.13.12, cli 0.12.17
* test(method): versionTime x dupe traces, targetVersionId guards, provide() boundary rejection
* fix(method): confirm dupes before versionTime early-return, guard dupe-conf history
* docs(adr): add ADR 068 (versionTime dupe eval, guarded dupe conf)