### PR TITLE
make CAS publication opt-in; add cli writable-CAS config

### DIFF
--- a/docs/adr/072-cli-writable-cas-and-publish-flag.md
+++ b/docs/adr/072-cli-writable-cas-and-publish-flag.md
@@ -1,0 +1,46 @@
+---
+title: "ADR 072: CLI Writable-CAS Configuration and an Opt-In --publish-to-cas Flag"
+---
+
+# ADR 072: CLI Writable-CAS Configuration and an Opt-In --publish-to-cas Flag
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-cas-rpc-url`
+
+**References:** [ADR 070](070-broadcast-result-and-cas-first-ordering.md), [ADR 071](071-api-cas-publication-policy.md), [ADR 073](073-cas-publication-is-opt-in.md)
+
+## Context
+
+[ADR 071](071-api-cas-publication-policy.md) wired CAS publication into the api update path behind a `publishToCas: 'auto' | 'always' | 'never'` policy and gave `CasConfig` a writable `rpcUrl` executor. The cli, however, could only configure a read-only CAS: its `--cas-gateway` flag, `BTCR2_CAS_GATEWAY` env var, and `profiles.<n>.cas.gateway` config key all map to a read-only IPFS HTTP gateway, and `resolveConnectionConfig` hard-typed the CAS it built as `{ gateway: string }`. ADR 071 §7 had the cli pass `publishToCas: 'never'` explicitly, with a note that a follow-up would "add writable-CAS configuration and a `--publish-to-cas` flag, at which point the explicit `'never'` is replaced by the exposed knob." This ADR is that follow-up.
+
+[ADR 073](073-cas-publication-is-opt-in.md) lands on this same branch and corrects the api policy so CAS publication is opt-in: the default is `'never'` and `'auto'` is best-effort (never blocks an update). This cli work assumes that corrected policy.
+
+A separate config-surface gap: `btcr2 config set profiles.x.cas.rpcUrl <url>` already wrote the key to disk (the `config set` command is a generic dotted-path writer), but `profileToOverrides` never read it back, so the value was silently dropped.
+
+The governing principle, from the method's design and the did:btcr2 spec, is that **CAS publication is optional and never required**. Every beacon update, including a CAS beacon's, can be completed and distributed entirely via sidecar. Publishing update artifacts to a content-addressed store is a convenience that makes OP_RETURN update hashes fetchable at resolution time without sidecar data; it is something a user opts into, not a precondition for updating.
+
+## Decision
+
+1. **A writable CAS is configurable through the same three-layer override chain as every other endpoint.** New `--cas-rpc-url <url>` global flag, `BTCR2_CAS_RPC_URL` environment variable, and `profiles.<n>.cas.rpcUrl` config key, merged in the standard precedence (CLI flag > env var > config file). `resolveConnectionConfig` now returns `cas?: CasConfig` (widened from `{ gateway: string }`) and passes both `gateway` and `rpcUrl` through when set; the api's `CasConfig` priority (`rpcUrl > gateway`) selects the writable RPC executor when both are present. `profileToOverrides` now reads `cas.rpcUrl`, closing the silently-dropped-key gap.
+
+2. **`update` and `deactivate` gain `--publish-to-cas <auto|always|never>`, defaulting to `'never'`.** The value is validated at parse time (an invalid value errors before any signing or spending) and forwarded verbatim to the api's `publishToCas`. This replaces the hardcoded `'never'` from ADR 071 §7.
+
+3. **The cli default is `'never'`, matching the corrected api default (ADR 073).** CAS publication stays strictly opt-in. A user who wants it passes `--publish-to-cas auto` (or `'always'`) and configures a writable CAS via `--cas-rpc-url`. With the default, `update`/`deactivate` complete sidecar-only and print every artifact a resolver needs (signed update, txid, announcement for CAS beacons, SMT proof for SMT beacons) for the user to distribute.
+
+## Consequences
+
+- The cli's default behavior is unchanged from the ADR 071 release: no `--publish-to-cas` flag means `publishToCas: 'never'`, exactly the value ADR 071 §7 hardcoded. This is purely additive; existing scripts are unaffected.
+- Configuring `--cas-rpc-url` alone does nothing until the user also opts in with `--publish-to-cas auto`/`always`. Requiring both is the cost of keeping publication opt-in: a configured writable endpoint is a capability, not a directive to use it.
+- Once a user opts in, the api's corrected policy (ADR 073) applies: `'auto'` publishes to a writable CAS and otherwise completes the update sidecar-only for every beacon type (it never blocks), while `'always'` requires a writable CAS and errors up-front (naming `cas.rpcUrl`) when none is configured.
+- **Privacy:** opting into `auto`/`always` publishes canonical signed updates (and announcements) to the configured, possibly public, CAS before the on-chain anchor. The `'never'` default keeps update data off public stores, matching the spec's guidance for privacy-conscious controllers. This is documented on the flag and in the cli README.
+- The change is a cli-only minor bump for the flag/config surface; the paired api correction (ADR 073) is a separate minor bump on `@did-btcr2/api`. The method package is untouched.
+
+## Rejected alternatives
+
+- **Default the cli to `'auto'`.** Even with the corrected api `'auto'` (which no longer blocks), defaulting the cli to `'auto'` would publish canonical signed updates to a configured CAS as a side effect of the user having configured `--cas-rpc-url` (perhaps only for reads), which is opt-out. Keeping the default `'never'` means publication happens only when the user explicitly asks, honoring "CAS publication is opt-in, never required." A writable endpoint is a capability, not a directive.
+- **A "smart" default that publishes when a writable CAS is configured and stays silent otherwise.** Convenient, but it couples two independent user intents (configure an endpoint vs. publish to it) and makes the publish decision implicit and config-dependent. An explicit flag is predictable and auditable; a user reading a command line sees exactly whether publication happens.
+- **Map `--cas-gateway` to a writable executor.** An IPFS HTTP gateway is read-only by protocol (trustless-gateway serves blocks, it does not accept `block/put`). Writes require the RPC API, which is a distinct endpoint; conflating them would misrepresent the gateway's capability and surface as a mid-operation failure.
+- **A single `--cas-url` flag inferring read-vs-write from the endpoint.** Gateway and RPC endpoints are not reliably distinguishable by URL, and the read/write distinction is exactly what the writable-capability detection in ADR 071 exists to make explicit. Two named flags keep the capability legible.

--- a/docs/adr/073-cas-publication-is-opt-in.md
+++ b/docs/adr/073-cas-publication-is-opt-in.md
@@ -1,0 +1,58 @@
+---
+title: "ADR 073: CAS Publication Is Opt-In - Default publishToCas to 'never' and Make 'auto' Non-Blocking"
+---
+
+# ADR 073: CAS Publication Is Opt-In - Default publishToCas to 'never' and Make 'auto' Non-Blocking
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-cas-rpc-url`
+
+**References:** [ADR 070](070-broadcast-result-and-cas-first-ordering.md), [ADR 071](071-api-cas-publication-policy.md)
+
+## Context
+
+[ADR 071](071-api-cas-publication-policy.md) introduced the api's `publishToCas` policy with a default of `'auto'`, where `'auto'` publishes when a writable CAS is configured and, for **CAS beacons only**, throws up-front when no writable CAS is available. The stated reasoning was that a CAS beacon signal points at an announcement that "must be retrievable somewhere," so refusing to broadcast prevents a resolution failure.
+
+That reasoning was wrong on the method's own principle: **CAS publication is optional and never required.** Every update, for every beacon type including a CAS beacon, can be completed and distributed entirely via sidecar. A CAS beacon's announcement is returned in `DidUpdateResult.announcement` precisely so the caller can distribute it out-of-band; sidecar-only distribution is a first-class, always-available path, not a footgun to be guarded against.
+
+Under ADR 071's default, two behaviors violated that principle:
+
+1. **Publishing happened without being asked.** With the default `'auto'` and any writable CAS configured (including one set up only for reads), every canonical signed update was published to a possibly-public store as a side effect of configuration. That is opt-out.
+2. **Sidecar-only was blocked for CAS beacons.** With the default `'auto'`, a CAS beacon update with no writable CAS threw up-front. Completing it sidecar-only required explicitly passing `'never'`. That makes CAS publication effectively required for CAS beacons, contradicting "never required."
+
+In short, ADR 071 made CAS publication opt-out (and mandatory for one beacon type), when it must be opt-in.
+
+## Decision
+
+1. **The default is `'never'`.** Out of the box, `DidMethodApi.update`, `DidBtcr2Api.updateDid`, and `UpdateBuilder` publish nothing. A configured CAS never causes publication on its own; the caller opts in explicitly.
+
+2. **`'auto'` is best-effort and never blocks.** It publishes the signed update (all beacon types) and the CAS Announcement (CAS beacons) when a writable CAS is configured; otherwise it skips publication silently for **every** beacon type (CAS beacons included) and returns the artifacts for sidecar distribution. The CAS-beacon up-front throw from ADR 071 is removed.
+
+3. **`'always'` is unchanged.** It requires a writable CAS and throws up-front for every beacon type when none is available. This is the explicit opt-in for a hard guarantee that the artifacts reached the CAS; the caller asked for a promise that cannot be met, so failing is correct.
+
+Resulting policy:
+
+| Policy | Writable CAS | Read-only / no CAS |
+|---|---|---|
+| `'never'` (default) | publish nothing | publish nothing |
+| `'auto'` | publish update (+ announcement for CAS) | skip silently, all beacon types |
+| `'always'` | publish update (+ announcement for CAS) | throw up-front, all beacon types |
+
+This supersedes ADR 071's decision 2 (the `'auto'` default and its CAS-beacon asymmetry). ADR 071's other decisions (the `canPublish`/`writable` capability detection, the update-then-announcement-then-broadcast ordering, the enriched `DidUpdateResult`, `broadcastOptions` passthrough, and the `resolve()` `NeedSMTProof` fail-fast) stand unchanged.
+
+## Consequences
+
+- CAS publication is now genuinely opt-in and never required. No update, for any beacon type, is ever blocked for lack of a writable CAS. Sidecar-only is the default distribution path.
+- **Behavior change for library callers relying on the ADR 071 default:** a caller who previously depended on the implicit `'auto'` now publishes nothing unless it passes `'auto'` or `'always'`. This is a deliberate correction; it ships as a minor bump at 0.x. Callers that want the old auto-publish behavior pass `publishToCas: 'auto'` explicitly.
+- A read-only or absent CAS under `'auto'` no longer errors; a CAS beacon update simply completes sidecar-only and returns its announcement. `'always'` remains the way to demand a writable CAS.
+- **Privacy improves by default:** canonical signed updates are no longer published to a possibly-public CAS as a side effect of the default. Publication to a public store now requires an explicit `'auto'`/`'always'`.
+- The cli, which already defaults its `--publish-to-cas` flag to `'never'`, is now simply consistent with the api default rather than diverging from it (see [ADR 072](072-cli-writable-cas-and-publish-flag.md)).
+
+## Rejected alternatives
+
+- **Keep the CAS-beacon up-front throw under `'auto'`, only change the default.** Fixes the opt-out default but leaves CAS publication mandatory-under-`'auto'` for CAS beacons, so an explicit `'auto'` on a CAS beacon with no writable CAS would still block a valid sidecar-only update. Half a fix.
+- **Drop `'auto'` entirely; support only `'never'` and `'always'`.** Maximally explicit, but it removes the useful "publish if I can, otherwise proceed" mode and is a larger breaking change to the enum for no principled gain: an explicitly-chosen `'auto'` is already a clear opt-in.
+- **Warn (log) when `'auto'` skips a CAS beacon publish.** A skipped publish under `'auto'` is the requested best-effort behavior, not an anomaly; the artifacts are returned for sidecar use. A warning would train callers to ignore logs. Callers who require publication use `'always'`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -148,3 +148,5 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 069 | 2026-07-06 | [Fetch-Based CAS Executors Replace the In-Process IPFS Dependency](069-fetch-based-cas-executors-drop-helia.md) |
 | 070 | 2026-07-07 | [Beacon Broadcasts Return Structured Artifacts and CAS Publication Precedes the On-Chain Spend](070-broadcast-result-and-cas-first-ordering.md) |
 | 071 | 2026-07-07 | [A CAS Publication Policy for the API Update Path (publishToCas), Writable-CAS Capability Detection, and Enriched Update Results](071-api-cas-publication-policy.md) |
+| 072 | 2026-07-07 | [CLI Writable-CAS Configuration and an Opt-In --publish-to-cas Flag](072-cli-writable-cas-and-publish-flag.md) |
+| 073 | 2026-07-07 | [CAS Publication Is Opt-In - Default publishToCas to 'never' and Make 'auto' Non-Blocking](073-cas-publication-is-opt-in.md) |

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @did-btcr2/api
 
+## 0.16.0
+
+### Minor Changes
+
+- Make CAS publication opt-in: `publishToCas` now defaults to `'never'`, and `'auto'` no longer blocks an update.
+
+  CAS publication is optional and never required: every update, for every beacon type, completes and is distributable via sidecar. The previous default of `'auto'` (from the prior release) was opt-out - it auto-published to any configured CAS and, for CAS beacons with no writable CAS, threw up-front - which effectively required CAS publication for that beacon type. This corrects that:
+
+  - **Default is now `'never'`** on `DidMethodApi.update`, `DidBtcr2Api.updateDid`, and `UpdateBuilder`. Out of the box, nothing is published; a configured CAS never triggers publication on its own.
+  - **`'auto'` is best-effort and never blocks:** it publishes when a writable CAS is configured, otherwise skips silently for every beacon type (CAS beacons included) and returns the artifacts for sidecar distribution. The CAS-beacon up-front throw is removed.
+  - **`'always'` is unchanged:** it requires a writable CAS and throws up-front for every beacon type when none is available.
+
+  Breaking for callers that relied on the implicit `'auto'` default: pass `publishToCas: 'auto'` explicitly to keep auto-publishing. See ADR 073 (supersedes ADR 071 §2).
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -17,7 +17,7 @@ If you're integrating did:btcr2 into an app, start here. If you're customizing t
 
 The api wires the configured `BitcoinApi` into the sans-I/O Resolver and Updater state machines, fulfilling `NeedBeaconSignals`, `NeedFunding`, `NeedBroadcast`, and CAS-related needs (`NeedGenesisDocument`, `NeedCASAnnouncement`, `NeedSignedUpdate`) automatically. `NeedSMTProof` is not auto-fulfilled by the facade: SMT proofs are nonce-blinded (there is no content address to fetch them by), so they must be provided upfront via `options.sidecar.smtProofs`; resolution fails fast with that pointer otherwise. Multi-party aggregation is out of scope here; drive the Updater directly and hand `NeedBroadcast` to the aggregation runner from `@did-btcr2/aggregation`.
 
-On the write path, `publishToCas` (`'auto'` | `'always'` | `'never'`, default `'auto'`) controls whether update artifacts are published to the configured CAS **before** the on-chain broadcast. With a writable CAS, `'auto'` publishes the canonical signed update (all beacon types) plus the CAS Announcement (CAS beacons), so resolvers can fetch every OP_RETURN update hash from the CAS with no sidecar. Update calls return a `DidUpdateResult` carrying the signal `txid` and the per-beacon-type sidecar artifacts (announcement, SMT proof) for callers that distribute them out-of-band instead.
+On the write path, `publishToCas` (`'never'` | `'auto'` | `'always'`, default `'never'`) controls whether update artifacts are published to the configured CAS **before** the on-chain broadcast. CAS publication is optional and never required: every update, for every beacon type, completes and is distributable via sidecar regardless. Publishing is opt-in: pass `'auto'` (best-effort - publishes when a writable CAS is configured, otherwise skips silently and never blocks the update) or `'always'` (requires a writable CAS and throws up-front when none is available). When publication happens, the canonical signed update (all beacon types) plus the CAS Announcement (CAS beacons) reach the CAS, so resolvers can fetch every OP_RETURN update hash from the CAS with no sidecar. Update calls return a `DidUpdateResult` carrying the signal `txid` and the per-beacon-type sidecar artifacts (announcement, SMT proof).
 
 ## Install
 
@@ -95,9 +95,12 @@ const result = await api.updateDid({
   verificationMethodId : `${did}#initialKey`,
   beaconId             : `${did}#initialP2WPKH`,
   signer,
-  // publishToCas defaults to 'auto'. Use 'never' for sidecar-only privacy:
-  // 'auto'/'always' publish canonical signed updates to the configured
-  // (possibly public) CAS before the on-chain anchor.
+  // publishToCas defaults to 'never' (opt-in): update artifacts are returned
+  // for sidecar distribution and nothing is published. Opt in with 'auto' to
+  // publish to the writable CAS configured above. Note 'auto'/'always' publish
+  // canonical signed updates to the configured (possibly public) CAS before the
+  // on-chain anchor, so keep the 'never' default for sidecar-only privacy.
+  publishToCas         : 'auto',
 });
 console.log(result.txid, result.publishedToCas); // e.g. { update: true, announcement: false }
 ```
@@ -154,7 +157,8 @@ The `lib/` directory contains end-to-end scripts that exercise the full update p
 - **[ADR-006](../../docs/adr/006-api-package-boundary.md)** API package boundary
 - **[ADR-024](../../docs/adr/024-api-facade-lazy-and-layered-config.md)** API facade lazy initialization + layered config
 - **[ADR-069](../../docs/adr/069-fetch-based-cas-executors-drop-helia.md)** Fetch-based CAS executors
-- **[ADR-071](../../docs/adr/071-api-cas-publication-policy.md)** CAS publication policy on the update path
+- **[ADR-071](../../docs/adr/071-api-cas-publication-policy.md)** CAS publication policy on the update path (default corrected by ADR-073)
+- **[ADR-073](../../docs/adr/073-cas-publication-is-opt-in.md)** CAS publication is opt-in: `publishToCas` defaults to `'never'` and `'auto'` never blocks
 - **Source reference** See JSDoc on `DidBtcr2Api`, `DidMethodApi`, and the sub-facade classes.
 
 ## License

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -196,10 +196,11 @@ export class DidBtcr2Api {
    *
    * If `sourceDocument` and `sourceVersionId` are both provided, resolution
    * is skipped. Otherwise the DID is resolved first to obtain them.
-   * @param params The update parameters. `publishToCas` (default `'auto'`)
+   * @param params The update parameters. `publishToCas` (default `'never'`)
    *   controls whether update artifacts are published to the configured CAS
-   *   before the on-chain broadcast; `broadcastOptions` passes fee estimator /
-   *   change address through to the beacon transaction.
+   *   before the on-chain broadcast; publication is opt-in and never required.
+   *   `broadcastOptions` passes fee estimator / change address through to the
+   *   beacon transaction.
    * @returns The broadcast artifacts: signed update, signal txid, per-beacon-type
    *   sidecar data, and which artifacts were published to CAS.
    */

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -12,18 +12,19 @@ import type { Logger } from './types.js';
 
 /**
  * Policy for publishing update artifacts to the configured CAS during
- * {@link DidMethodApi.update}:
+ * {@link DidMethodApi.update}. CAS publication is optional and never required:
+ * every update, for every beacon type, can be completed and distributed via
+ * sidecar alone. Publishing is opt-in, so the default is `'never'`.
  *
- * - `'auto'` (default): publish the signed update (all beacon types) and the CAS
- *   Announcement (CAS beacons) when a writable CAS is configured. Singleton and
- *   SMT beacon updates skip publication silently when the CAS is read-only or
- *   absent; CAS beacon updates **throw up-front** instead, because a CAS beacon
- *   signal whose announcement lands nowhere is unresolvable unless the caller
- *   distributes it out-of-band (opt into that explicitly with `'never'`).
- * - `'always'`: like `'auto'`, but a read-only or absent CAS throws up-front for
- *   every beacon type.
- * - `'never'`: publish nothing; the caller distributes the returned artifacts
- *   (signed update, announcement, proof) via sidecar themselves.
+ * - `'never'` (default): publish nothing. The caller distributes the returned
+ *   artifacts (signed update, announcement, proof) via sidecar themselves.
+ * - `'auto'`: best-effort. Publish the signed update (all beacon types) and the
+ *   CAS Announcement (CAS beacons) when a writable CAS is configured; otherwise
+ *   skip publication silently for every beacon type and return the artifacts for
+ *   sidecar distribution. Never blocks an update for lack of a writable CAS.
+ * - `'always'`: require a writable CAS. A read-only or absent CAS throws
+ *   up-front for every beacon type. Use this to opt into a hard guarantee that
+ *   the artifacts reached the CAS.
  * @public
  */
 export type PublishToCasMode = 'auto' | 'always' | 'never';
@@ -254,7 +255,7 @@ export class DidMethodApi {
     beaconId,
     signer,
     bitcoin,
-    publishToCas = 'auto',
+    publishToCas = 'never',
     broadcastOptions,
   }: {
     sourceDocument: Btcr2DidDocument;
@@ -291,12 +292,10 @@ export class DidMethodApi {
     });
 
     // Decide the CAS publication plan before any signing or spending happens, so
-    // a policy violation (e.g. a CAS beacon with a read-only CAS under 'auto')
-    // fails fast instead of after the update is signed. Runs after the factory so
-    // an invalid beaconId still throws the canonical error; the service lookup
-    // uses the factory's exact-id match.
-    const beaconType = sourceDocument.service?.find(s => s.id === beaconId)?.type;
-    const publishCas = this.#planCasPublication(publishToCas, beaconType, beaconId);
+    // a policy violation ('always' with no writable CAS) fails fast instead of
+    // after the update is signed. Runs after the factory so an invalid beaconId
+    // still throws the canonical error.
+    const publishCas = this.#planCasPublication(publishToCas, beaconId);
 
     // Drive the state machine. All I/O (signing delegation, CAS publication,
     // Bitcoin broadcast) happens inside the need-handlers below - the Updater
@@ -390,42 +389,32 @@ export class DidMethodApi {
   }
 
   /**
-   * Resolve the `publishToCas` policy against the configured CAS and the beacon
-   * type. Returns the {@link CasApi} to publish with, or `null` when publication
-   * is skipped; throws when the policy demands a writable CAS that is not available.
+   * Resolve the `publishToCas` policy against the configured CAS. Returns the
+   * {@link CasApi} to publish with, or `null` when publication is skipped
+   * (`'never'`, or `'auto'` with no writable CAS). Throws only under `'always'`
+   * when no writable CAS is available; `'auto'` never blocks an update, because
+   * CAS publication is optional and the artifacts are always distributable via
+   * sidecar.
    */
   #planCasPublication(
     mode: PublishToCasMode,
-    beaconType: string | undefined,
     beaconId: string,
   ): CasApi | null {
     if(mode === 'never') return null;
 
     if(this.#cas && this.#cas.writable) return this.#cas;
 
-    const casState = this.#cas
-      ? 'the configured CAS is read-only (e.g. an HTTP gateway)'
-      : 'no CAS is configured';
-
+    // No writable CAS. 'auto' is best-effort: skip publication and let the
+    // caller distribute the returned artifacts via sidecar. 'always' opted into
+    // a hard guarantee that cannot be met, so it fails up-front.
     if(mode === 'always') {
+      const casState = this.#cas
+        ? 'the configured CAS is read-only (e.g. an HTTP gateway)'
+        : 'no CAS is configured';
       throw new UpdateError(
         `publishToCas is 'always' but ${casState}. Configure a writable CAS `
         + '(cas.rpcUrl, cas.blockstore, or a custom cas.executor with publish support), '
         + 'or use publishToCas \'auto\'/\'never\'.',
-        INVALID_DID_UPDATE, { beaconId, publishToCas: mode }
-      );
-    }
-
-    // 'auto': a CAS beacon signal points at an announcement that must be
-    // retrievable somewhere; silently publishing nowhere would produce an
-    // unresolvable signal unless the caller distributes sidecar data, which
-    // they must opt into explicitly.
-    if(beaconType === 'CASBeacon') {
-      throw new UpdateError(
-        `CAS beacon updates publish the announcement to a content-addressed store, but ${casState}. `
-        + 'Configure a writable CAS (cas.rpcUrl, cas.blockstore, or a custom cas.executor with '
-        + 'publish support), or set publishToCas \'never\' to distribute the returned announcement '
-        + 'via sidecar yourself.',
         INVALID_DID_UPDATE, { beaconId, publishToCas: mode }
       );
     }
@@ -549,7 +538,7 @@ export class UpdateBuilder {
     return this;
   }
 
-  /** Set the CAS publication policy for this update (default `'auto'`). */
+  /** Set the CAS publication policy for this update (default `'never'`; opt-in). */
   publishToCas(mode: PublishToCasMode): this {
     this.#publishToCas = mode;
     return this;

--- a/packages/api/tests/did-method-api-cas-policy.spec.ts
+++ b/packages/api/tests/did-method-api-cas-policy.spec.ts
@@ -157,7 +157,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
       const executor = new MemCasExecutor(order);
       const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
 
-      const result = await methodApi.update(updateArgs(fixture, order, counters));
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
 
       expect(order).to.deep.equal(['cas:update', 'cas:announcement', 'tx-broadcast']);
       expect(result.txid).to.equal(TXID);
@@ -168,27 +171,73 @@ describe('DidMethodApi update() CAS publication policy', () => {
       expect(executor.store.has(canonicalHash(result.announcement!))).to.equal(true);
     });
 
-    it('auto + read-only CAS: throws up-front, before any signing or UTXO lookup', async () => {
+    it('default (omitted) + writable CAS: publishes nothing (publication is opt-in)', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const executor = new MemCasExecutor(order);
+      const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
+
+      // No publishToCas passed -> the default 'never'. Even a CAS beacon with a
+      // writable CAS configured must publish nothing: CAS publication is opt-in
+      // and never required, and the update completes sidecar-only.
+      const result = await methodApi.update(updateArgs(fixture, order, counters));
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(executor.store.size, 'nothing may reach the CAS by default').to.equal(0);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.announcement).to.deep.equal({ [fixture.did]: canonicalHash(result.signedUpdate) });
+    });
+
+    it('auto + read-only CAS: skips publication silently and returns the announcement', async () => {
       const fixture = updateFixture('CASBeacon');
       const { order, counters } = recorders();
       const methodApi = new DidMethodApi(
         undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
       );
 
-      await expect(methodApi.update(updateArgs(fixture, order, counters)))
-        .to.be.rejectedWith(/read-only.*publishToCas 'never'/s);
-      expect(counters.utxoCalls, 'must fail before the funding phase').to.equal(0);
-      expect(order).to.deep.equal([]);
+      // 'auto' is best-effort and never blocks: with no writable CAS it skips
+      // publication for CAS beacons too, and hands back the announcement.
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(counters.utxoCalls, 'the update proceeds to funding/broadcast rather than aborting up-front').to.be.greaterThan(0);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.announcement).to.deep.equal({ [fixture.did]: canonicalHash(result.signedUpdate) });
     });
 
-    it('auto + no CAS configured: throws up-front', async () => {
+    it('auto + no CAS configured: skips publication silently and returns the announcement', async () => {
       const fixture = updateFixture('CASBeacon');
       const { order, counters } = recorders();
       const methodApi = new DidMethodApi();
 
-      await expect(methodApi.update(updateArgs(fixture, order, counters)))
-        .to.be.rejectedWith(/no CAS is configured/);
-      expect(counters.utxoCalls).to.equal(0);
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
+
+      expect(order).to.deep.equal(['tx-broadcast']);
+      expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
+      expect(result.announcement).to.deep.equal({ [fixture.did]: canonicalHash(result.signedUpdate) });
+    });
+
+    it('always + read-only CAS: throws up-front for a CAS beacon too', async () => {
+      const fixture = updateFixture('CASBeacon');
+      const { order, counters } = recorders();
+      const methodApi = new DidMethodApi(
+        undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
+      );
+
+      // 'always' is the opt-in hard-guarantee mode: it fails up-front for every
+      // beacon type (including CAS) when no writable CAS is available.
+      await expect(methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'always',
+      })).to.be.rejectedWith(/'always'.*read-only/s);
+      expect(counters.utxoCalls, 'must fail before the funding phase').to.equal(0);
+      expect(order).to.deep.equal([]);
     });
 
     it('never + read-only CAS: succeeds and returns the announcement for sidecar distribution', async () => {
@@ -232,8 +281,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
         undefined, new CasApi({ executor: new FlakyCasExecutor(order, 1) })
       );
 
-      await expect(methodApi.update(updateArgs(fixture, order, counters)))
-        .to.be.rejectedWith(/cas publish unavailable/);
+      await expect(methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      })).to.be.rejectedWith(/cas publish unavailable/);
       expect(order, 'no publish label, no tx broadcast').to.deep.equal([]);
       expect(counters.sent, 'the beacon UTXO must not be spent').to.have.length(0);
     });
@@ -245,8 +296,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
         undefined, new CasApi({ executor: new FlakyCasExecutor(order, 2) })
       );
 
-      await expect(methodApi.update(updateArgs(fixture, order, counters)))
-        .to.be.rejectedWith(/cas publish unavailable/);
+      await expect(methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      })).to.be.rejectedWith(/cas publish unavailable/);
       // Partial-publish state: the update reached the CAS (harmless, content-
       // addressed), the announcement did not, and no transaction was broadcast.
       expect(order).to.deep.equal(['cas:update']);
@@ -262,7 +315,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
         undefined, new CasApi({ executor: new MemCasExecutor(order, false) })
       );
 
-      const result = await methodApi.update(updateArgs(fixture, order, counters));
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
 
       expect(order).to.deep.equal(['tx-broadcast']);
       expect(result.publishedToCas).to.deep.equal({ update: false, announcement: false });
@@ -277,7 +333,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
       const executor = new MemCasExecutor(order);
       const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
 
-      const result = await methodApi.update(updateArgs(fixture, order, counters));
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
 
       expect(order).to.deep.equal(['cas:update', 'tx-broadcast']);
       expect(result.publishedToCas).to.deep.equal({ update: true, announcement: false });
@@ -314,11 +373,13 @@ describe('DidMethodApi update() CAS publication policy', () => {
       expect(executor.store.has(canonicalHash(result.signedUpdate))).to.equal(true);
     });
 
-    it('auto + NO CAS configured: the default out-of-box path skips publication silently', async () => {
+    it('default (omitted) + NO CAS configured: the out-of-box path publishes nothing', async () => {
       const fixture = updateFixture('SingletonBeacon');
       const { order, counters } = recorders();
       const methodApi = new DidMethodApi();
 
+      // No publishToCas and no CAS: the out-of-box default 'never' completes the
+      // update sidecar-only, publishing nothing.
       const result = await methodApi.update(updateArgs(fixture, order, counters));
 
       expect(order).to.deep.equal(['tx-broadcast']);
@@ -334,7 +395,10 @@ describe('DidMethodApi update() CAS publication policy', () => {
       const executor = new MemCasExecutor(order);
       const methodApi = new DidMethodApi(undefined, new CasApi({ executor }));
 
-      const result = await methodApi.update(updateArgs(fixture, order, counters));
+      const result = await methodApi.update({
+        ...updateArgs(fixture, order, counters),
+        publishToCas : 'auto',
+      });
 
       expect(order).to.deep.equal(['cas:update', 'tx-broadcast']);
       expect(result.publishedToCas).to.deep.equal({ update: true, announcement: false });

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @did-btcr2/cli
 
+## 0.14.0
+
+### Minor Changes
+
+- Add writable-CAS configuration and an opt-in `--publish-to-cas` flag to `update`/`deactivate`.
+
+  - New global `--cas-rpc-url <url>` flag, `BTCR2_CAS_RPC_URL` environment variable, and `profiles.<n>.cas.rpcUrl` config key configure a writable IPFS HTTP RPC endpoint (reads + writes). `resolveConnectionConfig` now carries `cas.rpcUrl` through the flag/env/config precedence chain; a previously silently-dropped `config set profiles.x.cas.rpcUrl` is now honored. When both a gateway and an RPC URL are set, the writable RPC endpoint takes precedence.
+  - `update` and `deactivate` gain `--publish-to-cas <auto|always|never>`, validated at parse time and forwarded to the api's `publishToCas`. It **defaults to `never`**: CAS publication is optional and never required, so updates complete sidecar-only unless the user opts in. This replaces the hardcoded `'never'` from the previous release with no change to default behavior.
+
+  See ADR 072.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.16.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,12 +86,13 @@ Required flags: `-s/--source-document`, `--source-version-id`, `-p/--patches`, `
 | `-p, --patches <json>` | JSON Patch operations as a JSON array string |
 | `-m, --verification-method-id <id>` | DID document verification method ID |
 | `-b, --beacon-id <json>` | Beacon ID as a JSON string |
+| `--publish-to-cas <mode>` | Publish update artifacts to a writable CAS before broadcast: `auto`, `always`, or `never` (default: `never`). See [Publishing updates to CAS](#publishing-updates-to-cas) |
 
 ### deactivate (alias: delete)
 
 Permanently deactivates a DID. This is irreversible. Deactivation applies the `{ "op": "add", "path": "/deactivated", "value": true }` patch and routes through the same signed-update path as `update`, so it also signs via the keystore.
 
-Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`.
+Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>` (same as `update`).
 
 ### key
 
@@ -222,7 +223,8 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
 | `--btc-rpc-user <user>` | Bitcoin Core RPC username |
 | `--btc-rpc-pass <pass>` | Bitcoin Core RPC password |
-| `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads |
+| `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads (read-only) |
+| `--cas-rpc-url <url>` | IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables `--publish-to-cas`) |
 | `--keystore <path>` | Path to the keystore file (default: `$XDG_DATA_HOME/btcr2/keystore.json`) |
 | `--passphrase-file <path>` | Read the keystore passphrase from a file (unattended use) |
 | `--signing-key <ref>` | Key for create/update/deactivate signing: a URN, fingerprint prefix, or name |
@@ -236,6 +238,7 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
 | `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
+| `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |
 
 ### Config file
 
@@ -256,11 +259,13 @@ Profiles are matched by network name when `--profile` is not specified. For exam
     },
     "bitcoin": {
       "btc": { "rest": "https://my-mempool/api" },
-      "cas": { "gateway": "https://ipfs.io" }
+      "cas": { "gateway": "https://ipfs.io", "rpcUrl": "http://127.0.0.1:5001" }
     }
   }
 }
 ```
+
+`cas.gateway` is a read-only IPFS HTTP gateway (used for reads). `cas.rpcUrl` is an IPFS HTTP RPC endpoint that supports writes; configure it to enable `--publish-to-cas`. When both are set, `rpcUrl` takes precedence.
 
 ### Defaults
 
@@ -268,7 +273,35 @@ When no overrides are configured:
 
 - **Bitcoin REST**: [mempool.space](https://mempool.space) for `bitcoin`, `testnet3`, `testnet4`, and `signet`; [mutinynet.com](https://mutinynet.com) for `mutinynet`; `http://localhost:3000` for `regtest`
 - **Bitcoin RPC**: `http://localhost:18443` for `regtest` (credentials required), not configured for public networks
-- **CAS**: [ipfs.io](https://ipfs.io) HTTP gateway (read-only)
+- **CAS**: [ipfs.io](https://ipfs.io) HTTP gateway (read-only). Configure a writable CAS with `--cas-rpc-url` (or `cas.rpcUrl`) to publish with `--publish-to-cas`
+
+## Publishing updates to CAS
+
+CAS publication is **optional and never required**. Every `update` and `deactivate` can be completed and shared entirely via sidecar: the command always prints the artifacts a resolver needs (the signed update, the transaction id, the CAS announcement for CAS beacons, and the SMT proof for SMT beacons) for you to distribute yourself.
+
+Optionally, the signed update (and, for CAS beacons, the announcement) can be published to a content-addressed store before the on-chain broadcast, so any OP_RETURN update hash is fetchable from CAS at resolution time without sidecar data. This is opt-in via `--publish-to-cas`:
+
+| Mode | Behavior |
+|---|---|
+| `never` (default) | Publish nothing. Distribute the printed artifacts via sidecar. |
+| `auto` | Best-effort. Publish when a writable CAS is configured; otherwise skip publication silently for every beacon type and proceed. Never blocks an update. |
+| `always` | Require a writable CAS; error up-front for every beacon type when none is configured. |
+
+A writable CAS is configured with `--cas-rpc-url <url>` (an IPFS HTTP RPC endpoint, e.g. a local Kubo node at `http://127.0.0.1:5001`), the `BTCR2_CAS_RPC_URL` environment variable, or a profile's `cas.rpcUrl`. The default IPFS gateway is read-only, so without a configured `--cas-rpc-url`, `--publish-to-cas auto` publishes nothing and completes the update sidecar-only, while `--publish-to-cas always` errors up-front (naming the fix) for every beacon type.
+
+**Privacy:** under `auto`/`always`, canonical signed updates (and announcements) are published to the configured, possibly public, CAS before the on-chain anchor. Keep `never` (the default) to distribute update data privately via sidecar.
+
+```bash
+# Opt into CAS publication against a local IPFS (Kubo) node
+btcr2 update \
+  --cas-rpc-url http://127.0.0.1:5001 \
+  --publish-to-cas auto \
+  -s "$(cat did.json)" \
+  --source-version-id 1 \
+  -p '[{"op":"add","path":"/service/-","value":{"id":"#svc","type":"X","serviceEndpoint":"https://x"}}]' \
+  -m 'did:btcr2:k1qq...#key-0' \
+  -b '{"id":"#beacon-0","type":"SingletonBeacon","serviceEndpoint":"bitcoin:bc1..."}'
+```
 
 ## Links
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,7 +50,8 @@ export class DidBtcr2Cli {
       .option('--btc-rpc-url <url>', 'Override Bitcoin Core RPC endpoint')
       .option('--btc-rpc-user <user>', 'Bitcoin Core RPC username')
       .option('--btc-rpc-pass <pass>', 'Bitcoin Core RPC password')
-      .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads')
+      .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads (read-only)')
+      .option('--cas-rpc-url <url>', 'IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables --publish-to-cas)')
       .option('--keystore <path>', 'Path to the keystore file (default: $XDG_DATA_HOME/btcr2/keystore.json)')
       .option('--passphrase-file <path>', 'Read the keystore passphrase from a file (unattended use)')
       .option('--signing-key <ref>', 'Key for create/update/deactivate signing: a URN, fingerprint prefix, or name');

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -1,3 +1,4 @@
+import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
 import { deriveNetwork, type ApiFactory } from '../config.js';
@@ -36,11 +37,19 @@ export function registerDeactivateCommand(
       'Beacon ID as a JSON string',
       parseJsonArg('--beacon-id'),
     )
+    .option(
+      '--publish-to-cas <mode>',
+      'Publish update artifacts to a writable CAS before broadcast: auto|always|never. '
+        + 'CAS publication is optional; the default distributes the returned artifacts via sidecar.',
+      parsePublishToCasMode,
+      'never',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
       verificationMethodId : string;
       beaconId             : unknown;
+      publishToCas         : PublishToCasMode;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -70,9 +79,12 @@ export function registerDeactivateCommand(
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
-      // The CLI's CAS is a read-only gateway (no writable CAS is configurable
-      // yet), so CAS publication is disabled explicitly. The returned artifacts
-      // (txid, announcement, proof) are printed for manual sidecar distribution.
+      // CAS publication is optional and never required: every beacon update can
+      // be completed and shared via sidecar alone. It is opt-in and defaults to
+      // 'never'; pass --publish-to-cas auto|always to publish the signed update
+      // (and, for CAS beacons, the announcement) to a writable CAS configured
+      // via --cas-rpc-url. The returned artifacts (txid, announcement, proof)
+      // are always printed for sidecar distribution regardless.
       const data = await api.btcr2.update({
         sourceDocument       : parsed.sourceDocument,
         patches              : parsed.patches,
@@ -80,10 +92,25 @@ export function registerDeactivateCommand(
         verificationMethodId : parsed.verificationMethodId,
         beaconId             : parsed.beaconId,
         signer,
-        publishToCas         : 'never',
+        publishToCas         : options.publishToCas,
       });
       console.log(formatResult({ action: 'deactivate', data }, globals()));
     });
+}
+
+/**
+ * Commander argParser for `--publish-to-cas`. Validates the value is one of the
+ * three {@link PublishToCasMode} policies, erroring at parse time otherwise.
+ */
+function parsePublishToCasMode(value: string): PublishToCasMode {
+  if (value !== 'auto' && value !== 'always' && value !== 'never') {
+    throw new CLIError(
+      '--publish-to-cas must be one of "auto", "always", or "never".',
+      'INVALID_ARGUMENT_ERROR',
+      { value },
+    );
+  }
+  return value;
 }
 
 /**

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,3 +1,4 @@
+import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
 import { deriveNetwork, type ApiFactory } from '../config.js';
@@ -37,12 +38,20 @@ export function registerUpdateCommand(
       'Beacon ID as a JSON string',
       parseJsonArg('--beacon-id'),
     )
+    .option(
+      '--publish-to-cas <mode>',
+      'Publish update artifacts to a writable CAS before broadcast: auto|always|never. '
+        + 'CAS publication is optional; the default distributes the returned artifacts via sidecar.',
+      parsePublishToCasMode,
+      'never',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
       patches              : unknown;
       verificationMethodId : string;
       beaconId             : unknown;
+      publishToCas         : PublishToCasMode;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -70,9 +79,12 @@ export function registerUpdateCommand(
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
-      // The CLI's CAS is a read-only gateway (no writable CAS is configurable
-      // yet), so CAS publication is disabled explicitly. The returned artifacts
-      // (txid, announcement, proof) are printed for manual sidecar distribution.
+      // CAS publication is optional and never required: every beacon update can
+      // be completed and shared via sidecar alone. It is opt-in and defaults to
+      // 'never'; pass --publish-to-cas auto|always to publish the signed update
+      // (and, for CAS beacons, the announcement) to a writable CAS configured
+      // via --cas-rpc-url. The returned artifacts (txid, announcement, proof)
+      // are always printed for sidecar distribution regardless.
       const data = await api.btcr2.update({
         sourceDocument       : parsed.sourceDocument,
         patches              : parsed.patches,
@@ -80,10 +92,25 @@ export function registerUpdateCommand(
         verificationMethodId : parsed.verificationMethodId,
         beaconId             : parsed.beaconId,
         signer,
-        publishToCas         : 'never',
+        publishToCas         : options.publishToCas,
       });
       console.log(formatResult({ action: 'update', data }, globals()));
     });
+}
+
+/**
+ * Commander argParser for `--publish-to-cas`. Validates the value is one of the
+ * three {@link PublishToCasMode} policies, erroring at parse time otherwise.
+ */
+function parsePublishToCasMode(value: string): PublishToCasMode {
+  if (value !== 'auto' && value !== 'always' && value !== 'never') {
+    throw new CLIError(
+      '--publish-to-cas must be one of "auto", "always", or "never".',
+      'INVALID_ARGUMENT_ERROR',
+      { value },
+    );
+  }
+  return value;
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { createApi, Identifier, type BitcoinApiConfig, type DidBtcr2Api } from '@did-btcr2/api';
+import { createApi, Identifier, type BitcoinApiConfig, type CasConfig, type DidBtcr2Api } from '@did-btcr2/api';
 import type { KeyManager } from '@did-btcr2/key-manager';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -23,7 +23,10 @@ export type ConnectionOverrides = {
   btcRpcUrl?      : string;
   btcRpcUser?     : string;
   btcRpcPass?     : string;
+  /** IPFS HTTP gateway for CAS reads (read-only). */
   casGateway?     : string;
+  /** IPFS HTTP RPC endpoint for a writable CAS (reads + writes). */
+  casRpcUrl?      : string;
   config?         : string;
   profile?        : string;
   /** Keystore file path. Overrides the default `$XDG_DATA_HOME/btcr2/keystore.json`. */
@@ -49,7 +52,7 @@ export type ConnectionOverrides = {
  *     },
  *     "bitcoin": {
  *       "btc": { "rest": "https://my-mempool/api" },
- *       "cas": { "gateway": "https://ipfs.io" }
+ *       "cas": { "gateway": "https://ipfs.io", "rpcUrl": "http://127.0.0.1:5001" }
  *     }
  *   }
  * }
@@ -72,7 +75,10 @@ export type ConfigFile = {
       rpcPass? : string;
     };
     cas?: {
+      /** IPFS HTTP gateway for CAS reads (read-only). */
       gateway?: string;
+      /** IPFS HTTP RPC endpoint for a writable CAS (reads + writes). */
+      rpcUrl?: string;
     };
     /** Signing identity references. Never embeds key material; the secret lives in the keystore. */
     identity?: {
@@ -153,6 +159,7 @@ export type ApiFactory = (network?: NetworkOption, overrides?: ConnectionOverrid
  * | `BTCR2_BTC_RPC_USER`  | `--btc-rpc-user`   |
  * | `BTCR2_BTC_RPC_PASS`  | `--btc-rpc-pass`   |
  * | `BTCR2_CAS_GATEWAY`   | `--cas-gateway`    |
+ * | `BTCR2_CAS_RPC_URL`   | `--cas-rpc-url`    |
  */
 export const ENV_VARS = {
   BTC_REST     : 'BTCR2_BTC_REST',
@@ -160,6 +167,7 @@ export const ENV_VARS = {
   BTC_RPC_USER : 'BTCR2_BTC_RPC_USER',
   BTC_RPC_PASS : 'BTCR2_BTC_RPC_PASS',
   CAS_GATEWAY  : 'BTCR2_CAS_GATEWAY',
+  CAS_RPC_URL  : 'BTCR2_CAS_RPC_URL',
 } as const;
 
 /**
@@ -174,6 +182,7 @@ export function readEnvOverrides(): ConnectionOverrides {
     btcRpcUser : env(ENV_VARS.BTC_RPC_USER),
     btcRpcPass : env(ENV_VARS.BTC_RPC_PASS),
     casGateway : env(ENV_VARS.CAS_GATEWAY),
+    casRpcUrl  : env(ENV_VARS.CAS_RPC_URL),
   };
 }
 
@@ -221,6 +230,7 @@ export function profileToOverrides(
     btcRpcUser : profile.btc?.rpcUser,
     btcRpcPass : profile.btc?.rpcPass,
     casGateway : profile.cas?.gateway,
+    casRpcUrl  : profile.cas?.rpcUrl,
   };
 }
 
@@ -261,7 +271,7 @@ export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkO
 function resolveConnectionConfig(
   network?  : NetworkOption,
   overrides?: ConnectionOverrides,
-): { btc?: BitcoinApiConfig; cas?: { gateway: string } } {
+): { btc?: BitcoinApiConfig; cas?: CasConfig } {
   if (!network) return {};
 
   // Layer 1: Config file profile (lowest precedence of the three override layers)
@@ -280,6 +290,7 @@ function resolveConnectionConfig(
     btcRpcUser : overrides?.btcRpcUser ?? env.btcRpcUser ?? fileOverrides.btcRpcUser,
     btcRpcPass : overrides?.btcRpcPass ?? env.btcRpcPass ?? fileOverrides.btcRpcPass,
     casGateway : overrides?.casGateway ?? env.casGateway ?? fileOverrides.casGateway,
+    casRpcUrl  : overrides?.casRpcUrl  ?? env.casRpcUrl  ?? fileOverrides.casRpcUrl,
   };
 
   const btc: BitcoinApiConfig = { network };
@@ -296,9 +307,15 @@ function resolveConnectionConfig(
     };
   }
 
-  const cas = merged.casGateway ? { gateway: merged.casGateway } : undefined;
+  // A configured RPC endpoint is writable and takes precedence over the
+  // read-only gateway (matching the api's CasConfig priority: rpcUrl > gateway).
+  // Both may be set; the api selects one executor from them.
+  const cas: CasConfig = {};
+  if (merged.casGateway) cas.gateway = merged.casGateway;
+  if (merged.casRpcUrl) cas.rpcUrl = merged.casRpcUrl;
+  const hasCas = merged.casGateway || merged.casRpcUrl;
 
-  return { btc, ...(cas && { cas }) };
+  return { btc, ...(hasCas && { cas }) };
 }
 
 /**

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -56,6 +56,7 @@ export interface GlobalOptions {
   btcRpcUser?    : string;
   btcRpcPass?    : string;
   casGateway?    : string;
+  casRpcUrl?     : string;
   keystore?      : string;
   passphraseFile?: string;
   signingKey?    : string;

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -39,6 +39,7 @@ describe('readEnvOverrides', () => {
     expect(overrides.btcRpcUser).to.be.undefined;
     expect(overrides.btcRpcPass).to.be.undefined;
     expect(overrides.casGateway).to.be.undefined;
+    expect(overrides.casRpcUrl).to.be.undefined;
   });
 
   it('reads BTCR2_BTC_REST', () => {
@@ -55,6 +56,14 @@ describe('readEnvOverrides', () => {
     expect(overrides.btcRpcUrl).to.equal('http://env-rpc:18443');
     expect(overrides.btcRpcUser).to.equal('envuser');
     expect(overrides.btcRpcPass).to.equal('envpass');
+  });
+
+  it('reads BTCR2_CAS_GATEWAY and BTCR2_CAS_RPC_URL', () => {
+    process.env[ENV_VARS.CAS_GATEWAY] = 'https://ipfs.io';
+    process.env[ENV_VARS.CAS_RPC_URL] = 'http://127.0.0.1:5001';
+    const overrides = readEnvOverrides();
+    expect(overrides.casGateway).to.equal('https://ipfs.io');
+    expect(overrides.casRpcUrl).to.equal('http://127.0.0.1:5001');
   });
 
   it('treats empty string as undefined', () => {
@@ -114,7 +123,7 @@ describe('profileToOverrides', () => {
           rpcUser : 'polaruser',
           rpcPass : 'polarpass',
         },
-        cas : { gateway: 'http://localhost:8080' },
+        cas : { gateway: 'http://localhost:8080', rpcUrl: 'http://localhost:5001' },
       },
       bitcoin : {
         btc : { rest: 'https://my-mempool/api' },
@@ -129,6 +138,7 @@ describe('profileToOverrides', () => {
     expect(o.btcRpcUser).to.equal('polaruser');
     expect(o.btcRpcPass).to.equal('polarpass');
     expect(o.casGateway).to.equal('http://localhost:8080');
+    expect(o.casRpcUrl).to.equal('http://localhost:5001');
   });
 
   it('extracts partial profile', () => {
@@ -136,6 +146,7 @@ describe('profileToOverrides', () => {
     expect(o.btcRest).to.equal('https://my-mempool/api');
     expect(o.btcRpcUrl).to.be.undefined;
     expect(o.casGateway).to.be.undefined;
+    expect(o.casRpcUrl).to.be.undefined;
   });
 
   it('returns empty object for missing profile', () => {
@@ -254,20 +265,67 @@ describe('defaultApiFactory', () => {
     expect(api.btc.connection.name).to.equal('regtest');
   });
 
-  it('wires casGateway through to CAS executor', () => {
+  it('wires casGateway through to a read-only CAS executor', () => {
     const api = defaultApiFactory('regtest', {
       config     : join(tempDir, 'nope.json'),
       casGateway : 'https://ipfs.io',
     });
     expect(api).to.exist;
-    // Accessing api.cas should NOT throw - gateway config was wired through
+    // Accessing api.cas should NOT throw - gateway config was wired through.
+    // A gateway is read-only, so the CAS is not writable.
     expect(() => api.cas).to.not.throw();
+    expect(api.cas.writable).to.equal(false);
   });
 
-  it('defaults to public IPFS gateway when no casGateway is provided', () => {
+  it('defaults to public IPFS gateway (read-only) when no CAS is provided', () => {
     const api = defaultApiFactory('regtest', { config: join(tempDir, 'nope.json') });
     expect(api).to.exist;
-    // CAS should be configured with the default gateway - no throw
+    // CAS should be configured with the default gateway - no throw, not writable.
     expect(() => api.cas).to.not.throw();
+    expect(api.cas.writable).to.equal(false);
+  });
+
+  it('wires casRpcUrl through to a writable CAS executor', () => {
+    const api = defaultApiFactory('regtest', {
+      config    : join(tempDir, 'nope.json'),
+      casRpcUrl : 'http://127.0.0.1:5001',
+    });
+    expect(api).to.exist;
+    // An IPFS RPC endpoint supports publishing, so the CAS is writable.
+    expect(api.cas.writable).to.equal(true);
+  });
+
+  it('casRpcUrl takes precedence over casGateway and stays writable', () => {
+    const api = defaultApiFactory('regtest', {
+      config     : join(tempDir, 'nope.json'),
+      casGateway : 'https://ipfs.io',
+      casRpcUrl  : 'http://127.0.0.1:5001',
+    });
+    expect(api).to.exist;
+    // Priority is rpcUrl > gateway, so the writable RPC executor wins.
+    expect(api.cas.writable).to.equal(true);
+  });
+
+  it('wires cas.rpcUrl from the config-file profile', () => {
+    const configPath = join(tempDir, 'cas-rpc-profile.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        regtest : { cas: { rpcUrl: 'http://127.0.0.1:5001' } },
+      },
+    }));
+    const api = defaultApiFactory('regtest', { config: configPath });
+    expect(api.cas.writable).to.equal(true);
+  });
+
+  it('env BTCR2_CAS_RPC_URL wires a writable CAS over a gateway-only config file', () => {
+    const configPath = join(tempDir, 'cas-env-over-file.json');
+    writeFileSync(configPath, JSON.stringify({
+      profiles : {
+        regtest : { cas: { gateway: 'https://ipfs.io' } },
+      },
+    }));
+    process.env[ENV_VARS.CAS_RPC_URL] = 'http://127.0.0.1:5001';
+    const api = defaultApiFactory('regtest', { config: configPath });
+    expect(api.cas.writable).to.equal(true);
   });
 });

--- a/packages/cli/tests/update.spec.ts
+++ b/packages/cli/tests/update.spec.ts
@@ -77,11 +77,34 @@ describe('update and deactivate (signing)', () => {
     expect(captured.params.signer).to.be.instanceOf(KeyManagerSigner);
     expect(captured.params.sourceVersionId).to.equal(2);
     expect(captured.params.patches).to.deep.equal(JSON.parse(PATCHES));
-    // The CLI has no writable CAS configuration yet, so it must opt out of
-    // CAS publication explicitly (otherwise CAS-beacon updates would throw
-    // under the api's default 'auto' policy).
+    // CAS publication is opt-in and never required; with no --publish-to-cas
+    // flag the CLI defaults to 'never' so updates complete sidecar-only.
     expect(captured.params.publishToCas).to.equal('never');
     expect(JSON.parse(out[0]).signed).to.equal('mock');
+  });
+
+  it('update forwards --publish-to-cas auto to the api', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'update').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"',
+        '--publish-to-cas', 'auto'],
+      { from: 'user' },
+    );
+    expect(captured.params.publishToCas).to.equal('auto');
+  });
+
+  it('update rejects an invalid --publish-to-cas value before signing', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await expect(
+      sub(cli, 'update').parseAsync(
+        ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"',
+          '--publish-to-cas', 'sometimes'],
+        { from: 'user' },
+      ),
+    ).to.be.rejectedWith(CLIError, /must be one of "auto", "always", or "never"/);
+    expect(captured.params).to.equal(undefined);
   });
 
   it('rejects a non-numeric --source-version-id before signing', async () => {
@@ -106,5 +129,29 @@ describe('update and deactivate (signing)', () => {
     expect(captured.params.signer).to.be.instanceOf(KeyManagerSigner);
     expect(captured.params.patches).to.deep.equal([{ op: 'add', path: '/deactivated', value: true }]);
     expect(captured.params.publishToCas).to.equal('never');
+  });
+
+  it('deactivate forwards --publish-to-cas always to the api', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'deactivate').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '3', '-m', '#k0', '-b', '"#beacon-0"',
+        '--publish-to-cas', 'always'],
+      { from: 'user' },
+    );
+    expect(captured.params.publishToCas).to.equal('always');
+  });
+
+  it('deactivate rejects an invalid --publish-to-cas value before signing', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await expect(
+      sub(cli, 'deactivate').parseAsync(
+        ['-s', sourceDoc(), '--source-version-id', '3', '-m', '#k0', '-b', '"#beacon-0"',
+          '--publish-to-cas', 'sometimes'],
+        { from: 'user' },
+      ),
+    ).to.be.rejectedWith(CLIError, /must be one of "auto", "always", or "never"/);
+    expect(captured.params).to.equal(undefined);
   });
 });


### PR DESCRIPTION
* chore(release): bump api 0.16.0, cli 0.14.0
* test(api,cli): opt-in policy grid, rpcUrl wiring, flag validation
* fix(api): publishToCas defaults 'never'; 'auto' never blocks
* feat(cli): --cas-rpc-url + --publish-to-cas (default 'never')
* docs(adr): add ADR 072 (cli writable-CAS) + 073 (CAS opt-in)