### PR TITLE
wire CAS-first publication through the update path

### DIFF
--- a/docs/adr/070-broadcast-result-and-cas-first-ordering.md
+++ b/docs/adr/070-broadcast-result-and-cas-first-ordering.md
@@ -1,0 +1,61 @@
+---
+title: "ADR 070: Beacon Broadcasts Return Structured Artifacts and CAS Publication Precedes the On-Chain Spend"
+---
+
+# ADR 070: Beacon Broadcasts Return Structured Artifacts and CAS Publication Precedes the On-Chain Spend
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cas-first-broadcast`
+
+**References:** [ADR 037](037-single-party-beacon-and-two-axis-model.md), [ADR 056](056-beacon-signal-format-validation.md), [ADR 069](069-fetch-based-cas-executors-drop-helia.md)
+
+## Context
+
+Every single-party beacon broadcast (`SinglePartyBeacon.broadcastSignal` on the Singleton, CAS, and SMT beacons) returned only the `SignedBTCR2Update` the caller had passed in. Everything else the broadcast produced was discarded:
+
+- **The transaction id.** `buildSignAndBroadcast` returns the txid of the signal transaction; every beacon dropped it. Callers could not record which on-chain transaction anchors their update without re-querying the chain.
+- **The SMT inclusion proof and its nonce.** The SMT beacon built a single-entry Merkle tree with a freshly generated 32-byte nonce, broadcast the root, and threw both the tree and the nonce away. The did:btcr2 SMT proof-verification algorithm blinds each leaf with that nonce, and the nonce exists nowhere but in the broadcasting process's memory. Discarding it made **every single-party SMT beacon signal permanently unresolvable**: no resolver could ever link the on-chain root back to the update.
+- **The CAS Announcement.** The CAS beacon constructed the announcement (the DID-to-update-hash map whose canonical hash rides in OP_RETURN), broadcast its hash, and returned without exposing the announcement. A controller not using the optional `casPublish` callback (the sidecar-only flow the spec explicitly permits) had no way to capture the very object they are required to retain and distribute for resolution.
+
+Separately, the CAS beacon invoked the optional `casPublish` callback **after** the transaction broadcast. A CAS publish failure therefore surfaced only after the beacon UTXO was irrevocably spent, leaving an on-chain signal pointing at an announcement that never reached the store. The spec's data-retention requirement is that update data be available at resolution time; it mandates no publish-versus-broadcast ordering, so the ordering is an implementation-quality decision, and publishing after the spend is the strictly worse of the two orders.
+
+Finally, `Updater.announce` (the static utility wrapping `BeaconFactory.establish` plus `broadcastSignal`) accepted no options parameter, so callers going through it could not supply a fee estimator, change address, or `casPublish` callback at all.
+
+## Decision
+
+1. **`broadcastSignal` returns a structured `BroadcastResult`** on all three beacons (and on the abstract base signature):
+
+   ```typescript
+   interface BroadcastResult {
+     signedUpdate: SignedBTCR2Update;
+     txid: string;
+     announcement?: CASAnnouncement; // CAS beacons
+     proof?: SMTProof;               // SMT beacons
+   }
+   ```
+
+   The Singleton beacon returns `{ signedUpdate, txid }`. The CAS beacon adds the announcement. The SMT beacon serializes the inclusion proof from the tree it just built (`BTCR2MerkleTree.proof(did)`, which embeds the leaf nonce and the update hash) and returns it, fixing the unresolvable-signal defect. The nonce is not returned as a separate field: the serialized proof already carries it in the wire format the resolver consumes.
+
+2. **The CAS beacon publishes before it spends.** `casPublish(announcement)` runs before `buildSignAndBroadcast`. A publish failure aborts the operation while the beacon UTXO is still unspent. Because the announcement is content-addressed, the ordering is retry-safe in both failure directions: a publish that succeeded before a failed broadcast re-publishes the same bytes to the same address on retry, and an orphaned announcement in the store (published, never anchored) is inert.
+
+3. **`Updater.announce` gains an options parameter and returns the `BroadcastResult`.** The parameter is typed as `CASBroadcastOptions` (the widest single-party options shape); non-CAS beacons ignore `casPublish`.
+
+4. **`CasPublishFn` documentation is made executor-neutral** (it referenced a specific IPFS implementation) and now states the pre-spend invocation contract.
+
+## Consequences
+
+- Single-party SMT beacon broadcasts become resolvable for the first time: the caller receives the proof whose nonce previously died with the broadcast, and can distribute it via sidecar (`sidecar.smtProofs`). A regression test broadcasts against a mocked Bitcoin connection and round-trips the returned proof through `SMTBeacon.processSignals`.
+- Sidecar-only CAS beacon controllers can now capture the announcement they must distribute; the same round-trip is pinned by test.
+- The return-type change from `Promise<SignedBTCR2Update>` to `Promise<BroadcastResult>` is breaking for callers that used the return value directly; at 0.x this ships as a minor version bump. Callers that ignored the return value are unaffected.
+- The CAS publish-then-spend ordering is a semantic change for existing `casPublish` users: the callback now runs earlier, and its failure now prevents the spend instead of following it. This is called out in the changelog as the intended new contract.
+- The `Updater` state machine itself is unchanged: `NeedBroadcast` fulfillment and `UpdaterResult` keep their shapes. The caller driving the machine performs the broadcast and holds the `BroadcastResult`; threading it through `provide()` into the machine's result would grow the state machine's surface for data the caller already has.
+- A residual remains on the SMT path: the retry-safety argument above is content-addressing's, and an SMT root is not content-addressed (the nonce is generated per call). If the broadcast fails **ambiguously**, the send throws after the node actually accepted the transaction, the thrown path discards the proof and a retry builds a different tree, so the originally-propagated root can confirm on-chain as an unresolvable signal. Callers needing stronger guarantees should treat a broadcast timeout as possibly-sent and confirm before retrying; making the nonce injectable (so a retry rebuilds the identical tree) is deliberately deferred until a consumer needs it.
+
+## Rejected alternatives
+
+- **Return the SMT nonce as a separate `BroadcastResult` field.** The serialized proof already embeds the nonce in the format `processSignals` verifies; a second copy would be redundant state that could drift from the proof.
+- **Keep publishing after the broadcast.** No ordering is spec-mandated, but publish-after-spend converts a transient CAS outage into an on-chain signal with no retrievable announcement; publish-before-spend converts it into a clean, retryable abort. The only cost is a possible orphaned (published, never anchored) announcement, which is harmless.
+- **Have the beacons publish the signed update too.** The beacons' responsibility is the signal transaction and its immediate artifacts. Which stores receive the update, under what policy, is an application concern; the api layer implements it (ADR 071) via the `casPublish` seam and its own pre-broadcast publish step.

--- a/docs/adr/071-api-cas-publication-policy.md
+++ b/docs/adr/071-api-cas-publication-policy.md
@@ -1,0 +1,64 @@
+---
+title: "ADR 071: A CAS Publication Policy for the API Update Path (publishToCas), Writable-CAS Capability Detection, and Enriched Update Results"
+---
+
+# ADR 071: A CAS Publication Policy for the API Update Path (publishToCas), Writable-CAS Capability Detection, and Enriched Update Results
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cas-first-broadcast`
+
+**References:** [ADR 023](023-cas-read-path.md), [ADR 069](069-fetch-based-cas-executors-drop-helia.md), [ADR 070](070-broadcast-result-and-cas-first-ordering.md)
+
+## Context
+
+The api package's read path already treats a CAS as a first-class resolution source: `DidMethodApi.resolve` fulfills `NeedGenesisDocument`, `NeedCASAnnouncement`, and `NeedSignedUpdate` by fetching canonical JCS blocks from the configured `CasApi`. The write path, however, was fully unwired:
+
+- `DidMethodApi.update` called `broadcastSignal` with no options, so the CAS beacon's `casPublish` seam was never supplied and `CasApi.publish` had zero call sites in the workspace.
+- Nothing ever published the signed update itself, even though every beacon type's OP_RETURN hash (directly for Singleton beacons, indirectly via the announcement for CAS beacons) resolves to a canonical update block a CAS could serve.
+- There was no way to tell whether the configured CAS could accept writes at all. The default CAS is a read-only HTTP gateway whose `publish()` throws; the failure would have surfaced mid-update, after signing.
+- `broadcastSignal`'s `BroadcastOptions` (fee estimator, change address) were unreachable through the api, so api and cli users could not set fees.
+- A latent defect: `resolve()`'s need-dispatch switch had no `NeedSMTProof` case and no default. Because the resolver re-emits unfulfilled needs on every `resolve()` call, any SMT beacon signal without a matching sidecar proof spun the driver loop forever instead of failing.
+
+The did:btcr2 spec does not require CAS publication (sidecar-only distribution is expressly permitted), so the wiring must be optional and policy-driven, not mandatory.
+
+## Decision
+
+1. **`CasExecutor` gains an optional capability flag, `canPublish?: boolean`, where `undefined` MUST be treated as `true`.** Existing custom executors remain writable-by-default with no code change. The read-only `HttpGatewayCasExecutor` declares `canPublish = false`. `CasApi` exposes the derived `writable` getter.
+
+2. **`DidMethodApi.update` (and `UpdateBuilder`, and `DidBtcr2Api.updateDid`) gain `publishToCas: 'auto' | 'always' | 'never'`, defaulting to `'auto'`:**
+
+   | Policy | Writable CAS | Read-only / no CAS |
+   |---|---|---|
+   | `'auto'` | publish update (+ announcement for CAS beacons) | Singleton/SMT: skip silently. CAS beacon: **throw up-front** |
+   | `'always'` | publish update (+ announcement for CAS beacons) | **throw up-front**, all beacon types |
+   | `'never'` | publish nothing | publish nothing |
+
+   The CAS-beacon asymmetry under `'auto'` is deliberate: a Singleton or SMT update that skips CAS publication is still resolvable via sidecar with no surprises, but a CAS beacon signal points at an announcement that must be retrievable somewhere, so silently publishing it nowhere manufactures resolution failures. Callers who intend sidecar-only distribution state it explicitly with `'never'` and receive the announcement in the result. The policy check runs before the update is constructed or signed, so a misconfiguration costs nothing.
+
+3. **Publication order is update, then announcement, then transaction broadcast.** The api publishes the canonical signed update, hands the beacon a `casPublish` callback (CAS beacons only) that publishes the announcement, and only then does the beacon spend the UTXO (pre-spend ordering per ADR 070). Content addressing makes every step idempotent under retry.
+
+4. **`update()` returns a `DidUpdateResult`** instead of the bare `SignedBTCR2Update`: `{ signedUpdate, txid, announcement?, proof?, publishedToCas: { update, announcement } }`. Sidecar-only users capture the artifacts they must distribute; auditing callers see exactly what reached the CAS.
+
+5. **`broadcastOptions` (fee estimator, change address) pass through** `update()`, `UpdateBuilder.broadcastOptions()`, and `updateDid()` to the beacon transaction, closing the api-cannot-set-fees gap.
+
+6. **`resolve()` handles `NeedSMTProof` and unknown needs by failing fast.** SMT proofs are nonce-blinded and not content-addressed by anything on-chain, so no CAS fetch can fulfill the need; the error directs the caller to `options.sidecar.smtProofs`. A `default` case guards against future need kinds an older api cannot fulfill. Both replace an infinite loop.
+
+7. **The cli passes `publishToCas: 'never'` explicitly.** Its CAS configuration is currently gateway-only (read-only), so `'auto'` would make CAS-beacon updates fail with advice (set `'never'`) the cli offers no flag for yet. With `'never'`, cli CAS-beacon updates keep working sidecar-only and now print the announcement, txid, and proof for manual distribution. A follow-up change adds writable-CAS configuration and a `--publish-to-cas` flag, at which point the explicit `'never'` is replaced by the exposed knob.
+
+## Consequences
+
+- With a writable CAS configured, `'auto'` makes every OP_RETURN update hash fetchable from the CAS at resolution time: resolvers need no sidecar for Singleton and CAS beacon updates. This is the feature's goal.
+- **Privacy:** under `'auto'`, canonical signed updates (and announcements) are published to the configured, possibly public, CAS **before** the on-chain anchor. Controllers with privacy requirements should use `'never'` and distribute via sidecar, which matches the spec's guidance that privacy-conscious controllers keep update data off public stores. This trade-off is documented on the option itself.
+- CAS beacon updates through an api instance whose CAS is the default read-only gateway now throw up-front instead of silently producing a broadcast whose announcement the caller never sees (the old behavior additionally discarded the announcement entirely, pre-ADR 070). This is a deliberate behavior change: the old flow was a resolution failure deferred.
+- The `update()` return-type change is breaking for callers using the returned `SignedBTCR2Update` directly; at 0.x it ships as a minor bump, and the update is available as `result.signedUpdate`.
+- SMT-beacon resolution through the api now fails with an actionable error when the proof is absent, instead of hanging the process. Single-party SMT updates surface their proof through `DidUpdateResult.proof` (from ADR 070), which is the only channel that proof can reach a resolver by.
+
+## Rejected alternatives
+
+- **Silently skip CAS publication for CAS beacons under `'auto'` with a read-only CAS.** Symmetric with Singleton/SMT, but it turns a configuration gap into a future resolution failure for exactly the beacon type whose signals depend on retrievable announcements.
+- **Probe writability by attempting a publish.** A live probe costs a network round-trip, can leave junk in the store, and still races the real publish. A declared capability flag is free and exact; `undefined`-means-writable keeps it non-breaking for custom executors.
+- **Publish inside the `Updater` state machine.** The state machine is sans-I/O by design (its value is that broadcast and publication are the caller's I/O); the api layer is precisely the caller that owns I/O policy.
+- **Fulfill `NeedSMTProof` from the CAS.** The proof's root is nonce-blinded; there is no content address derivable from the on-chain signal, so a CAS lookup is impossible by construction. Failing fast with the sidecar pointer is the only honest behavior.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -146,3 +146,5 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 067 | 2026-07-02 | [Resolver Duplicate-Update Confirmation - Conditional Increment and Compare-Only History](067-resolver-duplicate-confirmation.md) |
 | 068 | 2026-07-06 | [versionTime Evaluation Order for Duplicates and Guarded Duplicate Confirmation](068-resolver-versiontime-duplicate-order.md) |
 | 069 | 2026-07-06 | [Fetch-Based CAS Executors Replace the In-Process IPFS Dependency](069-fetch-based-cas-executors-drop-helia.md) |
+| 070 | 2026-07-07 | [Beacon Broadcasts Return Structured Artifacts and CAS Publication Precedes the On-Chain Spend](070-broadcast-result-and-cas-first-ordering.md) |
+| 071 | 2026-07-07 | [A CAS Publication Policy for the API Update Path (publishToCas), Writable-CAS Capability Detection, and Enriched Update Results](071-api-cas-publication-policy.md) |

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @did-btcr2/api
 
+## 0.15.0
+
+### Minor Changes
+
+- CAS publication policy on the update path, writable-CAS capability detection, and enriched update results (ADR 071).
+
+  - `DidMethodApi.update`, `UpdateBuilder`, and `DidBtcr2Api.updateDid` gain `publishToCas: 'auto' | 'always' | 'never'` (default `'auto'`). Under `'auto'`/`'always'` with a writable CAS, the canonical signed update (all beacon types) and the CAS Announcement (CAS beacons) are published to the CAS **before** the on-chain broadcast, so any OP_RETURN update hash is fetchable from CAS at resolution time.
+  - Policy guards fail fast, before signing: `'always'` throws when the CAS is read-only or absent; `'auto'` throws for CAS beacons in that case (a CAS-beacon signal whose announcement lands nowhere is unresolvable); set `'never'` for sidecar-only distribution. Singleton/SMT updates skip publication silently under `'auto'`.
+  - **Privacy note:** `'auto'` publishes canonical signed updates to the configured (possibly public) CAS before anchoring. Privacy-conscious controllers should use `'never'` and distribute via sidecar.
+  - `update()`/`updateDid()`/`UpdateBuilder.execute()` now return a `DidUpdateResult` (`{ signedUpdate, txid, announcement?, proof?, publishedToCas }`) instead of the bare `SignedBTCR2Update`; read `result.signedUpdate` for the old value.
+  - `CasExecutor` gains optional `canPublish` (undefined means writable; `HttpGatewayCasExecutor` declares `false`); `CasApi` gains the `writable` getter.
+  - `broadcastOptions` (fee estimator, change address) now pass through the api update path to the beacon transaction.
+  - Fixed: `resolve()` no longer loops forever on an SMT beacon signal without a sidecar proof; it fails fast directing the caller to `options.sidecar.smtProofs` (SMT proofs are nonce-blinded and cannot be fetched from a CAS).
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/method@0.54.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -15,7 +15,9 @@ If you're integrating did:btcr2 into an app, start here. If you're customizing t
 - **`UpdateBuilder`** is a fluent chain over `DidMethodApi.update()` for callers who prefer named steps over a positional argument bag.
 - **`tryResolveDid(did)`** returns a discriminated `{ ok, document } | { ok, error, errorMessage }` instead of throwing, for cases where resolution failure is an expected outcome.
 
-The api wires the configured `BitcoinApi` into the sans-I/O Resolver and Updater state machines, fulfilling `NeedBeaconSignals`, `NeedFunding`, `NeedBroadcast`, and CAS-related needs (`NeedGenesisDocument`, `NeedCASAnnouncement`, `NeedSignedUpdate`) automatically. `NeedSMTProof` is not auto-fulfilled by the facade: SMT proofs must be provided upfront via `options.sidecar.smtProofs`. Multi-party aggregation is out of scope here; drive the Updater directly and hand `NeedBroadcast` to the aggregation runner from `@did-btcr2/aggregation`.
+The api wires the configured `BitcoinApi` into the sans-I/O Resolver and Updater state machines, fulfilling `NeedBeaconSignals`, `NeedFunding`, `NeedBroadcast`, and CAS-related needs (`NeedGenesisDocument`, `NeedCASAnnouncement`, `NeedSignedUpdate`) automatically. `NeedSMTProof` is not auto-fulfilled by the facade: SMT proofs are nonce-blinded (there is no content address to fetch them by), so they must be provided upfront via `options.sidecar.smtProofs`; resolution fails fast with that pointer otherwise. Multi-party aggregation is out of scope here; drive the Updater directly and hand `NeedBroadcast` to the aggregation runner from `@did-btcr2/aggregation`.
+
+On the write path, `publishToCas` (`'auto'` | `'always'` | `'never'`, default `'auto'`) controls whether update artifacts are published to the configured CAS **before** the on-chain broadcast. With a writable CAS, `'auto'` publishes the canonical signed update (all beacon types) plus the CAS Announcement (CAS beacons), so resolvers can fetch every OP_RETURN update hash from the CAS with no sidecar. Update calls return a `DidUpdateResult` carrying the signal `txid` and the per-beacon-type sidecar artifacts (announcement, SMT proof) for callers that distribute them out-of-band instead.
 
 ## Install
 
@@ -64,14 +66,40 @@ console.log(resolution.didDocument?.id);
 ```typescript
 import { LocalSigner } from '@did-btcr2/keypair';
 
-const signed = await api.btcr2
+// Ids are matched exactly against the document: use full DID URLs
+// (e.g. `${did}#initialKey`), not bare fragments.
+const { signedUpdate, txid, announcement, publishedToCas } = await api.btcr2
   .buildUpdate(currentDoc)
   .patch({ op: 'add', path: '/service/-', value: newService })
   .version(2)
-  .verificationMethodId('#initialKey')
-  .beacon('#beacon-0')
+  .verificationMethodId(`${did}#initialKey`)
+  .beacon(currentDoc.service[0].id)
   .signer(new LocalSigner(secretKey))
   .execute();
+```
+
+### Publish update artifacts to a CAS before broadcasting
+
+```typescript
+// A writable CAS (an IPFS node's RPC endpoint) makes updates resolvable
+// without sidecar data: the signed update (and, for CAS beacons, the
+// announcement) is published before the beacon transaction is broadcast.
+const api = createApi({
+  btc : { network: 'mutinynet' },
+  cas : { rpcUrl: 'http://127.0.0.1:5001' },
+});
+
+const result = await api.updateDid({
+  did,
+  patches              : [{ op: 'add', path: '/service/-', value: newService }],
+  verificationMethodId : `${did}#initialKey`,
+  beaconId             : `${did}#initialP2WPKH`,
+  signer,
+  // publishToCas defaults to 'auto'. Use 'never' for sidecar-only privacy:
+  // 'auto'/'always' publish canonical signed updates to the configured
+  // (possibly public) CAS before the on-chain anchor.
+});
+console.log(result.txid, result.publishedToCas); // e.g. { update: true, announcement: false }
 ```
 
 ### Resolve without throwing
@@ -95,8 +123,8 @@ const signer = new KeyManagerSigner(api.kms.kms, keyId);
 await api.updateDid({
   did,
   patches              : [{ op: 'add', path: '/service/-', value: newService }],
-  verificationMethodId : '#initialKey',
-  beaconId             : '#beacon-0',
+  verificationMethodId : `${did}#initialKey`,
+  beaconId             : `${did}#initialP2WPKH`,
   signer,
 });
 ```
@@ -105,7 +133,7 @@ await api.updateDid({
 
 - **Lazy sub-facades.** `api.btc` / `api.cas` / `api.btcr2` instantiate on first access. Creating an api without a Bitcoin config and never touching the chain costs nothing.
 - **Layered config.** Constructor config is applied first, then per-call overrides win. Bitcoin endpoint defaults come from `@did-btcr2/bitcoin`'s `DEFAULT_BITCOIN_NETWORK_CONFIG`.
-- **CAS has a sensible default.** If no `cas` config is passed, `api.cas` defaults to a read-only HTTP gateway against `https://ipfs.io`. Override for write capability or an alternative gateway.
+- **CAS has a sensible default.** If no `cas` config is passed, `api.cas` defaults to a read-only HTTP gateway against `https://ipfs.io`. Configure `cas.rpcUrl`, `cas.blockstore`, or a custom `cas.executor` for write capability; `api.cas.writable` reports whether the configured backend accepts publishes (executors declare it via `CasExecutor.canPublish`; undefined means writable).
 - **Driver injection.** `api.btcr2.resolve(did, options)` accepts an optional override; the api passes its own `BitcoinConnection` automatically when none is provided.
 
 ## Build & Test
@@ -125,6 +153,8 @@ The `lib/` directory contains end-to-end scripts that exercise the full update p
 - **Package docs on btcr2.dev** [btcr2.dev/impls/ts](https://btcr2.dev/impls/ts)
 - **[ADR-006](../../docs/adr/006-api-package-boundary.md)** API package boundary
 - **[ADR-024](../../docs/adr/024-api-facade-lazy-and-layered-config.md)** API facade lazy initialization + layered config
+- **[ADR-069](../../docs/adr/069-fetch-based-cas-executors-drop-helia.md)** Fetch-based CAS executors
+- **[ADR-071](../../docs/adr/071-api-cas-publication-policy.md)** CAS publication policy on the update path
 - **Source reference** See JSDoc on `DidBtcr2Api`, `DidMethodApi`, and the sub-facade classes.
 
 ## License

--- a/packages/api/lib/e2e-update-builder.ts
+++ b/packages/api/lib/e2e-update-builder.ts
@@ -86,7 +86,7 @@ console.log(`    funded + confirmed + indexed`);
 // ─── Step 5: Drive the UpdateBuilder fluent chain ───────────────────────────
 
 console.log(`\n[5] Calling api.btcr2.buildUpdate(...).signer(LocalSigner).execute() ...`);
-const signed = await api.btcr2
+const { signedUpdate: signed, txid } = await api.btcr2
   .buildUpdate(sourceDocument)
   .patch({
     op    : 'add',
@@ -103,7 +103,7 @@ const signed = await api.btcr2
   .signer(signer)
   .execute();
 
-console.log(`    update broadcast (targetVersionId: ${signed.targetVersionId})`);
+console.log(`    update broadcast (targetVersionId: ${signed.targetVersionId}, txid: ${txid})`);
 
 // Verify the DI proof.
 const verifierMultikey = SchnorrMultikey.fromVerificationMethod(sourceDocument.verificationMethod![0]!);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -3,7 +3,7 @@ import type { DocumentBytes, KeyBytes, PatchOperation } from '@did-btcr2/common'
 import type { Signer } from '@did-btcr2/keypair';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import type { KeyIdentifier } from '@did-btcr2/key-manager';
-import type { Btcr2DidDocument, DidCreateOptions, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
+import type { BroadcastOptions, Btcr2DidDocument, DidCreateOptions, ResolutionOptions } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 import { BitcoinApi } from './bitcoin.js';
 import { CasApi, DEFAULT_CAS_GATEWAY, type CasConfig } from './cas.js';
@@ -11,7 +11,7 @@ import { CryptoApi } from './crypto.js';
 import { DidApi } from './did.js';
 import { assertString, NOOP_LOGGER } from './helpers.js';
 import { KeyManagerApi } from './key-manager.js';
-import { DidMethodApi } from './method.js';
+import { DidMethodApi, type DidUpdateResult, type PublishToCasMode } from './method.js';
 import type { ApiConfig, BitcoinApiConfig, Logger, ResolutionResult } from './types.js';
 
 /**
@@ -196,8 +196,12 @@ export class DidBtcr2Api {
    *
    * If `sourceDocument` and `sourceVersionId` are both provided, resolution
    * is skipped. Otherwise the DID is resolved first to obtain them.
-   * @param params The update parameters.
-   * @returns The signed update.
+   * @param params The update parameters. `publishToCas` (default `'auto'`)
+   *   controls whether update artifacts are published to the configured CAS
+   *   before the on-chain broadcast; `broadcastOptions` passes fee estimator /
+   *   change address through to the beacon transaction.
+   * @returns The broadcast artifacts: signed update, signal txid, per-beacon-type
+   *   sidecar data, and which artifacts were published to CAS.
    */
   async updateDid({
     did,
@@ -207,6 +211,8 @@ export class DidBtcr2Api {
     signer,
     sourceDocument,
     sourceVersionId,
+    publishToCas,
+    broadcastOptions,
   }: {
     did: string;
     patches: PatchOperation[];
@@ -215,7 +221,9 @@ export class DidBtcr2Api {
     signer: Signer;
     sourceDocument?: Btcr2DidDocument;
     sourceVersionId?: number;
-  }): Promise<SignedBTCR2Update> {
+    publishToCas?: PublishToCasMode;
+    broadcastOptions?: BroadcastOptions;
+  }): Promise<DidUpdateResult> {
     this.#assertNotDisposed();
     assertString(did, 'did');
 
@@ -260,6 +268,8 @@ export class DidBtcr2Api {
       verificationMethodId,
       beaconId,
       signer,
+      publishToCas,
+      broadcastOptions,
     });
   }
 

--- a/packages/api/src/cas.ts
+++ b/packages/api/src/cas.ts
@@ -20,6 +20,15 @@ export interface CasExecutor {
   retrieve(hash: string): Promise<Uint8Array | null>;
   /** Publish raw bytes and return the base64url SHA-256 hash. */
   publish(data: Uint8Array): Promise<string>;
+  /**
+   * Whether this executor supports publishing. `undefined` MUST be treated as
+   * `true`: an executor that does not declare the capability is assumed
+   * writable, so existing custom executors keep working unchanged. Read-only
+   * executors (e.g. {@link HttpGatewayCasExecutor}) set `false`, letting
+   * callers route around `publish()` instead of discovering the limitation
+   * as a thrown error mid-operation.
+   */
+  readonly canPublish?: boolean;
 }
 
 /**
@@ -155,6 +164,7 @@ export class IpfsRpcCasExecutor implements CasExecutor {
  * @public
  */
 export class HttpGatewayCasExecutor implements CasExecutor {
+  readonly canPublish = false;
   readonly #gatewayUrl: string;
 
   constructor(gatewayUrl: string) {
@@ -242,6 +252,15 @@ export class CasApi {
       );
     }
     this.#timeoutMs = config.timeoutMs ?? DEFAULT_CAS_TIMEOUT_MS;
+  }
+
+  /**
+   * Whether the configured executor supports publishing. `true` unless the
+   * executor explicitly declares `canPublish: false` (an executor that does
+   * not declare the capability is assumed writable, per {@link CasExecutor}).
+   */
+  get writable(): boolean {
+    return this.#executor.canPublish !== false;
   }
 
   /**

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -2,13 +2,60 @@ import type { BitcoinConnection } from '@did-btcr2/bitcoin';
 import type { DocumentBytes, KeyBytes, PatchOperation } from '@did-btcr2/common';
 import { decode as decodeHash, IdentifierTypes, INVALID_DID_UPDATE, NotImplementedError, UpdateError } from '@did-btcr2/common';
 import type { Signer } from '@did-btcr2/keypair';
-import type { Btcr2DidDocument, CASAnnouncement, DidCreateOptions, NeedCASAnnouncement, NeedGenesisDocument, NeedSignedUpdate, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
+import type { BroadcastOptions, BroadcastResult, Btcr2DidDocument, CASAnnouncement, CASBroadcastOptions, DidCreateOptions, NeedCASAnnouncement, NeedGenesisDocument, NeedSignedUpdate, ResolutionOptions, SignedBTCR2Update, SMTProof } from '@did-btcr2/method';
 import { BeaconFactory, BeaconSignalDiscovery, DidBtcr2 } from '@did-btcr2/method';
 import type { DidResolutionResult, DidVerificationMethod } from '@web5/dids';
 import type { BitcoinApi } from './bitcoin.js';
 import type { CasApi } from './cas.js';
 import { assertBytes, assertCompressedPubkey, assertString, NOOP_LOGGER } from './helpers.js';
 import type { Logger } from './types.js';
+
+/**
+ * Policy for publishing update artifacts to the configured CAS during
+ * {@link DidMethodApi.update}:
+ *
+ * - `'auto'` (default): publish the signed update (all beacon types) and the CAS
+ *   Announcement (CAS beacons) when a writable CAS is configured. Singleton and
+ *   SMT beacon updates skip publication silently when the CAS is read-only or
+ *   absent; CAS beacon updates **throw up-front** instead, because a CAS beacon
+ *   signal whose announcement lands nowhere is unresolvable unless the caller
+ *   distributes it out-of-band (opt into that explicitly with `'never'`).
+ * - `'always'`: like `'auto'`, but a read-only or absent CAS throws up-front for
+ *   every beacon type.
+ * - `'never'`: publish nothing; the caller distributes the returned artifacts
+ *   (signed update, announcement, proof) via sidecar themselves.
+ * @public
+ */
+export type PublishToCasMode = 'auto' | 'always' | 'never';
+
+/**
+ * Result of {@link DidMethodApi.update}: the signed update plus every broadcast
+ * artifact a resolver (or a sidecar distributor) needs afterwards.
+ * @public
+ */
+export interface DidUpdateResult {
+  /** The signed update that was broadcast. */
+  signedUpdate: SignedBTCR2Update;
+  /** Transaction id of the on-chain beacon signal. */
+  txid: string;
+  /**
+   * The CAS Announcement whose hash rode in the OP_RETURN output (CAS beacons
+   * only). Capture it for sidecar distribution when it was not published to CAS.
+   */
+  announcement?: CASAnnouncement;
+  /**
+   * SMT inclusion proof for the update, with the leaf nonce embedded (SMT
+   * beacons only). Not content-addressable; always distribute via sidecar.
+   */
+  proof?: SMTProof;
+  /** Which artifacts were published to the configured CAS. */
+  publishedToCas: {
+    /** The canonical signed update bytes were published. */
+    update: boolean;
+    /** The canonical CAS Announcement bytes were published (CAS beacons only). */
+    announcement: boolean;
+  };
+}
 
 /**
  * DID method operations sub-facade: create, resolve, update, deactivate.
@@ -141,6 +188,25 @@ export class DidMethodApi {
               resolver.provide(need as NeedSignedUpdate, update as SignedBTCR2Update);
               break;
             }
+            case 'NeedSMTProof': {
+              // SMT proofs are nonce-blinded, so they are not content-addressed
+              // by anything on-chain and cannot be fetched from a CAS. Sidecar
+              // is the only channel; without it the need is unfulfillable.
+              throw new Error(
+                `SMT proof required but not in sidecar (root hash: ${need.smtRootHash}). `
+                + 'SMT proofs cannot be fetched from a CAS; provide the proof via '
+                + 'options.sidecar.smtProofs.'
+              );
+            }
+            default: {
+              // The switch is exhaustive over today's DataNeed union; this guards
+              // against a newer method package emitting a need this api version
+              // does not know how to fulfill, which would otherwise spin the
+              // while-loop forever.
+              throw new Error(
+                `Unsupported resolver data need: ${String((need as { kind?: string }).kind)}.`
+              );
+            }
           }
         }
         state = resolver.resolve();
@@ -165,6 +231,10 @@ export class DidMethodApi {
    * Update an existing DID document by driving the sans-I/O {@link Updater} state
    * machine (from @did-btcr2/method). This method handles the I/O side:
    * - Signing: supplies the {@link Signer} to `NeedSigningKey`.
+   * - CAS publication: publishes the signed update (and, for CAS beacons, the
+   *   announcement) to the configured CAS per the `publishToCas` policy,
+   *   **before** the on-chain broadcast, so any OP_RETURN update hash is
+   *   fetchable from CAS at resolution time without sidecar data.
    * - Broadcast: establishes a beacon via {@link BeaconFactory} and calls
    *   `broadcastSignal()` with the bitcoin connection configured on the API.
    *
@@ -173,7 +243,8 @@ export class DidMethodApi {
    * rather than using this high-level method.
    *
    * @param params The update parameters.
-   * @returns The signed update.
+   * @returns The broadcast artifacts: signed update, signal txid, per-beacon-type
+   *   sidecar data, and which artifacts were published to CAS.
    */
   async update({
     sourceDocument,
@@ -183,6 +254,8 @@ export class DidMethodApi {
     beaconId,
     signer,
     bitcoin,
+    publishToCas = 'auto',
+    broadcastOptions,
   }: {
     sourceDocument: Btcr2DidDocument;
     patches: PatchOperation[];
@@ -191,7 +264,9 @@ export class DidMethodApi {
     beaconId: string;
     signer: Signer;
     bitcoin?: BitcoinConnection;
-  }): Promise<SignedBTCR2Update> {
+    publishToCas?: PublishToCasMode;
+    broadcastOptions?: BroadcastOptions;
+  }): Promise<DidUpdateResult> {
     // Bitcoin connection resolution order: per-call `bitcoin` param wins over the
     // BitcoinApi injected at DidBtcr2Api construction time. One of the two must
     // be present; this can't be encoded in the type system, so it's a runtime check.
@@ -215,8 +290,19 @@ export class DidMethodApi {
       beaconId,
     });
 
-    // Drive the state machine. All I/O (signing delegation, Bitcoin broadcast)
-    // happens inside the need-handlers below - the Updater itself is pure.
+    // Decide the CAS publication plan before any signing or spending happens, so
+    // a policy violation (e.g. a CAS beacon with a read-only CAS under 'auto')
+    // fails fast instead of after the update is signed. Runs after the factory so
+    // an invalid beaconId still throws the canonical error; the service lookup
+    // uses the factory's exact-id match.
+    const beaconType = sourceDocument.service?.find(s => s.id === beaconId)?.type;
+    const publishCas = this.#planCasPublication(publishToCas, beaconType, beaconId);
+
+    // Drive the state machine. All I/O (signing delegation, CAS publication,
+    // Bitcoin broadcast) happens inside the need-handlers below - the Updater
+    // itself is pure.
+    let broadcastResult: BroadcastResult | undefined;
+    const publishedToCas = { update: false, announcement: false };
     let state = updater.advance();
     while(state.status === 'action-required') {
       for(const need of state.needs) {
@@ -241,21 +327,110 @@ export class DidMethodApi {
             break;
           }
           case 'NeedBroadcast': {
+            const options: CASBroadcastOptions = { ...broadcastOptions };
+
+            // Publication order: signed update, then announcement (inside the
+            // beacon, via casPublish), then the tx broadcast. Publishing before
+            // spending means a CAS failure aborts while the beacon UTXO is
+            // intact; content addressing makes a retry after a failed broadcast
+            // idempotent (same bytes, same address).
+            if(publishCas) {
+              this.#log.debug('Publishing signed update to CAS');
+              await publishCas.publish(need.signedUpdate);
+              publishedToCas.update = true;
+              if(need.beaconService.type === 'CASBeacon') {
+                options.casPublish = async (announcement) => {
+                  this.#log.debug('Publishing CAS announcement to CAS');
+                  await publishCas.publish(announcement);
+                  publishedToCas.announcement = true;
+                };
+              }
+            }
+
             this.#log.debug(
               'Broadcasting signed update via %s beacon', need.beaconService.type
             );
             const beacon = BeaconFactory.establish(need.beaconService);
-            await beacon.broadcastSignal(need.signedUpdate, signer, btcConnection);
+            broadcastResult = await beacon.broadcastSignal(
+              need.signedUpdate, signer, btcConnection, options
+            );
             updater.provide(need);
             break;
+          }
+          default: {
+            // The switch is exhaustive over today's UpdaterDataNeed union; this
+            // guards against a newer method package emitting a need this api
+            // version cannot fulfill, which would otherwise spin the while-loop
+            // forever (the updater re-emits unfulfilled needs on every advance()).
+            throw new UpdateError(
+              `Unsupported updater data need: ${String((need as { kind?: string }).kind)}.`,
+              INVALID_DID_UPDATE, { beaconId }
+            );
           }
         }
       }
       state = updater.advance();
     }
 
+    if(!broadcastResult) {
+      throw new UpdateError(
+        'Updater completed without reaching the broadcast phase.',
+        INVALID_DID_UPDATE, { beaconId }
+      );
+    }
+
     this.#log.debug('DID update complete', sourceDocument.id);
-    return state.result.signedUpdate;
+    return {
+      signedUpdate : state.result.signedUpdate,
+      txid         : broadcastResult.txid,
+      ...(broadcastResult.announcement ? { announcement: broadcastResult.announcement } : {}),
+      ...(broadcastResult.proof ? { proof: broadcastResult.proof } : {}),
+      publishedToCas,
+    };
+  }
+
+  /**
+   * Resolve the `publishToCas` policy against the configured CAS and the beacon
+   * type. Returns the {@link CasApi} to publish with, or `null` when publication
+   * is skipped; throws when the policy demands a writable CAS that is not available.
+   */
+  #planCasPublication(
+    mode: PublishToCasMode,
+    beaconType: string | undefined,
+    beaconId: string,
+  ): CasApi | null {
+    if(mode === 'never') return null;
+
+    if(this.#cas && this.#cas.writable) return this.#cas;
+
+    const casState = this.#cas
+      ? 'the configured CAS is read-only (e.g. an HTTP gateway)'
+      : 'no CAS is configured';
+
+    if(mode === 'always') {
+      throw new UpdateError(
+        `publishToCas is 'always' but ${casState}. Configure a writable CAS `
+        + '(cas.rpcUrl, cas.blockstore, or a custom cas.executor with publish support), '
+        + 'or use publishToCas \'auto\'/\'never\'.',
+        INVALID_DID_UPDATE, { beaconId, publishToCas: mode }
+      );
+    }
+
+    // 'auto': a CAS beacon signal points at an announcement that must be
+    // retrievable somewhere; silently publishing nowhere would produce an
+    // unresolvable signal unless the caller distributes sidecar data, which
+    // they must opt into explicitly.
+    if(beaconType === 'CASBeacon') {
+      throw new UpdateError(
+        `CAS beacon updates publish the announcement to a content-addressed store, but ${casState}. `
+        + 'Configure a writable CAS (cas.rpcUrl, cas.blockstore, or a custom cas.executor with '
+        + 'publish support), or set publishToCas \'never\' to distribute the returned announcement '
+        + 'via sidecar yourself.',
+        INVALID_DID_UPDATE, { beaconId, publishToCas: mode }
+      );
+    }
+
+    return null;
   }
 
   /**
@@ -275,12 +450,12 @@ export class DidMethodApi {
    *
    * @example
    * ```ts
-   * const signed = await api.btcr2
+   * const { signedUpdate, txid } = await api.btcr2
    *   .buildUpdate(currentDoc)
    *   .patch({ op: 'add', path: '/service/1', value: newService })
    *   .version(2)
-   *   .verificationMethodId('#initialKey')
-   *   .beacon('#beacon-0')
+   *   .verificationMethodId(`${currentDoc.id}#initialKey`)
+   *   .beacon(currentDoc.service[0].id)
    *   .signer(new LocalSigner(secretKey))
    *   .execute();
    * ```
@@ -317,6 +492,8 @@ export class UpdateBuilder {
   #beaconId?: string;
   #signer?: Signer;
   #bitcoin?: BitcoinConnection;
+  #publishToCas?: PublishToCasMode;
+  #broadcastOptions?: BroadcastOptions;
 
   /** @internal */
   constructor(methodApi: DidMethodApi, sourceDocument: Btcr2DidDocument) {
@@ -372,11 +549,23 @@ export class UpdateBuilder {
     return this;
   }
 
+  /** Set the CAS publication policy for this update (default `'auto'`). */
+  publishToCas(mode: PublishToCasMode): this {
+    this.#publishToCas = mode;
+    return this;
+  }
+
+  /** Set beacon broadcast options (fee estimator, change address). */
+  broadcastOptions(options: BroadcastOptions): this {
+    this.#broadcastOptions = options;
+    return this;
+  }
+
   /**
    * Execute the update.
    * @throws {Error} If required fields (version, verificationMethodId, beacon, signer) are missing.
    */
-  async execute(): Promise<SignedBTCR2Update> {
+  async execute(): Promise<DidUpdateResult> {
     if (this.#sourceVersionId === undefined) {
       throw new Error('UpdateBuilder: sourceVersionId is required. Call .version(id) before .execute().');
     }
@@ -401,6 +590,8 @@ export class UpdateBuilder {
       beaconId             : this.#beaconId,
       signer               : this.#signer,
       bitcoin              : this.#bitcoin,
+      publishToCas         : this.#publishToCas,
+      broadcastOptions     : this.#broadcastOptions,
     });
   }
 }

--- a/packages/api/tests/cas-api.spec.ts
+++ b/packages/api/tests/cas-api.spec.ts
@@ -248,6 +248,36 @@ describe('CasApi', () => {
     });
   });
 
+  describe('canPublish / writable', () => {
+    it('HttpGatewayCasExecutor declares canPublish false and CasApi reports non-writable', () => {
+      const executor = new HttpGatewayCasExecutor('https://gateway.example');
+      expect(executor.canPublish).to.equal(false);
+      expect(new CasApi({ executor }).writable).to.equal(false);
+    });
+
+    it('an executor without canPublish is treated as writable (undefined means true)', () => {
+      const executor: CasExecutor = {
+        retrieve : async () => null,
+        publish  : async () => 'hash',
+      };
+      expect(new CasApi({ executor }).writable).to.equal(true);
+    });
+
+    it('an executor with canPublish true is writable', () => {
+      const executor: CasExecutor = {
+        retrieve   : async () => null,
+        publish    : async () => 'hash',
+        canPublish : true,
+      };
+      expect(new CasApi({ executor }).writable).to.equal(true);
+    });
+
+    it('blockstore- and RPC-backed configs are writable', () => {
+      expect(new CasApi({ blockstore: new FakeBlockstore() }).writable).to.equal(true);
+      expect(new CasApi({ rpcUrl: 'http://127.0.0.1:5001' }).writable).to.equal(true);
+    });
+  });
+
   describe('publish / retrieve', () => {
     it('publish canonicalizes the object and returns its canonical hash', async () => {
       const cas = new CasApi({ blockstore: new FakeBlockstore() });

--- a/packages/api/tests/did-method-api-cas-policy.spec.ts
+++ b/packages/api/tests/did-method-api-cas-policy.spec.ts
@@ -1,0 +1,475 @@
+import type { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { canonicalHash, canonicalHashBytes, encode, hash } from '@did-btcr2/common';
+import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
+import type { Btcr2DidDocument, NeedBeaconSignals } from '@did-btcr2/method';
+import { DidBtcr2, ID_PLACEHOLDER_VALUE } from '@did-btcr2/method';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { Address, OutScript, p2wpkh, Transaction } from '@scure/btc-signer';
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import type { BitcoinApi, CasExecutor, DidUpdateResult } from '../src/index.js';
+import { CasApi, createApi, DidMethodApi, MultikeyApi } from '../src/index.js';
+
+use(chaiAsPromised);
+
+const network = getNetwork('regtest');
+const TXID = 'e'.repeat(64);
+
+/**
+ * In-memory {@link CasExecutor} that records publish order. Each publish is
+ * labeled `cas:update` or `cas:announcement` by inspecting the canonical JSON
+ * (signed updates carry a `targetHash`; announcements are flat DID-to-hash maps).
+ */
+class MemCasExecutor implements CasExecutor {
+  readonly store = new Map<string, Uint8Array>();
+  readonly canPublish?: boolean;
+  readonly #order?: string[];
+
+  constructor(order?: string[], canPublish?: boolean) {
+    this.#order = order;
+    this.canPublish = canPublish;
+  }
+
+  async retrieve(hashKey: string): Promise<Uint8Array | null> {
+    return this.store.get(hashKey) ?? null;
+  }
+
+  async publish(data: Uint8Array): Promise<string> {
+    const text = new TextDecoder().decode(data);
+    this.#order?.push(text.includes('"targetHash"') ? 'cas:update' : 'cas:announcement');
+    const hashKey = encode(hash(text), 'base64urlnopad');
+    this.store.set(hashKey, data);
+    return hashKey;
+  }
+}
+
+/** Writable executor whose publish rejects on the given 1-indexed call. */
+class FlakyCasExecutor extends MemCasExecutor {
+  #failOnCall: number;
+  #calls = 0;
+
+  constructor(order: string[], failOnCall: number) {
+    super(order);
+    this.#failOnCall = failOnCall;
+  }
+
+  override async publish(data: Uint8Array): Promise<string> {
+    this.#calls += 1;
+    if (this.#calls === this.#failOnCall) throw new Error('cas publish unavailable');
+    return super.publish(data);
+  }
+}
+
+/**
+ * Minimal BitcoinConnection that funds `beaconAddress` with one confirmed UTXO
+ * and records broadcasts into `order` / UTXO lookups into `counters`.
+ */
+function mockBitcoin(
+  beaconAddress: string,
+  order: string[],
+  counters: { utxoCalls: number; sent: string[] },
+): BitcoinConnection {
+  const beaconScript = OutScript.encode(Address(network).decode(beaconAddress));
+  const prevTx = new Transaction({ allowUnknownOutputs: true });
+  prevTx.addOutput({ amount: 100_000n, script: beaconScript });
+  prevTx.addInput({ txid: new Uint8Array(32), index: 0xffffffff, finalScriptSig: new Uint8Array([0x00]) });
+  const prevTxBytes = prevTx.toBytes();
+  const utxo: AddressUtxo = { txid: prevTx.id, vout: 0, value: 100_000, status: { confirmed: true, block_height: 100 } as never };
+  return {
+    data : network,
+    rest : {
+      address     : { getUtxos: async () => { counters.utxoCalls += 1; return [utxo]; } },
+      transaction : {
+        getHex : async () => bytesToHex(prevTxBytes),
+        send   : async (hex: string) => { counters.sent.push(hex); order.push('tx-broadcast'); return TXID; },
+      },
+    },
+  } as unknown as BitcoinConnection;
+}
+
+/**
+ * Resolve a deterministic DID to its genesis document (sans-I/O, empty signals)
+ * and swap its services for a single beacon of `beaconType` at the address the
+ * signer's key can spend. Returns everything an update() call needs.
+ */
+function updateFixture(beaconType: 'SingletonBeacon' | 'CASBeacon' | 'SMTBeacon'): {
+  did: string;
+  sourceDocument: Btcr2DidDocument;
+  verificationMethodId: string;
+  beaconId: string;
+  signer: LocalSigner;
+  beaconAddress: string;
+} {
+  const kp = SchnorrKeyPair.generate();
+  const signer = new LocalSigner(kp.secretKey.bytes);
+  const did = DidBtcr2.create(kp.publicKey.compressed, { idType: 'KEY', network: 'regtest' });
+
+  const resolver = DidBtcr2.resolve(did);
+  const state = resolver.resolve();
+  if(state.status !== 'action-required') throw new Error('expected action-required');
+  resolver.provide(state.needs[0] as NeedBeaconSignals, new Map());
+  const final = resolver.resolve();
+  if(final.status !== 'resolved') throw new Error('expected resolved');
+
+  const beaconAddress = p2wpkh(signer.publicKey, network).address!;
+  const beaconId = `${did}#beacon-test`;
+  const sourceDocument = JSON.parse(JSON.stringify(final.result.didDocument)) as Btcr2DidDocument;
+  sourceDocument.service = [{
+    id              : beaconId,
+    type            : beaconType,
+    serviceEndpoint : `bitcoin:${beaconAddress}`,
+  }];
+
+  return {
+    did,
+    sourceDocument,
+    verificationMethodId : `${did}#initialKey`,
+    beaconId,
+    signer,
+    beaconAddress,
+  };
+}
+
+/** Common update() args for a fixture, wired to fresh recorders. */
+function updateArgs(fixture: ReturnType<typeof updateFixture>, order: string[], counters: { utxoCalls: number; sent: string[] }) {
+  return {
+    sourceDocument       : fixture.sourceDocument,
+    patches              : [],
+    sourceVersionId      : 1,
+    verificationMethodId : fixture.verificationMethodId,
+    beaconId             : fixture.beaconId,
+    signer               : fixture.signer,
+    bitcoin              : mockBitcoin(fixture.beaconAddress, order, counters),
+  };
+}
+
+describe('DidMethodApi update() CAS publication policy', () => {
+
+  function recorders(): { order: string[]; counters: { utxoCalls: number; sent: string[] } } {
+    return { order: [], counters: { utxoCalls: 0, sent: [] } };
+  }
+
+  describe('CAS beacon', () => {
+    it('auto + writable CAS: publishes update then announcement, then broadcasts', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['cas:update', 'cas:announcement', 'tx-broadcast']);
+      expect(result.txid).to.equal(TXID);
+      expect(result.publishedToCas).to.deep.equal({ update: true, announcement: true });
+      expect(result.announcement).to.deep.equal({ [fixture.did]: canonicalHash(result.signedUpdate) });
+      // Both artifacts are retrievable at their canonical hashes.
+      expect(executor.store.has(canonicalHash(result.signedUpdate))).to.equal(true);
+      expect(executor.store.has(canonicalHash(result.announcement!))).to.equal(true);
+    });
+
+    it('auto + read-only CAS: throws up-front, before any signing or UTXO lookup', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      await expect(methodApi.update(updateArgs(fixture, order, counters)))
+        .to.be.rejectedWith(/read-only.*publishToCas 'never'/s);
+      expect(counters.utxoCalls, 'must fail before the funding phase').to.equal(0);
+      expect(order).to.deep.equal([]);
+    });
+
+    it('auto + no CAS configured: throws up-front', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi();
+
+      await expect(methodApi.update(updateArgs(fixture, order, counters)))
+        .to.be.rejectedWith(/no CAS is configured/);
+      expect(counters.utxoCalls).to.equal(0);
+    });
+
+    it('never + read-only CAS: succeeds and returns the announcement for sidecar distribution', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'never',
+      });
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.announcement).to.deep.equal({ [fixture.did]: canonicalHash(result.signedUpdate) });
+    });
+
+    it('never + WRITABLE CAS: the explicit opt-out publishes nothing', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'never',
+      });
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(executor.store.size, 'nothing may reach the CAS under never').to.equal(0);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.announcement).to.exist;
+    });
+
+    it('publish failure on the signed update aborts before any broadcast', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new FlakyCasExecutor(order, 1) })
+      );
+
+      await expect(methodApi.update(updateArgs(fixture, order, counters)))
+        .to.be.rejectedWith(/cas publish unavailable/);
+      expect(order, 'no publish label, no tx broadcast').to.deep.equal([]);
+      expect(counters.sent, 'the beacon UTXO must not be spent').to.have.length(0);
+    });
+
+    it('publish failure on the announcement aborts after the update publish, before the spend', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new FlakyCasExecutor(order, 2) })
+      );
+
+      await expect(methodApi.update(updateArgs(fixture, order, counters)))
+        .to.be.rejectedWith(/cas publish unavailable/);
+      // Partial-publish state: the update reached the CAS (harmless, content-
+      // addressed), the announcement did not, and no transaction was broadcast.
+      expect(order).to.deep.equal(['cas:update']);
+      expect(counters.sent).to.have.length(0);
+    });
+  });
+
+  describe('Singleton beacon', () => {
+    it('auto + read-only CAS: skips publication silently', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.txid).to.equal(TXID);
+      expect(result.announcement).to.equal(undefined);
+      expect(result.proof).to.equal(undefined);
+    });
+
+    it('auto + writable CAS: publishes the signed update before broadcasting', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['cas:update', 'tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: true, announcement: false });
+      expect(executor.store.has(canonicalHash(result.signedUpdate))).to.equal(true);
+    });
+
+    it('always + read-only CAS: throws up-front', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      await expect(methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'always',
+      })).to.be.rejectedWith(/'always'.*read-only/s);
+      expect(counters.utxoCalls).to.equal(0);
+    });
+
+    it('always + writable CAS: actually publishes the update', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'always',
+      });
+
+      expect(order).to.deep.equal(['cas:update', 'tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: true, announcement: false });
+      expect(executor.store.has(canonicalHash(result.signedUpdate))).to.equal(true);
+    });
+
+    it('auto + NO CAS configured: the default out-of-box path skips publication silently', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi();
+
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(result.txid).to.equal(TXID);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+    });
+  });
+
+  describe('SMT beacon', () => {
+    it('auto + writable CAS: publishes the update and returns the inclusion proof', async () => {
+      const fixture = updateFixture('SMTBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['cas:update', 'tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: true, announcement: false });
+      expect(result.proof, 'the SMT proof must surface through the api').to.exist;
+      expect(result.proof!.nonce).to.be.a('string');
+      expect(result.proof!.updateId).to.equal(canonicalHash(result.signedUpdate));
+    });
+  });
+
+  describe('broadcastOptions passthrough', () => {
+    it('forwards a custom fee estimator to the beacon transaction', async () => {
+      const fixture = updateFixture('SingletonBeacon');
+      const { order, counters } = recorders();
+      const feeCalls: number[] = [];
+      const methodApi = new DidMethodApi();
+
+      await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas     : 'never',
+        broadcastOptions : { feeEstimator: { estimateFee: async (vsize: number) => { feeCalls.push(vsize); return 1000n; } } },
+      });
+
+      expect(feeCalls.length, 'the custom estimator must be consulted').to.be.greaterThan(0);
+    });
+  });
+
+  describe('UpdateBuilder passthrough', () => {
+    it('chains publishToCas and broadcastOptions into update()', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      const result = await methodApi.buildUpdate(fixture.sourceDocument)
+        .version(1)
+        .verificationMethodId(fixture.verificationMethodId)
+        .beacon(fixture.beaconId)
+        .signer(fixture.signer)
+        .bitcoin(mockBitcoin(fixture.beaconAddress, order, counters))
+        .publishToCas('never')
+        .broadcastOptions({})
+        .execute();
+
+      expect(result.txid).to.equal(TXID);
+      expect(result.announcement).to.exist;
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+    });
+  });
+
+  describe('DidBtcr2Api.updateDid passthrough', () => {
+    it('forwards publishToCas and broadcastOptions to the method facade', async () => {
+      const api = createApi();
+      const captured: { params?: any } = {};
+      const canned: DidUpdateResult = {
+        signedUpdate   : {} as DidUpdateResult['signedUpdate'],
+        txid           : TXID,
+        publishedToCas : { update: false, announcement: false },
+      };
+      // Shadow the lazy btcr2 getter with a capturing stub so the forwarding
+      // is observable without real signing or Bitcoin I/O.
+      Object.defineProperty(api, 'btcr2', {
+        value : { update: async (params: unknown) => { captured.params = params; return canned; } },
+      });
+
+      const feeEstimator = { estimateFee: async () => 1000n };
+      const result = await api.updateDid({
+        did                  : 'did:btcr2:k1qtest',
+        patches              : [],
+        verificationMethodId : '#k',
+        beaconId             : '#b',
+        signer               : {} as never,
+        sourceDocument       : {} as never,
+        sourceVersionId      : 1,
+        publishToCas         : 'never',
+        broadcastOptions     : { feeEstimator },
+      });
+
+      expect(captured.params.publishToCas).to.equal('never');
+      expect(captured.params.broadcastOptions.feeEstimator).to.equal(feeEstimator);
+      expect(result).to.equal(canned);
+    });
+  });
+});
+
+describe('DidMethodApi resolve() SMT proof handling', () => {
+  it('fails fast with a sidecar pointer instead of spinning on NeedSMTProof', async () => {
+    // Mint an x1 DID whose genesis document carries an SMT beacon, then surface
+    // one on-chain signal for it with no proof in the sidecar.
+    const kp = SchnorrKeyPair.generate();
+    const mkApi = new MultikeyApi();
+    const mk = mkApi.create('#key-0', ID_PLACEHOLDER_VALUE, kp);
+    const vm = mkApi.toVerificationMethod(mk);
+    const beaconAddress = p2wpkh(new LocalSigner(kp.secretKey.bytes).publicKey, network).address!;
+    const genesisDocument = {
+      'id'                   : ID_PLACEHOLDER_VALUE,
+      '@context'             : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+      'verificationMethod'   : [{ ...vm, id: `${ID_PLACEHOLDER_VALUE}#key-0`, controller: ID_PLACEHOLDER_VALUE }],
+      'authentication'       : [`${ID_PLACEHOLDER_VALUE}#key-0`],
+      'assertionMethod'      : [`${ID_PLACEHOLDER_VALUE}#key-0`],
+      'capabilityInvocation' : [`${ID_PLACEHOLDER_VALUE}#key-0`],
+      'capabilityDelegation' : [`${ID_PLACEHOLDER_VALUE}#key-0`],
+      'service'              : [{
+        id              : `${ID_PLACEHOLDER_VALUE}#smt-beacon`,
+        type            : 'SMTBeacon',
+        serviceEndpoint : `bitcoin:${beaconAddress}`,
+      }],
+    };
+
+    const methodApi = new DidMethodApi();
+    const did = methodApi.createExternal(canonicalHashBytes(genesisDocument), { network: 'regtest' });
+
+    const smtRootHex = 'ab'.repeat(32);
+    const signalTx = {
+      vout   : [{ scriptpubkey_asm: `OP_RETURN OP_PUSHBYTES_32 ${smtRootHex}` }],
+      status : { block_height: 100, block_time: 1700000000 },
+    };
+    const btcMock = {
+      connection : {
+        data : network,
+        rest : {
+          block   : { count: async () => 105 },
+          address : { getTxs: async () => [signalTx] },
+        },
+      } as unknown as BitcoinConnection,
+    } as unknown as BitcoinApi;
+
+    const withSignals = new DidMethodApi(btcMock);
+    try {
+      await withSignals.resolve(did, { sidecar: { genesisDocument } });
+      expect.fail('resolution should have failed on the missing SMT proof');
+    } catch (err: any) {
+      expect(err.message).to.include('Failed to resolve DID');
+      expect(String(err.cause?.message)).to.match(/SMT proof required/);
+      expect(String(err.cause?.message)).to.match(/sidecar\.smtProofs/);
+    }
+  });
+});

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @did-btcr2/cli
 
+## 0.13.0
+
+### Minor Changes
+
+- **Breaking output change:** `update` and `deactivate` now print the api's enriched `DidUpdateResult` instead of the bare signed update. The old payload moves under `data.signedUpdate`; new fields are `data.txid`, `data.announcement` (CAS beacons), `data.proof` (SMT beacons), and `data.publishedToCas`. Note that `data.proof` changes meaning: it was the signed update's Data Integrity proof (now at `data.signedUpdate.proof`) and is now the optional SMT inclusion proof. Scripts parsing this output must be updated.
+
+  The enriched output surfaces the artifacts required for manual sidecar distribution (txid, announcement, SMT proof). The cli passes `publishToCas: 'never'` explicitly (its CAS configuration is read-only gateway-only for now); a follow-up exposes writable-CAS configuration and a `--publish-to-cas` flag.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.15.0
+  - @did-btcr2/method@0.54.0
+
 ## 0.12.18
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.12.18",
+  "version": "0.13.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -70,6 +70,9 @@ export function registerDeactivateCommand(
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
+      // The CLI's CAS is a read-only gateway (no writable CAS is configurable
+      // yet), so CAS publication is disabled explicitly. The returned artifacts
+      // (txid, announcement, proof) are printed for manual sidecar distribution.
       const data = await api.btcr2.update({
         sourceDocument       : parsed.sourceDocument,
         patches              : parsed.patches,
@@ -77,6 +80,7 @@ export function registerDeactivateCommand(
         verificationMethodId : parsed.verificationMethodId,
         beaconId             : parsed.beaconId,
         signer,
+        publishToCas         : 'never',
       });
       console.log(formatResult({ action: 'deactivate', data }, globals()));
     });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -70,6 +70,9 @@ export function registerUpdateCommand(
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
+      // The CLI's CAS is a read-only gateway (no writable CAS is configurable
+      // yet), so CAS publication is disabled explicitly. The returned artifacts
+      // (txid, announcement, proof) are printed for manual sidecar distribution.
       const data = await api.btcr2.update({
         sourceDocument       : parsed.sourceDocument,
         patches              : parsed.patches,
@@ -77,6 +80,7 @@ export function registerUpdateCommand(
         verificationMethodId : parsed.verificationMethodId,
         beaconId             : parsed.beaconId,
         signer,
+        publishToCas         : 'never',
       });
       console.log(formatResult({ action: 'update', data }, globals()));
     });

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,5 +1,6 @@
+import type { DidUpdateResult } from '@did-btcr2/api';
 import type { PatchOperation } from '@did-btcr2/common';
-import type { Btcr2DidDocument, ResolutionOptions, SignedBTCR2Update } from '@did-btcr2/method';
+import type { Btcr2DidDocument, ResolutionOptions } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 
 export type NetworkOption = 'bitcoin' | 'testnet3' | 'testnet4' | 'signet' | 'mutinynet' | 'regtest';
@@ -25,8 +26,8 @@ export interface UpdateCommandOptions {
 export type CommandResult =
   | { action: 'create'; data: string; keyId?: string; publicKey?: string }
   | { action: 'resolve'; data: DidResolutionResult }
-  | { action: 'update'; data: SignedBTCR2Update }
-  | { action: 'deactivate'; data: SignedBTCR2Update }
+  | { action: 'update'; data: DidUpdateResult }
+  | { action: 'deactivate'; data: DidUpdateResult }
   | { action: 'key-generate'; data: { keyId: string; publicKey: string; active: boolean } }
   | { action: 'key-list'; data: Array<{ keyId: string; fingerprint: string; name?: string; active: boolean }> }
   | { action: 'key-show'; data: { keyId: string; publicKey: string; tags?: Record<string, string> } }

--- a/packages/cli/tests/update.spec.ts
+++ b/packages/cli/tests/update.spec.ts
@@ -77,6 +77,10 @@ describe('update and deactivate (signing)', () => {
     expect(captured.params.signer).to.be.instanceOf(KeyManagerSigner);
     expect(captured.params.sourceVersionId).to.equal(2);
     expect(captured.params.patches).to.deep.equal(JSON.parse(PATCHES));
+    // The CLI has no writable CAS configuration yet, so it must opt out of
+    // CAS publication explicitly (otherwise CAS-beacon updates would throw
+    // under the api's default 'auto' policy).
+    expect(captured.params.publishToCas).to.equal('never');
     expect(JSON.parse(out[0]).signed).to.equal('mock');
   });
 
@@ -101,5 +105,6 @@ describe('update and deactivate (signing)', () => {
     );
     expect(captured.params.signer).to.be.instanceOf(KeyManagerSigner);
     expect(captured.params.patches).to.deep.equal([{ op: 'add', path: '/deactivated', value: true }]);
+    expect(captured.params.publishToCas).to.equal('never');
   });
 });

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @did-btcr2/method
 
+## 0.54.0
+
+### Minor Changes
+
+- Beacon broadcasts return structured artifacts, and CAS publication precedes the on-chain spend (ADR 070).
+
+  - `broadcastSignal` on all three beacons (Singleton, CAS, SMT) now returns a `BroadcastResult` (`{ signedUpdate, txid, announcement?, proof? }`) instead of echoing the `SignedBTCR2Update`. Callers that used the return value directly should read `result.signedUpdate`.
+  - SMT beacon broadcasts return the Merkle inclusion proof (leaf nonce embedded). Previously the proof and nonce were discarded, which made every single-party SMT signal permanently unresolvable; capture `result.proof` for sidecar distribution.
+  - CAS beacon broadcasts return the CAS Announcement, so sidecar-only controllers can capture the object a resolver needs.
+  - **Semantic change:** the CAS beacon now invokes `casPublish` **before** broadcasting the signal transaction. A publish failure aborts the operation while the beacon UTXO is still unspent; retries are idempotent (content-addressed re-publish).
+  - `Updater.announce` accepts an options parameter (fee estimator, change address, `casPublish`) and returns the `BroadcastResult`.
+
 ## 0.53.0
 
 ### Minor Changes

--- a/packages/method/README.md
+++ b/packages/method/README.md
@@ -97,10 +97,14 @@ while (state.status === 'action-required') {
         // Check UTXOs at need.beaconAddress, fund if needed
         updater.provide(need);
         break;
-      case 'NeedBroadcast':
-        await Updater.announce(need.beaconService, need.signedUpdate, signer, bitcoin);
+      case 'NeedBroadcast': {
+        // Capture the BroadcastResult: broadcast.txid, plus broadcast.announcement
+        // (CAS beacons) and broadcast.proof (SMT beacons; must be retained, the
+        // proof's nonce exists nowhere else).
+        const broadcast = await Updater.announce(need.beaconService, need.signedUpdate, signer, bitcoin);
         updater.provide(need);
         break;
+      }
     }
   }
   state = updater.advance();

--- a/packages/method/lib/generate-vector.ts
+++ b/packages/method/lib/generate-vector.ts
@@ -942,9 +942,10 @@ async function announceUpdate(
   console.log(`  endpoint: ${beaconService.serviceEndpoint}`);
 
   const signer = new LocalSigner(hex.decode(signingMaterial));
-  await Updater.announce(beaconService, signedUpdate, signer, bitcoin);
+  const { txid } = await Updater.announce(beaconService, signedUpdate, signer, bitcoin);
 
   console.log(`Update announced to Bitcoin (${network})`);
+  console.log(`  txid: ${txid}`);
 }
 
 /**

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.53.0",
+    "version": "0.54.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -4,8 +4,9 @@ import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import { concatBytes, hexToBytes } from '@noble/hashes/utils.js';
 import { Address, OutScript, p2pkh, p2tr, p2wpkh, Script, SigHash, Transaction } from '@scure/btc-signer';
+import type { SMTProof } from '../interfaces.js';
 import type { BeaconProcessResult } from '../resolver.js';
-import type { SidecarData } from '../types.js';
+import type { CASAnnouncement, SidecarData } from '../types.js';
 import { BeaconError } from './error.js';
 import { DEFAULT_FEE_ESTIMATOR } from './fee-estimator.js';
 import type { FeeEstimator } from './fee-estimator.js';
@@ -183,6 +184,33 @@ export interface BroadcastOptions {
    * stop linking the beacon's announcements into one on-chain chain (ADR 044).
    */
   changeAddress?: string;
+}
+
+/**
+ * Result of a single-party beacon broadcast. Beyond the signed update itself,
+ * it carries every artifact the broadcast produced that a resolver will later
+ * need: without them, some signals are unresolvable (the SMT proof) or the
+ * controller cannot distribute the sidecar data the spec requires them to
+ * retain (the CAS announcement).
+ */
+export interface BroadcastResult {
+  /** The signed update that was broadcast. */
+  signedUpdate: SignedBTCR2Update;
+  /** Transaction id of the on-chain beacon signal. */
+  txid: string;
+  /**
+   * The CAS Announcement whose hash rode in the OP_RETURN output. CAS beacons
+   * only. Capture it for sidecar distribution (or publish it to a CAS): a
+   * resolver cannot process the signal without it.
+   */
+  announcement?: CASAnnouncement;
+  /**
+   * SMT inclusion proof for the broadcast update, including the nonce the leaf
+   * was blinded with. SMT beacons only. Capture it for sidecar distribution:
+   * the nonce is generated at broadcast time and appears nowhere else, so a
+   * signal whose proof is dropped is permanently unresolvable.
+   */
+  proof?: SMTProof;
 }
 
 /**
@@ -544,14 +572,15 @@ export abstract class SinglePartyBeacon {
    *   ECDSA for P2PKH / P2WPKH singletons, Schnorr (BIP-340) for P2TR key-path.
    * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
    * @param {BroadcastOptions} [options] Optional broadcast configuration (e.g. fee estimator).
-   * @returns {Promise<SignedBTCR2Update>} The signed update that was broadcast.
+   * @returns {Promise<BroadcastResult>} The broadcast artifacts: the signed update, the
+   *   signal txid, and the per-beacon-type sidecar data (CAS announcement / SMT proof).
    */
   abstract broadcastSignal(
     signedUpdate: SignedBTCR2Update,
     signer: Signer,
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
-  ): Promise<SignedBTCR2Update>;
+  ): Promise<BroadcastResult>;
 
   /**
    * Build + sign + broadcast a singleton beacon signal transaction. The beacon

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -4,14 +4,15 @@ import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import type { BeaconService, BeaconSignal, BlockMetadata, CasPublishFn } from './interfaces.js';
 
 /**
  * CAS-specific broadcast options: extends {@link BroadcastOptions} with an optional
- * `casPublish` callback used to publish the CAS Announcement off-chain after the
- * OP_RETURN signal is broadcast.
+ * `casPublish` callback used to publish the CAS Announcement off-chain before the
+ * OP_RETURN signal transaction is broadcast. A publish failure aborts the broadcast
+ * while the beacon UTXO is still unspent.
  */
 export interface CASBroadcastOptions extends BroadcastOptions {
   casPublish?: CasPublishFn;
@@ -134,17 +135,23 @@ export class CASBeacon extends SinglePartyBeacon {
   /**
    * Broadcasts a CAS Beacon signal to the Bitcoin network.
    *
-   * Creates a CAS Announcement mapping the DID to the update hash, broadcasts the hash of the
-   * announcement via OP_RETURN, and optionally publishes the announcement off-chain via the
-   * supplied `casPublish` callback. UTXO selection, PSBT construction, fee estimation, signing,
+   * Creates a CAS Announcement mapping the DID to the update hash, optionally publishes the
+   * announcement off-chain via the supplied `casPublish` callback, then broadcasts the hash of
+   * the announcement via OP_RETURN. UTXO selection, PSBT construction, fee estimation, signing,
    * and broadcast are delegated to {@link SinglePartyBeacon.buildSignAndBroadcast}.
+   *
+   * The CAS publish happens **before** the transaction broadcast: a publish failure aborts the
+   * operation while the beacon UTXO is still unspent, so no on-chain signal ever points at an
+   * announcement that failed to publish. The announcement is content-addressed, so a retry
+   * after a failed broadcast re-publishes the same bytes to the same address (idempotent).
    *
    * @param {SignedBTCR2Update} signedUpdate The signed BTCR2 update to broadcast.
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
    * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
    * @param {CASBroadcastOptions} [options] Optional broadcast configuration, including a
    *   `casPublish` callback to publish the announcement off-chain and a `feeEstimator`.
-   * @returns {Promise<SignedBTCR2Update>} The signed update that was broadcast.
+   * @returns {Promise<BroadcastResult>} The signed update, the signal txid, and the CAS
+   *   Announcement (capture it for sidecar distribution when no `casPublish` is supplied).
    * @throws {BeaconError} if the bitcoin address is invalid, unfunded, or UTXO cannot cover the fee.
    */
   async broadcastSignal(
@@ -152,7 +159,7 @@ export class CASBeacon extends SinglePartyBeacon {
     signer: Signer,
     bitcoin: BitcoinConnection,
     options?: CASBroadcastOptions
-  ): Promise<SignedBTCR2Update> {
+  ): Promise<BroadcastResult> {
     // Extract the DID from the beacon service id (strip the #fragment)
     const did = this.service.id.split('#')[0];
 
@@ -165,14 +172,15 @@ export class CASBeacon extends SinglePartyBeacon {
     // Canonicalize and hash the CAS Announcement for the OP_RETURN output
     const announcementHash = hash(canonicalize(casAnnouncement));
 
-    // Delegate UTXO selection, PSBT construction, fee estimation, signing, and broadcast
-    await this.buildSignAndBroadcast(announcementHash, signer, bitcoin, options);
-
-    // Publish CAS Announcement to content-addressed store if callback provided
+    // Publish the announcement to the content-addressed store before spending the
+    // beacon UTXO, so a publish failure aborts pre-spend.
     if(options?.casPublish) {
       await options.casPublish(casAnnouncement);
     }
 
-    return signedUpdate;
+    // Delegate UTXO selection, PSBT construction, fee estimation, signing, and broadcast
+    const txid = await this.buildSignAndBroadcast(announcementHash, signer, bitcoin, options);
+
+    return { signedUpdate, txid, announcement: casAnnouncement };
   }
 }

--- a/packages/method/src/core/beacon/interfaces.ts
+++ b/packages/method/src/core/beacon/interfaces.ts
@@ -68,8 +68,11 @@ export interface BeaconSignal {
 
 /**
  * Callback for publishing a CAS Announcement to a content-addressed store.
- * The method package defines this type; the api layer provides the implementation
- * (e.g., via CasApi.publish backed by IPFS/Helia).
+ * The method package defines this type; the caller provides the implementation
+ * (e.g., the api layer's CasApi.publish backed by any CAS executor).
+ *
+ * Invoked before the beacon signal transaction is broadcast, so a thrown error
+ * aborts the operation while the beacon UTXO is still unspent.
  *
  * @param announcement The CAS Announcement object (DID to update hash mapping).
  */

--- a/packages/method/src/core/beacon/singleton-beacon.ts
+++ b/packages/method/src/core/beacon/singleton-beacon.ts
@@ -4,7 +4,7 @@ import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from './interfaces.js';
 
@@ -70,7 +70,7 @@ export class SingletonBeacon extends SinglePartyBeacon {
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
    * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
    * @param {BroadcastOptions} [options] Optional broadcast configuration (e.g. fee estimator).
-   * @returns {Promise<SignedBTCR2Update>} The signed update that was broadcast.
+   * @returns {Promise<BroadcastResult>} The signed update and the signal txid.
    * @throws {BeaconError} if the bitcoin address is invalid, unfunded, or UTXO cannot cover the fee.
    */
   async broadcastSignal(
@@ -78,9 +78,9 @@ export class SingletonBeacon extends SinglePartyBeacon {
     signer: Signer,
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
-  ): Promise<SignedBTCR2Update> {
+  ): Promise<BroadcastResult> {
     const signalBytes = hash(canonicalize(signedUpdate));
-    await this.buildSignAndBroadcast(signalBytes, signer, bitcoin, options);
-    return signedUpdate;
+    const txid = await this.buildSignAndBroadcast(signalBytes, signer, bitcoin, options);
+    return { signedUpdate, txid };
   }
 }

--- a/packages/method/src/core/beacon/smt-beacon.ts
+++ b/packages/method/src/core/beacon/smt-beacon.ts
@@ -6,7 +6,7 @@ import { base64UrlToHash, blockHash, BTCR2MerkleTree, didToIndex, hashToHex, ver
 import { randomBytes } from '@noble/hashes/utils';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import { SMTBeaconError } from './error.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from './interfaces.js';
@@ -133,7 +133,9 @@ export class SMTBeacon extends SinglePartyBeacon {
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
    * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
    * @param {BroadcastOptions} [options] Optional broadcast configuration (e.g. fee estimator).
-   * @return {Promise<SignedBTCR2Update>} The signed update that was broadcast.
+   * @return {Promise<BroadcastResult>} The signed update, the signal txid, and the SMT
+   *   inclusion proof (with the leaf nonce embedded). The proof MUST be captured for sidecar
+   *   distribution: the nonce exists only here, so the on-chain signal is unresolvable without it.
    * @throws {BeaconError} if the bitcoin address is invalid, unfunded, or UTXO cannot cover the fee.
    */
   async broadcastSignal(
@@ -141,7 +143,7 @@ export class SMTBeacon extends SinglePartyBeacon {
     signer: Signer,
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
-  ): Promise<SignedBTCR2Update> {
+  ): Promise<BroadcastResult> {
     // Extract the DID from the beacon service id (strip the #fragment)
     const did = this.service.id.split('#')[0];
 
@@ -152,9 +154,14 @@ export class SMTBeacon extends SinglePartyBeacon {
     tree.addEntries([{ did, nonce, signedUpdate: canonicalBytes }]);
     tree.finalize();
 
-    // Root hash is the signal bytes for the OP_RETURN output
-    await this.buildSignAndBroadcast(tree.rootHash, signer, bitcoin, options);
+    // Serialize the inclusion proof (carrying the nonce and updateId) before
+    // broadcasting: it is the only artifact that can link the on-chain root back
+    // to the update, and the nonce it embeds is irrecoverable once dropped.
+    const proof = tree.proof(did);
 
-    return signedUpdate;
+    // Root hash is the signal bytes for the OP_RETURN output
+    const txid = await this.buildSignAndBroadcast(tree.rootHash, signer, bitcoin, options);
+
+    return { signedUpdate, txid, proof };
   }
 }

--- a/packages/method/src/core/updater.ts
+++ b/packages/method/src/core/updater.ts
@@ -5,6 +5,8 @@ import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import type { Signer } from '@did-btcr2/keypair';
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from './btcr2-update.js';
 import { DidDocument, type Btcr2DidDocument, type DidVerificationMethod } from '../utils/did-document.js';
+import type { BroadcastResult } from './beacon/beacon.js';
+import type { CASBroadcastOptions } from './beacon/cas-beacon.js';
 import { BeaconFactory } from './beacon/factory.js';
 import type { BeaconService } from './beacon/interfaces.js';
 
@@ -56,9 +58,14 @@ export interface FundingProof {
  * The updater needs the caller to broadcast the signed update via the beacon.
  *
  * The caller decides how: for single-party beacons, call
- * `Updater.announce(beaconService, signedUpdate, secretKey, bitcoin)` or
+ * `Updater.announce(beaconService, signedUpdate, signer, bitcoin, options?)` or
  * `BeaconFactory.establish(beaconService).broadcastSignal(...)`. For multi-party
  * aggregate beacons, hand off to the aggregation protocol.
+ *
+ * Both single-party paths return a `BroadcastResult`; capture it. Beyond the txid,
+ * it carries the per-beacon-type sidecar artifacts: the CAS Announcement (CAS
+ * beacons) and the SMT inclusion proof (SMT beacons), whose embedded nonce exists
+ * nowhere else, so a discarded proof makes the signal permanently unresolvable.
  *
  * After the broadcast succeeds, the caller calls `updater.provide(need)` (with no
  * data) to transition the updater to Complete.
@@ -137,10 +144,14 @@ export interface UpdaterParams {
  *         // Check UTXOs at need.beaconAddress, fund if needed
  *         updater.provide(need);
  *         break;
- *       case 'NeedBroadcast':
- *         await Updater.announce(need.beaconService, need.signedUpdate, signer, bitcoin);
+ *       case 'NeedBroadcast': {
+ *         // Capture the BroadcastResult: broadcast.txid, plus broadcast.announcement
+ *         // (CAS beacons) and broadcast.proof (SMT beacons; must be retained, the
+ *         // proof's nonce exists nowhere else).
+ *         const broadcast = await Updater.announce(need.beaconService, need.signedUpdate, signer, bitcoin);
  *         updater.provide(need);
  *         break;
+ *       }
  *     }
  *   }
  *   state = updater.advance();
@@ -315,16 +326,21 @@ export class Updater {
    * @param {SignedBTCR2Update} update The signed update to announce.
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
    * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
-   * @returns {Promise<SignedBTCR2Update>} The signed update that was broadcast.
+   * @param {CASBroadcastOptions} [options] Optional broadcast configuration (fee estimator,
+   *   change address, and, for CAS beacons, a `casPublish` callback invoked before the
+   *   transaction broadcast; other beacon types ignore `casPublish`).
+   * @returns {Promise<BroadcastResult>} The broadcast artifacts: the signed update, the signal
+   *   txid, and any per-beacon-type sidecar data (CAS announcement / SMT proof).
    */
   static async announce(
     beaconService: BeaconService,
     update: SignedBTCR2Update,
     signer: Signer,
-    bitcoin: BitcoinConnection
-  ): Promise<SignedBTCR2Update> {
+    bitcoin: BitcoinConnection,
+    options?: CASBroadcastOptions
+  ): Promise<BroadcastResult> {
     const beacon = BeaconFactory.establish(beaconService);
-    return beacon.broadcastSignal(update, signer, bitcoin);
+    return beacon.broadcastSignal(update, signer, bitcoin, options);
   }
 
   // Private instance wrappers

--- a/packages/method/tests/beacon-broadcast.spec.ts
+++ b/packages/method/tests/beacon-broadcast.spec.ts
@@ -1,0 +1,244 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
+import type { AddressUtxo, BitcoinConnection } from '@did-btcr2/bitcoin';
+import { canonicalHash, decode, encode } from '@did-btcr2/common';
+import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { Address, OutScript, p2wpkh, Transaction } from '@scure/btc-signer';
+import { expect } from 'chai';
+import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
+import { opReturnScript } from '../src/core/beacon/beacon.js';
+import { CASBeacon } from '../src/core/beacon/cas-beacon.js';
+import type { BeaconService, BeaconSignal, BlockMetadata } from '../src/core/beacon/interfaces.js';
+import { SingletonBeacon } from '../src/core/beacon/singleton-beacon.js';
+import { SMTBeacon } from '../src/core/beacon/smt-beacon.js';
+import type { SMTProof } from '../src/core/interfaces.js';
+import type { CASAnnouncement, SidecarData } from '../src/core/types.js';
+import { Updater } from '../src/core/updater.js';
+
+const network = getNetwork('regtest');
+const DID = 'did:btcr2:k1q5ptvjpcgt0jfgvddau2fllfcpxwa5qtw2umkafp5xqwqr72a7xanvcjf324y';
+const TXID = 'f'.repeat(64);
+
+/** Helper: empty sidecar data maps for each beacon type. */
+function emptySidecar(): SidecarData {
+  return {
+    updateMap : new Map<string, SignedBTCR2Update>(),
+    casMap    : new Map<string, CASAnnouncement>(),
+    smtMap    : new Map<string, SMTProof>(),
+  };
+}
+
+/** Helper: stock block metadata for test signals. */
+const blockMeta: BlockMetadata = { height: 100, time: 1700000000, confirmations: 6 };
+
+/** Helper: a fake signed update object for tests. */
+function fakeUpdate(marker: string): SignedBTCR2Update {
+  return {
+    '@context'       : ['test'],
+    patch            : [],
+    sourceHash       : `${marker}-source`,
+    targetHash       : `${marker}-target`,
+    targetVersionId  : 2,
+  } as unknown as SignedBTCR2Update;
+}
+
+/** Helper: a fake BeaconSignal with given hex signal bytes. */
+function fakeSignal(signalBytes: string): BeaconSignal {
+  return { tx: {} as unknown as BeaconSignal['tx'], signalBytes, blockMetadata: blockMeta };
+}
+
+/**
+ * Minimal BitcoinConnection that funds `beaconAddress` with a single confirmed
+ * UTXO and records broadcasts. Builds a real prev tx whose output 0 pays the
+ * beacon address so scure's nonWitnessUtxo hash check passes. Each call to
+ * `transaction.send` appends the raw hex to `sent` and the label
+ * `'tx-broadcast'` to `order` (shared with CAS-publish recorders).
+ */
+function mockBitcoin(
+  beaconAddress: string,
+  sent: string[],
+  order: string[],
+): BitcoinConnection {
+  const beaconScript = OutScript.encode(Address(network).decode(beaconAddress));
+  const prevTx = new Transaction({ allowUnknownOutputs: true });
+  prevTx.addOutput({ amount: 100_000n, script: beaconScript });
+  prevTx.addInput({ txid: new Uint8Array(32), index: 0xffffffff, finalScriptSig: new Uint8Array([0x00]) });
+  const prevTxBytes = prevTx.toBytes();
+  const utxo: AddressUtxo = { txid: prevTx.id, vout: 0, value: 100_000, status: { confirmed: true, block_height: 100 } as never };
+  return {
+    data : network,
+    rest : {
+      address     : { getUtxos: async () => [utxo] },
+      transaction : {
+        getHex : async () => bytesToHex(prevTxBytes),
+        send   : async (hex: string) => { sent.push(hex); order.push('tx-broadcast'); return TXID; },
+      },
+    },
+  } as unknown as BitcoinConnection;
+}
+
+/** Helper: the OP_RETURN script (hex) of the last output of a sent raw tx. */
+function lastOutputScriptHex(rawHex: string): string {
+  const tx = Transaction.fromRaw(hexToBytes(rawHex), { allowUnknownOutputs: true, allowUnknownInputs: true });
+  return bytesToHex(tx.getOutput(tx.outputsLength - 1).script!);
+}
+
+/** Fresh signer + the P2WPKH beacon service it can spend, per beacon type. */
+function testBeaconSetup(type: 'SingletonBeacon' | 'CASBeacon' | 'SMTBeacon'): {
+  signer: LocalSigner;
+  service: BeaconService;
+} {
+  const signer = new LocalSigner(SchnorrKeyPair.generate().secretKey.bytes);
+  const address = p2wpkh(signer.publicKey, network).address!;
+  return {
+    signer,
+    service : { id: `${DID}#beacon-0`, type, serviceEndpoint: `bitcoin:${address}` },
+  };
+}
+
+describe('SinglePartyBeacon.broadcastSignal result shape', () => {
+
+  describe('SingletonBeacon', () => {
+    it('returns the signed update and the broadcast txid, with the update hash in OP_RETURN', async () => {
+      const { signer, service } = testBeaconSetup('SingletonBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+      const update = fakeUpdate('singleton-result');
+
+      const result = await new SingletonBeacon(service).broadcastSignal(update, signer, bitcoin);
+
+      expect(result.signedUpdate).to.equal(update);
+      expect(result.txid).to.equal(TXID);
+      expect(result.announcement).to.equal(undefined);
+      expect(result.proof).to.equal(undefined);
+      expect(sent).to.have.length(1);
+      const expectedSignal = decode(canonicalHash(update), 'base64urlnopad');
+      expect(lastOutputScriptHex(sent[0]!)).to.equal(bytesToHex(opReturnScript(expectedSignal)));
+    });
+  });
+
+  describe('CASBeacon', () => {
+    it('returns the announcement mapping the DID to the update hash, plus the txid', async () => {
+      const { signer, service } = testBeaconSetup('CASBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+      const update = fakeUpdate('cas-result');
+
+      const result = await new CASBeacon(service).broadcastSignal(update, signer, bitcoin);
+
+      expect(result.signedUpdate).to.equal(update);
+      expect(result.txid).to.equal(TXID);
+      expect(result.announcement).to.deep.equal({ [DID]: canonicalHash(update) });
+      // OP_RETURN carries the canonical hash of the announcement, not the update.
+      const expectedSignal = decode(canonicalHash(result.announcement!), 'base64urlnopad');
+      expect(lastOutputScriptHex(sent[0]!)).to.equal(bytesToHex(opReturnScript(expectedSignal)));
+    });
+
+    it('invokes casPublish before the transaction broadcast', async () => {
+      const { signer, service } = testBeaconSetup('CASBeacon');
+      const order: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), [], order);
+      let published: CASAnnouncement | undefined;
+
+      await new CASBeacon(service).broadcastSignal(fakeUpdate('cas-order'), signer, bitcoin, {
+        casPublish : async (announcement) => { order.push('cas-publish'); published = announcement; },
+      });
+
+      expect(order).to.deep.equal(['cas-publish', 'tx-broadcast']);
+      expect(published).to.deep.equal({ [DID]: canonicalHash(fakeUpdate('cas-order')) });
+    });
+
+    it('aborts pre-spend when casPublish fails: no transaction is broadcast', async () => {
+      const { signer, service } = testBeaconSetup('CASBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+
+      let threw = false;
+      try {
+        await new CASBeacon(service).broadcastSignal(fakeUpdate('cas-fail'), signer, bitcoin, {
+          casPublish : async () => { throw new Error('cas unavailable'); },
+        });
+      } catch(err) {
+        threw = true;
+        expect((err as Error).message).to.equal('cas unavailable');
+      }
+      expect(threw, 'expected the casPublish failure to propagate').to.equal(true);
+      expect(sent, 'the beacon UTXO must not be spent after a publish failure').to.have.length(0);
+    });
+
+    it('round-trips: broadcast artifacts fed back as sidecar resolve the update with no needs', async () => {
+      const { signer, service } = testBeaconSetup('CASBeacon');
+      const beacon = new CASBeacon(service);
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), [], []);
+      const update = fakeUpdate('cas-roundtrip');
+
+      const result = await beacon.broadcastSignal(update, signer, bitcoin);
+
+      const sidecar = emptySidecar();
+      const announcementHashHex = canonicalHash(result.announcement!, { encoding: 'hex' });
+      sidecar.casMap.set(announcementHashHex, result.announcement!);
+      sidecar.updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
+
+      const { updates, needs } = beacon.processSignals([fakeSignal(announcementHashHex)], sidecar);
+      expect(needs).to.have.length(0);
+      expect(updates).to.have.length(1);
+      expect(updates[0]![0]).to.equal(update);
+    });
+  });
+
+  describe('SMTBeacon', () => {
+    it('returns the inclusion proof (nonce embedded) that the on-chain root verifies against', async () => {
+      const { signer, service } = testBeaconSetup('SMTBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+      const update = fakeUpdate('smt-result');
+
+      const result = await new SMTBeacon(service).broadcastSignal(update, signer, bitcoin);
+
+      expect(result.signedUpdate).to.equal(update);
+      expect(result.txid).to.equal(TXID);
+      expect(result.proof, 'the proof must be returned: its nonce exists nowhere else').to.exist;
+      expect(result.proof!.nonce).to.be.a('string');
+      expect(result.proof!.updateId).to.equal(canonicalHash(update));
+      // OP_RETURN carries the tree root the proof commits to.
+      const rootBytes = decode(result.proof!.id, 'base64urlnopad');
+      expect(lastOutputScriptHex(sent[0]!)).to.equal(bytesToHex(opReturnScript(rootBytes)));
+    });
+
+    it('round-trips: the returned proof makes the on-chain signal resolvable', async () => {
+      const { signer, service } = testBeaconSetup('SMTBeacon');
+      const beacon = new SMTBeacon(service);
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), [], []);
+      const update = fakeUpdate('smt-roundtrip');
+
+      const result = await beacon.broadcastSignal(update, signer, bitcoin);
+
+      const sidecar = emptySidecar();
+      const rootHex = encode(decode(result.proof!.id, 'base64urlnopad'), 'hex');
+      sidecar.smtMap.set(rootHex, result.proof!);
+      sidecar.updateMap.set(canonicalHash(update, { encoding: 'hex' }), update);
+
+      const { updates, needs } = beacon.processSignals([fakeSignal(rootHex)], sidecar);
+      expect(needs).to.have.length(0);
+      expect(updates).to.have.length(1);
+      expect(updates[0]![0]).to.equal(update);
+    });
+  });
+
+  describe('Updater.announce', () => {
+    it('forwards broadcast options to the beacon and returns the BroadcastResult', async () => {
+      const { signer, service } = testBeaconSetup('CASBeacon');
+      const order: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), [], order);
+      const update = fakeUpdate('announce-options');
+
+      const result = await Updater.announce(service, update, signer, bitcoin, {
+        casPublish : async () => { order.push('cas-publish'); },
+      });
+
+      expect(order).to.deep.equal(['cas-publish', 'tx-broadcast']);
+      expect(result.txid).to.equal(TXID);
+      expect(result.announcement).to.deep.equal({ [DID]: canonicalHash(update) });
+    });
+  });
+});


### PR DESCRIPTION
* chore(release): bump method 0.54.0, api 0.15.0, cli 0.13.0
* test(method,api,cli): broadcast shapes, CAS ordering + pre-spend aborts, policy grid, roundtrips
* feat(method): broadcastSignal returns BroadcastResult; casPublish + broadcast; Updater.announce options result
* feat(cli): update/deactivate print enriched broadcast artifacts (breaking output shape)
* feat(api): publishToCas + CasExecutor/CasApi + enriched DidUpdateResult + broadcastOptions passthrough
* docs(adr): add ADR 070 (BroadcastResult + CAS-first ordering) and ADR 071 (api CAS publication policy)