### PR TITLE
user-config CLI Bitcoin/CAS I/O: correctness, introspection, secrets

### DIFF
--- a/docs/adr/074-cli-config-resolution-correctness.md
+++ b/docs/adr/074-cli-config-resolution-correctness.md
@@ -1,0 +1,74 @@
+---
+title: "ADR 074: CLI Configuration Resolution Correctness and Safety"
+---
+
+# ADR 074: CLI Configuration Resolution Correctness and Safety
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-io-config`
+
+**References:** [ADR 053](053-bitcoin-defaults-in-sdk.md), [ADR 072](072-cli-writable-cas-and-publish-flag.md), [ADR 073](073-cas-publication-is-opt-in.md), [ADR 075](075-cli-config-validation-and-introspection.md), [ADR 076](076-cli-io-passthrough-knobs.md), [ADR 077](077-cli-rpc-secret-handling.md)
+
+## Context
+
+The cli already resolves connection config through a four-layer precedence chain: CLI flag -> environment variable -> config-file profile -> per-network SDK default (`resolveConnectionConfig`, `config.ts:271-319`). The config file is XDG-located (`config.ts:197-202`), read-modify-written atomically at 0600 (`config.ts:99-105`), and exposed through the `config` and `profile` command groups. The per-network Bitcoin defaults live in the SDK ([ADR 053](053-bitcoin-defaults-in-sdk.md)): mempool.space for public networks, localhost Polar for regtest.
+
+That machinery has the right shape, but a review of the shipped code surfaced nine latent defects. Several of them cause the cli to silently ignore a user's configured private endpoint and fall through to a public default (mempool.space) or to a wrong host. For a censorship-resistant DID method where the whole point of a private node is to avoid leaking which identifiers you resolve, a silent fall-through to a public endpoint is a correctness and privacy defect, not a cosmetic one. Two of the defects (config write, stale credentials) can also destroy user data or send credentials to the wrong host.
+
+Concretely:
+
+1. **A malformed file is indistinguishable from a missing one.** `readConfigFile` (`config.ts:208-215`) wraps `readFileSync` + `JSON.parse` in a single `try`/`catch` that returns `undefined` for *any* error. A JSON typo (trailing comma, unquoted key) is reported identically to `ENOENT`, so both `resolveConnectionConfig` and `resolveDefaultNetwork` treat a broken file as "no file" and fall back to network defaults. The user's private node is silently replaced by mempool.space with no diagnostic.
+
+2. **A write can clobber an unparseable file.** `writeConfigFile` (`config.ts:100`) begins with `readConfigFile(path) ?? {}`. Because a parse error is swallowed to `undefined` (defect 1), the next `config set` or `profile use` starts from `{}`, mutates it, and atomically overwrites the file, destroying every other profile and default that the malformed-but-recoverable file still held. A single stray character followed by one write is unrecoverable data loss.
+
+3. **A blank value is treated as unset only at the env layer.** `readEnvOverrides` collapses `''` to `undefined` with `|| undefined` (`config.ts:178`), but the flag and file layers merge with `??` (`config.ts:288-294`), which only skips `null`/`undefined`. An empty flag value or an empty string in a profile therefore masks a populated lower layer and then, being falsy at the `if (merged.btcRest)` guards (`config.ts:298-316`), contributes nothing, so resolution silently reverts to the SDK network default.
+
+4. **An empty XDG variable resolves to a CWD-relative path.** `defaultConfigPath` (`config.ts:198-201`) and `defaultKeystorePath` (`keystore/paths.ts:16-19`) use `process.env.XDG_CONFIG_HOME ?? process.env.APPDATA ?? homedir(...)`. `??` only falls through on `null`/`undefined`, so `XDG_CONFIG_HOME=""` (common in CI images and containers) yields a relative `btcr2/config.json` resolved against the current working directory rather than the home directory. The XDG Base Directory specification says an empty value must be treated as unset.
+
+5. **RPC url, user, and pass merge independently.** `resolveConnectionConfig` (`config.ts:289-291`) resolves `btcRpcUrl`, `btcRpcUser`, and `btcRpcPass` as three separate `??` chains. So `--btc-rpc-url http://node-B` layered over a profile that holds node-A's url plus node-A's credentials produces `{ host: 'node-B', username: node-A-user, password: node-A-pass }`: node-A's credentials are sent to node-B.
+
+6. **`config set` coerces known scalars to non-strings.** The `set` command runs `JSON.parse` on the raw value and stores whatever it yields (`commands/config.ts:78-84`). `config set profiles.regtest.btc.rpcUrl 8080` therefore stores the *number* `8080`, which flows into `btc.rpc.host` (`config.ts:302-307`) as a non-string host and breaks downstream URL handling.
+
+7. **The two network resolvers disagree.** `resolveConnectionConfig` picks the profile key as `flag ?? defaults.profile ?? network` (`config.ts:280`), so *any* active profile supplies endpoints. But `resolveDefaultNetwork` only treats a profile as a network when the profile *name* is itself a supported network (`config.ts:249-255`). So an active profile named `production` that holds mainnet endpoints, combined with `create` and no `--network`, mints a **regtest** DID (the fallback) while the same run wires **production** endpoints. The identifier's network and the endpoints it talks to disagree.
+
+8. **`defaults.output` is written but never read.** It is part of the `ConfigFile` type (`config.ts:65-69`) and stamped by `config init` (`commands/config.ts:36`), but the commander option carries a hard default of `'text'` (`cli.ts:44`). `formatResult` reads only `options.output` (`output.ts:11-12`), which is therefore always `'text'` (or the flag), so the configured default is dead.
+
+9. **`schemaVersion` is written but never read.** Every write stamps `CONFIG_SCHEMA_VERSION` (`config.ts:102`), yet no read path compares it. A file written by a newer cli, or a legacy pre-versioned file, is parsed blindly under today's assumptions with no guard and no migration.
+
+## Decision
+
+1. **Distinguish a missing file from a malformed one.** `readConfigFile` returns `undefined` only for `ENOENT` (a genuinely absent file). Any other read failure, and every JSON parse failure, throws a `CLIError` that names the file path and, for parse errors, the byte offset reported by the JSON parser. A broken config now fails loudly instead of silently degrading to public defaults.
+
+2. **Never clobber an unparseable file on write.** `writeConfigFile` no longer starts from `{}` when the file exists but fails to parse. It surfaces the parse error (via decision 1) and refuses the write, so a recoverable typo can be fixed by hand rather than destroyed by the next `set`. A true `ENOENT` still starts from `{}` as before.
+
+3. **Treat a blank value as unset at every layer.** A shared `blankToUndef` helper normalizes `''` and whitespace-only strings to `undefined`, and it is applied to flag values and config-file values before the `??` merge, matching what `|| undefined` already does for the env layer (`config.ts:178`). An empty flag or an empty profile field no longer masks a populated lower layer; the next layer down is consulted as if the blank were absent.
+
+4. **Treat an empty XDG or APPDATA value as unset.** `defaultConfigPath` and `defaultKeystorePath` use the same blank-to-undefined normalization for `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `APPDATA`, and `LOCALAPPDATA`, so an empty value falls through to the home-directory fallback per the XDG Base Directory specification. This mirrors the `|| undefined` pattern already used at `config.ts:178` and removes the CWD-relative-path hazard.
+
+5. **Treat the RPC url plus user plus pass as one atomic credential unit.** When the effective `btcRpcUrl` is resolved from a higher-precedence layer than the credentials would be, the username and password are taken from the *same* layer as the url, or dropped if that layer supplies none. Credentials are never inherited across a url that came from a different (higher) layer, so a flag-supplied host can never be handed a profile-supplied user and password.
+
+6. **Store raw strings for known scalar endpoint and credential paths.** `config set` skips `JSON.parse` for the known scalar paths (the `btc.rest`/`btc.rpcUrl`/`btc.rpcUser`/`btc.rpcPass` and `cas.gateway`/`cas.rpcUrl` leaves under any profile, plus `defaults.profile`/`defaults.network`/`defaults.output`) and stores the raw string. JSON coercion is retained only for genuinely structured values (objects, arrays, booleans, numbers at paths that expect them), so `config set profiles.regtest.btc.rpcUrl 8080` stores the string `'8080'`.
+
+7. **Add `profiles.<name>.network` and unify the two network resolvers.** A profile may carry an explicit `network` field. Both `resolveDefaultNetwork` and `resolveConnectionConfig` derive the `(profileName, network)` pair from one shared helper: the profile's own `network` field takes precedence over inferring a network from the profile *name*. When the network the `create` command is about to encode and the active profile's declared network disagree, the cli emits a warning naming both, so a `production` profile holding mainnet endpoints can no longer silently mint a regtest DID.
+
+8. **Honor `defaults.output`.** The commander `-o/--output` hard default of `'text'` (`cli.ts:44`) is dropped so an unset flag reads as `undefined`. Effective output is resolved as flag -> env -> config `defaults.output` -> `'text'`, so a configured default is used when no flag is given and the flag still wins when present.
+
+9. **Validate and migrate `schemaVersion` on read.** On read, the file's `schemaVersion` is compared to `CONFIG_SCHEMA_VERSION`. A newer version is refused with a clear message telling the user to upgrade the cli. An older version runs registered migrations to bring the in-memory shape up to the current version before use. An absent `schemaVersion` is treated as the earliest known version and migrated forward.
+
+## Consequences
+
+- These are correctness and data-safety repairs to already-shipped config code. The only new user-facing surface is the `profiles.<name>.network` field (decision 7) and the now-honored `defaults.output` (decision 8); everything else changes internal resolution behavior, not the config schema.
+- A malformed config now fails loudly, naming the file and the parse offset, instead of silently falling through to public endpoints or clobbering the file on the next write. Users who previously had a broken-but-unnoticed config will start seeing an explicit error; that is the intended correction.
+- Precedence becomes reliable across all four layers: a blank at any layer defers to the next, credentials travel with their url, and an empty XDG value no longer drops a config or keystore file into the working directory.
+- The network a `create` run encodes and the endpoints it talks to can no longer silently disagree; a mismatch warns.
+- This ships as a cli minor bump at 0.x. No `api` or `method` change is required; the resolution logic is entirely cli-side.
+- **Precedence tests are strengthened to be non-vacuous.** The existing tests (`config.spec.ts:239-266`) assert only `api.btc.connection.name === 'regtest'`, an invariant that holds regardless of which layer won, so they would pass even if precedence were reversed. New tests assert the resolved host (`api.btc.connection.rest.config.host`) equals the expected layer's value, that `rpcUser`/`rpcPass` actually reach `btc.rpc`, and that a config-file `defaults.profile` selects a non-network-named profile's endpoints.
+
+## Rejected alternatives
+
+- **Keep swallowing parse errors and just log a warning.** A silent (or warned-then-ignored) fall-through to public endpoints is a correctness and privacy hazard for a method whose value proposition is private resolution, and warnings on stderr are routinely lost in scripted use. Refusing to proceed on a broken config is the only safe default; the loud failure is the point.
+- **Keep independent field merge and document the stale-credential footgun.** Documentation does not stop the credentials from leaking. As long as the three fields merge separately, a url from one layer can be paired with credentials from another and node-A's secrets can be sent to node-B. The fix belongs in the resolution logic, not the manual.
+- **Infer the network from the profile name only (the status quo) instead of adding an explicit `network` field.** Requiring the profile name to equal a network name is brittle and surprising: it forces users to name profiles after networks and silently misbehaves for any profile that is not (a `staging` or `production` profile cannot express its network at all). An explicit `network` field is the direct, unambiguous representation.

--- a/docs/adr/075-cli-config-validation-and-introspection.md
+++ b/docs/adr/075-cli-config-validation-and-introspection.md
@@ -1,0 +1,54 @@
+---
+title: "ADR 075: CLI Configuration Validation and Introspection"
+---
+
+# ADR 075: CLI Configuration Validation and Introspection
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-io-config`
+
+**References:** [ADR 074](074-cli-config-resolution-correctness.md), [ADR 072](072-cli-writable-cas-and-publish-flag.md)
+
+## Context
+
+The cli grew a real configuration surface: a flag -> env -> config-file-profile -> per-network-default precedence merge (`resolveConnectionConfig`, `config.ts:271-319`), a `config` command group (`init`/`get`/`set`/`unset`/`list`), and a `profile` command group. That surface has no validation and no introspection, and both gaps produce the same failure mode: a user changes configuration, the tool silently ignores or overrides the change, and nothing tells them why.
+
+Two concrete footguns:
+
+1. **`config set` accepts anything.** `setConfigPath` (`config.ts:116-126`) splits a dotted path, creates intermediate objects, and writes the leaf with zero schema awareness; the `config set` action (`commands/config.ts:52-58`) parses the value as JSON-or-string and persists it. So `config set profiles.regtest.btc.rset http://x` (a typo for `rest`) and `config set defaults.network mainnett` (not a supported network) both write successfully and are then silently ignored at read time, because `profileToOverrides` (`config.ts:221-235`) only reads the known keys and `resolveDefaultNetwork` (`config.ts:245-258`) only accepts values in `SUPPORTED_NETWORKS`. This is the classic "my config isn't taking effect and I can't tell why."
+
+2. **The effective config is never surfaced.** `config get` and `config list` (`commands/config.ts:44-50,68-74`) print only the raw file. The config that actually reaches the api, the merged `BitcoinApiConfig`/`CasConfig`, is computed inside the non-exported `resolveConnectionConfig` and never shown. A user cannot answer "which btc-rest will actually be used, and did it come from my flag, my env, my profile, or the network default?" without reading the source.
+
+The merge already models exactly four provenance layers (`config.ts:286-294`): CLI flag, environment variable, config-file profile, and the per-network default supplied by `BitcoinConnection`. That layering is the natural basis for both a provenance display and an "is this value even valid" check, and it is currently locked inside a private function.
+
+This ADR is the introspection-and-validation companion to [ADR 074](074-cli-config-resolution-correctness.md). ADR 074 makes the resolution semantics correct; this ADR surfaces and guards them. It does not change precedence or merge order.
+
+## Decision
+
+1. **Write-time validation in `config set`.** Validate the dotted path against the known config schema (the `btc.*`, `cas.*`, `identity.*`, and `defaults.*` shapes in `ConfigFile`, `config.ts:61-89`) and validate enum values for known keys: `defaults.network` must be in `SUPPORTED_NETWORKS` (`types.ts:9`) and `defaults.output` must be in `{'json', 'text'}` (`OutputFormat`, `types.ts:7`). An **unknown path is a warning that still writes**, so forward-compatible and third-party keys are never blocked. An **invalid enum value for a known key is a hard rejection** (a `CLIError`), so `defaults.network mainnett` fails loudly at write time instead of being silently discarded at read time.
+
+2. **A `config validate` subcommand.** Read an existing config file and report unknown keys, out-of-enum values for known keys, and a `schemaVersion` mismatch against `CONFIG_SCHEMA_VERSION` (`config.ts:92`), ending in a clear pass/fail. It reuses the same schema knowledge as the write-time validation in decision 1, so `set` and `validate` never disagree. This is the strict check that complements the permissive warn-and-write of `config set`.
+
+3. **A `config effective [--network <n>]` subcommand.** Print the resolved connection config (the merged `BitcoinApiConfig`/`CasConfig` that `resolveConnectionConfig` produces) with a per-value provenance tag drawn from the same four layers the merge already uses: `flag`, `env`, `file:<profile>`, or `default`. This answers "what btc-rest will actually be used, and where did it come from?" directly, without the user reconstructing the precedence in their head. Because the merge is unchanged, `effective` reports the resolver's real output rather than an approximation.
+
+4. **A `config path` subcommand.** Print the resolved config-file path (honoring `--config` and the XDG resolution in `defaultConfigPath`, `config.ts:197-202`) and the resolved keystore path (honoring `--keystore` and `defaultKeystorePath`, `keystore/paths.ts:15-20`), so a user can locate the exact files the tool is reading rather than guessing at the XDG defaults.
+
+5. **A `config doctor` subcommand.** Probe reachability of the resolved endpoints without mutating anything: a lightweight REST call against btc-rest, a `getblockchaininfo` against btc-rpc when an RPC endpoint is configured, and a reachability check against the configured CAS (gateway and/or rpcUrl). Report per-endpoint `ok`/`fail` and surface the profile/network coherence warning (for example, a profile whose endpoints point at a different network than the one selected). `doctor` reads configuration and touches the network; it never writes.
+
+## Consequences
+
+- This is the introspection-and-validation surface a user-configurable I/O tool needs: `set`/`validate` stop silent-typo configuration from persisting unnoticed, and `effective`/`path`/`doctor` let a user see what the tool actually resolved and reached.
+- `config effective` and `config doctor` are also how a user confirms that other configuration fixes took effect. When ADR 074 corrects a resolution edge case, or when a user adds a profile, `effective` shows the new resolved value with its provenance and `doctor` shows whether the endpoint answers.
+- **No change to merge semantics.** This ADR surfaces and guards the precedence and merge order; it does not redefine them. Precedence correctness is [ADR 074](074-cli-config-resolution-correctness.md)'s concern. `config effective` reads through the existing resolver rather than reimplementing it, so the two cannot drift.
+- **Provenance tagging reuses the existing four-layer model** (`config.ts:286-294`). No new precedence concept is introduced; the tags (`flag`, `env`, `file:<profile>`, `default`) name the layers the merge already walks.
+- Warn-and-write for unknown paths keeps `config set` forward-compatible: a key added by a future schema version, or by a third-party extension, is not rejected by an older cli. `config validate` remains available for a strict pass.
+- Ships as a cli minor bump. It is additive (new subcommands plus a write-time guard that only hard-rejects previously-silently-ignored invalid enum values); it adds no api or method change, since the resolved config, the schema, and the four layers all already exist in the cli.
+
+## Rejected alternatives
+
+- **Reject unknown config paths outright.** Too rigid. It blocks forward-compatible keys (a newer schema version written by a newer cli, then read by an older one) and third-party extension of the config file, for no safety gain the enum checks do not already provide. Warn-and-write is the right default, with `config validate` for callers who want a strict check.
+- **Infer effective config by re-reading the file in each command instead of a dedicated `config effective`.** Duplicative and lossy. Every command would reconstruct the merge, the reconstructions would drift from `resolveConnectionConfig`, and none of them would show provenance, which is the actual question a user has. One subcommand that reads through the real resolver is both simpler and strictly more informative.
+- **A persistent daemon or health endpoint instead of a one-shot `config doctor`.** Far too heavy for a CLI. A one-shot probe that reports per-endpoint `ok`/`fail` and exits gives the user the answer they want (are my endpoints reachable right now) without a background process, a port, or a lifecycle to manage.

--- a/docs/adr/076-cli-io-passthrough-knobs.md
+++ b/docs/adr/076-cli-io-passthrough-knobs.md
@@ -1,0 +1,58 @@
+---
+title: "ADR 076: CLI Bitcoin and CAS I/O Passthrough Knobs"
+---
+
+# ADR 076: CLI Bitcoin and CAS I/O Passthrough Knobs
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-io-config`
+
+**References:** [ADR 044](044-beacon-change-output-address.md), [ADR 053](053-bitcoin-defaults-in-sdk.md), [ADR 070](070-broadcast-result-and-cas-first-ordering.md), [ADR 072](072-cli-writable-cas-and-publish-flag.md), [ADR 078](078-wire-dead-config-surface.md)
+
+## Context
+
+Several I/O knobs are honored end-to-end by the SDK but are unreachable from the cli, so the cli can only ever exercise their defaults. The api/method passthrough for the write path already exists: `DidMethodApi.update` accepts and forwards `broadcastOptions: { feeEstimator?; changeAddress? }` (api `method.ts:259-329`, into the beacon at `beacon.ts:388` / `beacon.ts:609`), and the Bitcoin and CAS config surfaces already carry timeout and header fields. What is missing is the cli plumbing that lets a user set any of them.
+
+Concretely, the write path is called with none of these options set:
+
+1. **Fee rate.** `update.ts:88-96` (and the deactivate command) call `api.btcr2.update` with only `publishToCas` and no `broadcastOptions`, so every cli broadcast falls back to the 5 sat/vB `DEFAULT_FEE_ESTIMATOR` (`fee-estimator.ts:18`). On `bitcoin`, `testnet4`, or `signet` under congestion, a fixed 5 sat/vB can underpay and the beacon transaction may never confirm, with no way to raise it. This is the one gap that can make a cli on-chain update fail today.
+2. **Change address.** `BroadcastOptions.changeAddress` (`beacon.ts:178-186`), the ADR 044 unlinkability opt-out, defaults to the beacon address when unset (`resolveChangeAddress`, `beacon.ts:147-149`). Since the cli never sets it, every cli update chains change back to the beacon address and links a DID's announcements together on-chain, defeating ADR 044.
+3. **Bitcoin request timeout.** `BitcoinApiConfig.timeoutMs` is honored at the bitcoin layer (the fetch executor is wrapped in `AbortSignal.timeout`), but the cli exposes no way to set it, so requests wait unbounded.
+4. **CAS request timeout.** `CasConfig.timeoutMs` is honored (api `cas.ts:219`; `0` disables, SDK default `30000`), but the cli cannot override it.
+5. **REST headers.** `RestConfig.headers` is live and consumed at `rest/protocol.ts:38`, but the cli cannot set headers, so authenticated Esplora/mempool endpoints (API key or `Authorization`) are out of reach.
+6. **RPC wallet and headers.** `RpcConfig.wallet` and `RpcConfig.headers` exist on the config type but are not yet consumed at the RPC transport; the sibling [ADR 078](078-wire-dead-config-surface.md) wires them. The cli exposes no way to set them either.
+
+Each knob below follows the cli's existing flag -> env -> config-profile -> per-network-default precedence merge (`config.ts:271-319`) and adds a matching `BTCR2_*` env var and a `profiles.<n>.btc` or `profiles.<n>.cas` field.
+
+## Decision
+
+Add the following cli knobs. Unless noted, each is pure cli wiring over passthrough that already exists in api/method.
+
+1. **`--fee-rate <satsPerVByte>`** for `update` and `deactivate` (env `BTCR2_FEE_RATE`, profile `profiles.<n>.btc.feeRate`). When set, the cli builds a `StaticFeeEstimator(rate)` and passes it as `broadcastOptions.feeEstimator` through the existing passthrough (api `method.ts:259-329`, into `beacon.ts:388` / `beacon.ts:609`). When unset, the SDK's 5 sat/vB `DEFAULT_FEE_ESTIMATOR` still applies, so behavior is unchanged for callers that do not opt in. This is the one item that can make a cli on-chain update fail today.
+
+2. **`--change-address <addr>`** for `update` and `deactivate` (profile `profiles.<n>.btc.changeAddress`; no env var, since a change address is DID/network-specific and not a stable machine default). When set, the cli passes it as `broadcastOptions.changeAddress`. It is validated against the DID's network before broadcast (the beacon already fails fast on a mismatch at `beacon.ts:147-149`), so a fresh controller-owned address can be supplied to stop linking a DID's announcements on-chain (ADR 044).
+
+3. **`--btc-timeout <ms>`** (env `BTCR2_BTC_TIMEOUT`, profile `profiles.<n>.btc.timeoutMs`) mapped to `BitcoinApiConfig.timeoutMs`. There is **no default**: a timeout is applied only when the user sets one, preserving today's unbounded behavior for callers that want it. Documentation (and the config-doctor in the sibling introspection ADR) should steer unattended or scripted use toward setting a timeout so requests fail fast instead of hanging.
+
+4. **`--cas-timeout <ms>`** (env `BTCR2_CAS_TIMEOUT`, profile `profiles.<n>.cas.timeoutMs`) mapped to `CasConfig.timeoutMs` (api `cas.ts:219`, where `0` disables). This is an explicit override; when unset, the SDK's own default of `30000` ms applies.
+
+5. **`--btc-rest-header 'Key: Value'`** (repeatable; profile `profiles.<n>.btc.headers`) mapped to `RestConfig.headers`, consumed live at `rest/protocol.ts:38`. This enables authenticated Esplora/mempool endpoints that require an API key or an `Authorization` header. No env var: an env-encoded header map is awkward and secret material in the environment is handled by the sibling secret-handling ADR, not by ad hoc encoding here.
+
+6. **`--btc-rpc-wallet <name>`** and **`--btc-rpc-header 'Key: Value'`** (repeatable) for the Bitcoin Core RPC connection, mapped to `RpcConfig.wallet` and `RpcConfig.headers`. These two `RpcConfig` fields are only made functional at the transport by the sibling [ADR 078](078-wire-dead-config-surface.md), which wires the currently-dead RPC config surface; this ADR adds only the cli flags/profile that feed them. `--btc-rpc-wallet` selects a named wallet on a multi-wallet node; `--btc-rpc-header` reaches an authenticated or proxied Bitcoin Core endpoint.
+
+## Consequences
+
+- The cli can now set fees for congested networks (the one gap that can make a cli on-chain update fail today), make unlinkable updates per ADR 044, bound request time for scripted use, lengthen or shorten CAS timeouts, reach authenticated REST endpoints, and target multi-wallet or authenticated Bitcoin Core nodes.
+- Almost all of this is pure cli wiring: the api/method `broadcastOptions` passthrough (ADR 070), the Bitcoin/CAS timeout fields, and `RestConfig.headers` already exist and are honored. Only the RPC wallet/header knobs depend on the sibling transport change in [ADR 078](078-wire-dead-config-surface.md).
+- Each knob obeys the established flag -> env -> config-profile precedence (`config.ts:271-319`), so a value can be set once in a profile and overridden per invocation, consistent with the knobs added in [ADR 072](072-cli-writable-cas-and-publish-flag.md).
+- `--btc-timeout` intentionally ships with no default, so existing scripts that rely on unbounded waits are unaffected; the burden is on the operator (guided by docs and the config-doctor) to opt into a bound.
+- This ships as a cli minor. The RPC transport change that gives `--btc-rpc-wallet` / `--btc-rpc-header` their effect ships as a bitcoin minor via [ADR 078](078-wire-dead-config-surface.md); until that lands, the two RPC flags are accepted and stored but inert.
+
+## Rejected alternatives
+
+- **Default `--btc-timeout` to a fixed value (for example 30s).** Rejected here to avoid changing today's behavior for callers that rely on unbounded waits: a request that currently completes after a long but legitimate stall would start failing. An explicit opt-in is safer, and docs plus the config-doctor can steer scripted users toward setting one.
+- **A single generic `--timeout` covering both Bitcoin and CAS.** Rejected: it conflates two independent I/O paths with different default semantics (Bitcoin has no SDK default and stays unbounded when unset; CAS defaults to `30000` ms and treats `0` as "disable"). One flag cannot express both without surprising one side.
+- **Auto-deriving fee rate from a live estimator in the cli.** Useful later but out of scope. A static `--fee-rate` override is the minimal fix for the confirm-failure risk and composes cleanly with a future dynamic estimator: the estimator would populate the same `broadcastOptions.feeEstimator` slot, and an explicit `--fee-rate` would remain the manual override.

--- a/docs/adr/077-cli-rpc-secret-handling.md
+++ b/docs/adr/077-cli-rpc-secret-handling.md
@@ -1,0 +1,45 @@
+---
+title: "ADR 077: CLI Secret Handling for Bitcoin RPC Credentials"
+---
+
+# ADR 077: CLI Secret Handling for Bitcoin RPC Credentials
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-io-config`
+
+**References:** [ADR 052](052-cli-keystore-file-locking.md), [ADR 072](072-cli-writable-cas-and-publish-flag.md), [ADR 074](074-cli-config-resolution-correctness.md)
+
+## Context
+
+The Bitcoin Core RPC password is the one CLI-held secret with no protection and no indirection. It is declared as a plain string field on the profile schema (`config.ts:75`, `rpcPass?: string`), copied verbatim through `profileToOverrides` (`config.ts:231`, `btcRpcPass: profile.btc?.rpcPass`), and merged straight into the RPC client's `password` field in `resolveConnectionConfig` (`config.ts:306`). At every hop it is plaintext.
+
+The introspection commands make that plaintext visible. `config get profiles.<name>.btc.rpcPass` and `config list` render whatever value the key holds through `formatResult` (`output.ts:11-16`), which serializes the payload as-is. So the routine act of inspecting configuration prints the RPC password into terminal scrollback, screen shares, and CI job logs, none of which are places a credential should land.
+
+This is out of step with the only other secret the CLI handles. The keystore passphrase is never accepted from a command-line flag (which would leak into process listings and shell history), and it already supports a file and an environment variable as sources, with a single trailing newline trimmed so the input is source-independent (`keystore/passphrase.ts:24-49`). The RPC password has none of that: no env var, no file reference, no redaction. The README compounds the gap by showing a bare cleartext password in a `config set` example (`README.md:257`).
+
+The connection-config merge itself is otherwise sound after ADR 074, and the RPC password already flows correctly through the flag -> env -> profile -> per-network-default precedence. The problem here is narrow: the secret is stored and displayed in the clear, and there is no way to keep it out of `config.json`.
+
+## Decision
+
+1. **Redact secret-looking keys in printed output by default.** `config get` and `config list` mask the value of `rpcPass` and of any key whose leaf name matches a secret-name pattern (`pass`, `password`, `secret`, `token`), printing a fixed placeholder in place of the value. The redaction is display-only: the stored `config.json` is untouched, and the value still flows normally into the RPC client at connection time. Passing `--show-secrets` prints the real values for deliberate debugging.
+
+2. **Add a file/env secret-ref for the RPC password, mirroring the keystore-passphrase pattern.** The `rpcPass` value accepts two indirection forms in addition to a literal: `env:<VARNAME>` reads the secret from the named environment variable, and `file:<path>` reads it from a file. A `BTCR2_BTC_RPC_PASS_FILE` environment variable names a file to read when no other source applies, matching how `BTCR2_KEYSTORE_PASSPHRASE` and `--passphrase-file` supply the keystore secret. Resolution trims at most one trailing newline (`\r?\n$`), identical to `keystore/passphrase.ts:28,31`, so a file written by `echo` behaves the same as an inline value. With a secret-ref in place, the secret need not live in `config.json` at all.
+
+3. **Document the plaintext-at-rest tradeoff.** The README states plainly that an `rpcPass` written directly into `config.json` is stored in cleartext (the file is mode 0600 but not encrypted), and recommends either the `env:`/`file:` secret-ref or an RPC-URL-embedded credential for anything sensitive. The `config set` example is changed away from a bare cleartext password so the docs stop modeling the weakest option.
+
+## Consequences
+
+- Routine introspection no longer echoes RPC passwords. `config get`/`config list` show a placeholder for secret keys unless `--show-secrets` is given, so screen shares and CI logs stop leaking the credential by default.
+- Unattended and automated use gains a file-based secret path (`env:`/`file:` and `BTCR2_BTC_RPC_PASS_FILE`) that is consistent with the keystore passphrase, letting operators keep the RPC password out of `config.json` and out of shell history.
+- **Printed-output change for secret keys.** `config get` and `config list` no longer print `rpcPass` (and other secret-name-matched keys) verbatim. Per the CLI's output-shape-is-a-surface convention, this rides a cli minor bump at 0.x.
+- The redaction is purely a display concern. It does not change what `config effective` / `doctor` (sibling [ADR 075](075-cli-config-validation-and-introspection.md)) resolve in order to connect, and it does not alter the resolved RPC `password` handed to the client.
+- This does not encrypt `config.json`. The keystore remains the mechanism for encrypted secret material; RPC credentials are deliberately kept out of the keystore, since they are low-value connection secrets rather than signing keys, and folding them in would couple network config to keystore unlock.
+
+## Rejected alternatives
+
+- **Encrypt `rpcPass` inside `config.json`.** Large scope creep for a low-value secret: it duplicates the keystore's job, forces a passphrase (or its own key material) on every config read, and complicates `config get`/`config set`/`list` and the connection merge for marginal benefit. The env/file secret-ref plus display redaction is the proportionate fix and keeps `config.json` a plain, hand-editable file.
+- **Forbid storing `rpcPass` in the file at all and require a secret-ref.** Too rigid for local and regtest workflows, where a 0600 cleartext password in `config.json` is an acceptable convenience and the credential guards a throwaway node. The decision keeps the inline value working and makes the secret-ref the recommended path for sensitive setups rather than the only path.
+- **Redact but offer no way to reveal.** Blocks legitimate debugging, since an operator sometimes needs to confirm exactly what value is stored. `--show-secrets` is the explicit escape hatch, so the safe default does not become an obstacle.

--- a/docs/adr/078-wire-dead-config-surface.md
+++ b/docs/adr/078-wire-dead-config-surface.md
@@ -1,0 +1,45 @@
+---
+title: "ADR 078: Wire the Advertised-but-Dead Bitcoin RPC and Profile-Identity Config Surface"
+---
+
+# ADR 078: Wire the Advertised-but-Dead Bitcoin RPC and Profile-Identity Config Surface
+
+**Status:** Accepted
+
+**Date:** 2026-07-07
+
+**Branch / PR:** `feat/cli-io-config`
+
+**References:** [ADR 053](053-bitcoin-defaults-in-sdk.md), [ADR 072](072-cli-writable-cas-and-publish-flag.md), [ADR 076](076-cli-io-passthrough-knobs.md)
+
+## Context
+
+Two pieces of config surface are advertised on their types but do nothing at runtime. A field that exists on a public type is a promise: an operator who reads the type reasonably expects setting it to change behavior. These two do not, and both gaps run deeper than "the CLI never passes them through."
+
+1. **`RpcConfig` fields are dead at the transport.** `RpcConfig` (bitcoin `types.ts`) declares `headers` (line 112), `wallet` (line 116), and `allowDefaultWallet` (line 117), but `JsonRpcProtocol` (`client/rpc/protocol.ts:44-69`) reads only `host`, `username`, and `password`. Its constructor builds the request headers from the derived `Authorization` header and a fixed `Content-Type` only, and it takes the RPC URL verbatim from `host`. So multi-wallet Bitcoin Core selection and custom or authenticated RPC headers are dead at the transport layer, not merely un-wired in the CLI: even a direct bitcoin-package caller that set `wallet` or `headers` would see them ignored.
+
+2. **The profile `identity` block is dead in the CLI.** `ConfigFile` declares `profiles.<name>.identity.keystore` and `identity.default` (`config.ts:83-87`), but nothing reads them. `buildKeystoreKms` (`config.ts:341-346`) resolves the keystore path as `overrides?.keystore ?? defaultKeystorePath()` and never consults the active profile, and signing-key resolution never consults `identity.default`. Both keys are also undocumented, so a profile can carry an `identity` block that silently has no effect.
+
+Bitcoin Core exposes per-wallet RPCs under a `/wallet/<name>` URL path, and RPC endpoints fronted by a reverse proxy commonly require custom or bearer headers. Both are ordinary operator needs that the declared fields already imply support for.
+
+## Decision
+
+1. **Wire `RpcConfig.headers` and `RpcConfig.wallet` in `JsonRpcProtocol`.** Merge configured `headers` into the request headers alongside the derived `Authorization` header, so custom or authenticated RPC endpoints work. When `wallet` is set, append `/wallet/<name>` to the RPC URL so Bitcoin Core wallet RPCs target the named wallet. This is a bitcoin-package change and ships as a bitcoin minor bump.
+
+2. **Remove `RpcConfig.allowDefaultWallet`.** It is unused, and its intended guard semantics (refuse the node's default wallet) add surface without a caller. Drop the field rather than implement a knob nobody asked for.
+
+3. **Wire `profiles.<name>.identity` into the CLI.** `identity.keystore` feeds `buildKeystoreKms`, so a profile can point at its own keystore file, and `identity.default` feeds signing-key resolution as the profile's default signing key. Both fall **below** the corresponding global flags (`--keystore`, `--signing-key`) in precedence, and both are documented in the README config-file section.
+
+## Consequences
+
+- Authenticated RPC endpoints and multi-wallet Bitcoin Core nodes become usable. The CLI flags that feed `RpcConfig.wallet` and `RpcConfig.headers` are added by the sibling passthrough ADR ([ADR 076](076-cli-io-passthrough-knobs.md)); this ADR is what makes those fields live at the transport.
+- Each profile can carry its own keystore and default signing key, completing the profile model: switching profiles now switches signing identity, not just I/O endpoints.
+- The dead `allowDefaultWallet` field is gone, so the type no longer advertises a guard that does not exist.
+- The transport change is the only reason the bitcoin package version moves in this refactor; the rest of the sweep is CLI-only wiring.
+- Add tests: an RPC request built with `wallet` set appends the `/wallet/<name>` path; configured `headers` appear on the built request alongside `Authorization`; and a profile `identity.keystore` / `identity.default` is honored, but a global `--keystore` / `--signing-key` flag still wins over it.
+
+## Rejected alternatives
+
+- **Remove all three `RpcConfig` fields and the `identity` block instead of wiring them.** This closes the dead-surface gap but permanently forecloses authenticated and multi-wallet RPC and per-profile identity, all of which are ordinary operator needs. Wiring is the better completion of a user-configurable I/O surface; deletion would trade a small honesty win for a real capability loss.
+- **Implement `allowDefaultWallet` as a guard.** No caller needs it, and it complicates the common single-wallet path (every default-wallet call would have to route around the guard). Removing the field is simpler and loses nothing in use today.
+- **Wire `identity` above the global flags.** A flag is an explicit per-invocation choice and should always win over a persisted profile default. Placing `identity` above `--keystore` / `--signing-key` would make the flags unreliable, so `identity` stays the lower-precedence layer, consistent with the flag -> env -> profile -> default ordering the CLI already uses.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -150,3 +150,8 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 071 | 2026-07-07 | [A CAS Publication Policy for the API Update Path (publishToCas), Writable-CAS Capability Detection, and Enriched Update Results](071-api-cas-publication-policy.md) |
 | 072 | 2026-07-07 | [CLI Writable-CAS Configuration and an Opt-In --publish-to-cas Flag](072-cli-writable-cas-and-publish-flag.md) |
 | 073 | 2026-07-07 | [CAS Publication Is Opt-In - Default publishToCas to 'never' and Make 'auto' Non-Blocking](073-cas-publication-is-opt-in.md) |
+| 074 | 2026-07-07 | [CLI Configuration Resolution Correctness and Safety](074-cli-config-resolution-correctness.md) |
+| 075 | 2026-07-07 | [CLI Configuration Validation and Introspection](075-cli-config-validation-and-introspection.md) |
+| 076 | 2026-07-07 | [CLI Bitcoin and CAS I/O Passthrough Knobs](076-cli-io-passthrough-knobs.md) |
+| 077 | 2026-07-07 | [CLI Secret Handling for Bitcoin RPC Credentials](077-cli-rpc-secret-handling.md) |
+| 078 | 2026-07-07 | [Wire the Advertised-but-Dead Bitcoin RPC and Profile-Identity Config Surface](078-wire-dead-config-surface.md) |

--- a/packages/aggregation/CHANGELOG.md
+++ b/packages/aggregation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @did-btcr2/aggregation
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.9.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/aggregation/package.json
+++ b/packages/aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/aggregation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Multi-party coordination for did:btcr2 aggregate beacons: sans-I/O AggregationService and AggregationParticipant state machines, MuSig2 (BIP-327) signing sessions, cohort conditions, and pluggable transports (Nostr, HTTP, in-memory).",
   "main": "./dist/cjs/index.js",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @did-btcr2/api
 
+## 0.16.1
+
+### Patch Changes
+
+- Remove the dead `allowDefaultWallet: true` from the exported `DEFAULT_BITCOIN_NETWORK_CONFIG.regtest.rpc` default, following ADR 078's removal of `RpcConfig.allowDefaultWallet` in `@did-btcr2/bitcoin`. The field was never consumed at the transport, so this is a behavior-neutral tidy of the exported config surface.
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.9.0
+  - @did-btcr2/method@0.54.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/bitcoin.ts
+++ b/packages/api/src/bitcoin.ts
@@ -49,8 +49,7 @@ export const DEFAULT_BITCOIN_NETWORK_CONFIG = {
   },
   regtest : {
     rpc  : {
-      host               : 'http://localhost:18443',
-      allowDefaultWallet : true,
+      host : 'http://localhost:18443',
     },
     rest : { host: 'http://localhost:3000' }
   },

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @did-btcr2/bitcoin
+
+## 0.9.0
+
+### Minor Changes
+
+- Wire the previously-dead `RpcConfig.wallet` and `RpcConfig.headers` fields in `JsonRpcProtocol` (ADR 078). A configured `wallet` appends `/wallet/<name>` (URL-encoded) to the RPC URL so per-wallet Bitcoin Core RPCs are reachable; configured `headers` are merged into the request headers, while the derived Basic `Authorization` and the fixed `Content-Type` still take precedence. The unused `RpcConfig.allowDefaultWallet` field is removed.

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/bitcoin",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "type": "module",
     "description": "Bitcoin Core RPC and Rest Client Implementations in JS/TS. Used by @did-btcr2/method.",
     "main": "./dist/cjs/index.js",

--- a/packages/bitcoin/src/client/rpc/protocol.ts
+++ b/packages/bitcoin/src/client/rpc/protocol.ts
@@ -60,9 +60,19 @@ export class JsonRpcProtocol {
       }
     }
 
+    // Target a named wallet's RPCs when configured: Bitcoin Core exposes
+    // per-wallet RPC methods under the `/wallet/<name>` URL path.
+    if (cfg.wallet) {
+      url = `${url}/wallet/${encodeURIComponent(cfg.wallet)}`;
+    }
+
     this.url = url;
     this.hasAuth = authHeader !== undefined;
+    // Configured headers come first, so a custom or bearer header reaches an
+    // authenticated or proxied endpoint; the fixed Content-Type and the derived
+    // Basic Authorization header take precedence over any same-named entry.
     this._headers = {
+      ...cfg.headers,
       'Content-Type' : 'application/json',
       ...(authHeader ? { Authorization: authHeader } : {}),
     };

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -114,7 +114,6 @@ export interface RpcConfig {
   password?: string;
   username?: string;
   wallet?: string;
-  allowDefaultWallet?: boolean;
 }
 
 export type FeeEstimateMode = 'UNSET' | 'ECONOMICAL' | 'CONSERVATIVE';

--- a/packages/bitcoin/tests/json-rpc.spec.ts
+++ b/packages/bitcoin/tests/json-rpc.spec.ts
@@ -30,6 +30,16 @@ describe('JsonRpcProtocol', () => {
       const protocol = new JsonRpcProtocol({ host: 'http://node:8332' });
       expect(protocol.hasAuth).to.be.false;
     });
+
+    it('appends /wallet/<name> to the URL when a wallet is configured', () => {
+      const protocol = new JsonRpcProtocol({ host: 'http://node:8332', wallet: 'primary' });
+      expect(protocol.url).to.equal('http://node:8332/wallet/primary');
+    });
+
+    it('URL-encodes a wallet name with special characters', () => {
+      const protocol = new JsonRpcProtocol({ host: 'http://node:8332', wallet: 'my wallet/2' });
+      expect(protocol.url).to.equal('http://node:8332/wallet/my%20wallet%2F2');
+    });
   });
 
   describe('buildRequest()', () => {
@@ -70,6 +80,30 @@ describe('JsonRpcProtocol', () => {
       const req2 = protocol.buildRequest('b', []);
       req1.headers['X-Mutated'] = 'yes';
       expect(req2.headers['X-Mutated']).to.be.undefined;
+    });
+
+    it('includes configured headers alongside Content-Type', () => {
+      const protocol = new JsonRpcProtocol({ host: 'http://node:8332', headers: { 'X-Api-Key': 'secret' } });
+      const req = protocol.buildRequest('getblockcount', []);
+      expect(req.headers['X-Api-Key']).to.equal('secret');
+      expect(req.headers['Content-Type']).to.equal('application/json');
+    });
+
+    it('does not let a configured Authorization override derived Basic auth', () => {
+      const protocol = new JsonRpcProtocol({
+        host     : 'http://node:8332',
+        username : 'u',
+        password : 'p',
+        headers  : { Authorization: 'Bearer nope' },
+      });
+      const req = protocol.buildRequest('getblockcount', []);
+      expect(req.headers['Authorization']).to.match(/^Basic /);
+    });
+
+    it('keeps a configured Authorization header when no Basic auth is derived', () => {
+      const protocol = new JsonRpcProtocol({ host: 'http://node:8332', headers: { Authorization: 'Bearer token' } });
+      const req = protocol.buildRequest('getblockcount', []);
+      expect(req.headers['Authorization']).to.equal('Bearer token');
     });
   });
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @did-btcr2/cli
 
+## 0.15.0
+
+### Minor Changes
+
+- User-configurable Bitcoin/CAS I/O with config correctness, validation, introspection, and secret handling (ADRs 074-078).
+
+  - Config resolution correctness and safety: a malformed config now fails loudly instead of silently falling back to public endpoints or clobbering the file; a blank value at any precedence layer defers to the next layer; an empty `$XDG_CONFIG_HOME`/`$XDG_DATA_HOME` is treated as unset; the RPC url, user, and pass resolve as one atomic credential unit (a URL from a higher layer never inherits a lower layer's credentials); `config set` stores known scalar paths as strings; profiles gain an explicit `network` field and the two network resolvers are unified with a coherence warning; `defaults.output` is honored; `schemaVersion` is validated on read.
+  - New Bitcoin/CAS I/O knobs, each with a `BTCR2_*` env var and a profile field: `--fee-rate`, `--change-address`, `--btc-timeout`, `--cas-timeout`, `--btc-rest-header`, `--btc-rpc-wallet`, `--btc-rpc-header`.
+  - New introspection and validation: `config validate`, `config effective` (resolved values with per-value provenance), `config path`, and `config doctor` (endpoint reachability). `config set` rejects an invalid enum for a known key and warns on an unknown path.
+  - Secret handling: `config get`/`list`/`effective` redact secret-looking values by default (`--show-secrets` reveals them); `rpcPass` accepts `env:<VAR>` and `file:<path>` secret references plus a `BTCR2_BTC_RPC_PASS_FILE` fallback.
+  - Per-profile `identity.keystore` and `identity.default` are wired, below the `--keystore` / `--signing-key` flags.
+
+  Printed output for `config get` and `config list` changes (secret values are now redacted by default), so this rides a minor bump.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.16.1
+  - @did-btcr2/method@0.54.1
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -87,12 +87,14 @@ Required flags: `-s/--source-document`, `--source-version-id`, `-p/--patches`, `
 | `-m, --verification-method-id <id>` | DID document verification method ID |
 | `-b, --beacon-id <json>` | Beacon ID as a JSON string |
 | `--publish-to-cas <mode>` | Publish update artifacts to a writable CAS before broadcast: `auto`, `always`, or `never` (default: `never`). See [Publishing updates to CAS](#publishing-updates-to-cas) |
+| `--fee-rate <satsPerVByte>` | Fee rate in sats/vByte for the beacon transaction (default: `5`). Raise it under congestion so the transaction confirms (also `BTCR2_FEE_RATE`, profile `btc.feeRate`) |
+| `--change-address <address>` | Send transaction change to this address instead of the beacon address, so a DID's announcements are not linked on-chain (profile `btc.changeAddress`) |
 
 ### deactivate (alias: delete)
 
 Permanently deactivates a DID. This is irreversible. Deactivation applies the `{ "op": "add", "path": "/deactivated", "value": true }` patch and routes through the same signed-update path as `update`, so it also signs via the keystore.
 
-Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>` (same as `update`).
+Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>`, `--fee-rate <satsPerVByte>`, `--change-address <address>` (same as `update`).
 
 ### key
 
@@ -117,10 +119,14 @@ Read and write CLI configuration.
 | Subcommand | Alias | Description |
 |---|---|---|
 | `config init` | - | Create a default config file with one profile per network. `--force` overwrites |
-| `config get [path]` | - | Print a value at a dotted path, or the whole config |
-| `config set <path> <value>` | - | Set a value at a dotted path (value parsed as JSON when valid, else a string) |
+| `config get [path]` | - | Print a value at a dotted path, or the whole config. Secret values are redacted; `--show-secrets` reveals them |
+| `config set <path> <value>` | - | Set a value at a dotted path (value parsed as JSON when valid, else a string). An invalid enum for a known key is rejected; an unknown path warns but writes |
 | `config unset <path>` | - | Delete a value at a dotted path |
-| `config list` | `ls` | Print the entire config file |
+| `config list` | `ls` | Print the entire config file. Secret values are redacted; `--show-secrets` reveals them |
+| `config validate` | - | Report unknown keys, invalid enum values, and an unsupported schema version |
+| `config effective` | - | Print the resolved connection config with per-value provenance (`flag`/`env`/`file`/`default`). `-n, --network <n>` selects the network; `--show-secrets` reveals the RPC password |
+| `config path` | - | Print the resolved config-file and keystore paths |
+| `config doctor` | - | Probe reachability of the resolved endpoints (read-only; touches the network). `-n, --network <n>` selects the network |
 
 ### profile
 
@@ -214,7 +220,7 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | Flag | Description |
 |---|---|
 | `-v, --version` | Output the current version |
-| `-o, --output <format>` | Output format: `json` or `text` (default: `text`) |
+| `-o, --output <format>` | Output format: `json` or `text` (default: config `defaults.output`, else `text`) |
 | `--verbose` | Verbose output |
 | `--quiet` | Suppress non-essential output |
 | `-c, --config <path>` | Path to config file (default: `$XDG_CONFIG_HOME/btcr2/config.json`) |
@@ -222,9 +228,14 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `--btc-rest <url>` | Override Bitcoin REST endpoint (Esplora API) |
 | `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
 | `--btc-rpc-user <user>` | Bitcoin Core RPC username |
-| `--btc-rpc-pass <pass>` | Bitcoin Core RPC password |
+| `--btc-rpc-pass <pass>` | Bitcoin Core RPC password (accepts an `env:<VAR>` or `file:<path>` secret reference) |
+| `--btc-rpc-wallet <name>` | Bitcoin Core wallet name for wallet-scoped RPCs (`/wallet/<name>`) |
+| `--btc-rpc-header <header>` | Extra Bitcoin Core RPC header `"Key: Value"` (repeatable) |
+| `--btc-rest-header <header>` | Extra Bitcoin REST header `"Key: Value"` (repeatable), e.g. an API key |
+| `--btc-timeout <ms>` | Bitcoin REST/RPC request timeout in milliseconds (default: unbounded) |
 | `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads (read-only) |
 | `--cas-rpc-url <url>` | IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables `--publish-to-cas`) |
+| `--cas-timeout <ms>` | CAS request timeout in milliseconds (default: `30000`; `0` disables) |
 | `--keystore <path>` | Path to the keystore file (default: `$XDG_DATA_HOME/btcr2/keystore.json`) |
 | `--passphrase-file <path>` | Read the keystore passphrase from a file (unattended use) |
 | `--signing-key <ref>` | Key for create/update/deactivate signing: a URN, fingerprint prefix, or name |
@@ -237,35 +248,72 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
 | `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` |
+| `BTCR2_BTC_RPC_PASS_FILE` | file whose contents are the RPC password |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |
+| `BTCR2_BTC_TIMEOUT` | `--btc-timeout` |
+| `BTCR2_CAS_TIMEOUT` | `--cas-timeout` |
+| `BTCR2_FEE_RATE` | `--fee-rate` |
+| `BTCR2_OUTPUT` | `-o, --output` |
 
 ### Config file
 
-Default location: `$XDG_CONFIG_HOME/btcr2/config.json` (falls back to `~/.config/btcr2/config.json`).
+Default location: `$XDG_CONFIG_HOME/btcr2/config.json` (falls back to `~/.config/btcr2/config.json`). An empty `$XDG_CONFIG_HOME` is treated as unset. A malformed config file fails loudly (the CLI never silently falls back to public endpoints, and never overwrites an unparseable file).
 
-Profiles are matched by network name when `--profile` is not specified. For example, resolving a regtest DID automatically selects the `"regtest"` profile.
+Profiles are matched by network name when `--profile` is not specified. For example, resolving a regtest DID automatically selects the `"regtest"` profile. A profile that is not named after a network can declare its network with a `network` field.
 
 ```json
 {
+  "schemaVersion": 1,
+  "defaults": {
+    "profile": "production",
+    "network": "bitcoin",
+    "output": "text"
+  },
   "profiles": {
     "regtest": {
       "btc": {
         "rest": "http://localhost:3000",
         "rpcUrl": "http://localhost:18443",
         "rpcUser": "polaruser",
-        "rpcPass": "polarpass"
+        "rpcPass": "polarpass",
+        "wallet": "primary",
+        "feeRate": 5,
+        "timeoutMs": 30000
       }
     },
-    "bitcoin": {
-      "btc": { "rest": "https://my-mempool/api" },
-      "cas": { "gateway": "https://ipfs.io", "rpcUrl": "http://127.0.0.1:5001" }
+    "production": {
+      "network": "bitcoin",
+      "btc": {
+        "rest": "https://my-mempool/api",
+        "headers": { "Authorization": "Bearer <api-key>" },
+        "feeRate": 20
+      },
+      "cas": { "gateway": "https://ipfs.io", "rpcUrl": "http://127.0.0.1:5001", "timeoutMs": 30000 },
+      "identity": { "keystore": "/secure/prod-keystore.json", "default": "did:btcr2:...#key-0" }
     }
   }
 }
 ```
 
-`cas.gateway` is a read-only IPFS HTTP gateway (used for reads). `cas.rpcUrl` is an IPFS HTTP RPC endpoint that supports writes; configure it to enable `--publish-to-cas`. When both are set, `rpcUrl` takes precedence.
+Field notes:
+
+- **`defaults`**: `profile` selects the active profile; `network` fixes the network `create` encodes when `-n` is absent; `output` sets the default output format. `schemaVersion` is stamped on every write; a file written by a newer CLI is refused.
+- **`btc`**: `rest`/`rpcUrl`/`rpcUser`/`rpcPass` are endpoints and credentials; `wallet` targets a Bitcoin Core wallet (`/wallet/<name>`); `headers`/`rpcHeaders` add REST/RPC headers; `feeRate` (sats/vByte), `changeAddress`, and `timeoutMs` set broadcast and request behavior. The RPC url, user, and pass are resolved as one atomic unit, so a URL from a higher-precedence layer never inherits credentials from a lower one.
+- **`cas`**: `gateway` is a read-only IPFS HTTP gateway; `cas.rpcUrl` is a writable IPFS HTTP RPC endpoint (enables `--publish-to-cas`; `rpcUrl` wins over `gateway`); `timeoutMs` bounds CAS operations (`0` disables).
+- **`identity`**: `keystore` points the profile at its own keystore file, and `default` is the profile's default signing key. Both fall **below** the corresponding `--keystore` / `--signing-key` flags.
+
+Use `config validate` to check a file, and `config effective` to see the resolved values with their provenance.
+
+### RPC password and secrets
+
+`config get` and `config list` redact secret-looking values (RPC password and any `pass`/`secret`/`token` key) by default; pass `--show-secrets` to reveal them.
+
+An `rpcPass` written directly into `config.json` is stored in cleartext (the file is mode 0600 but not encrypted). For anything sensitive, keep the secret out of the file with a reference or an RPC-URL-embedded credential:
+
+- `"rpcPass": "env:MY_RPC_PASS"` reads the password from the `MY_RPC_PASS` environment variable.
+- `"rpcPass": "file:/run/secrets/rpc-pass"` reads it from a file (a single trailing newline is trimmed).
+- `BTCR2_BTC_RPC_PASS_FILE=/run/secrets/rpc-pass` names a file to read when no other RPC password source applies.
 
 ### Defaults
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,7 +10,7 @@ import {
   registerResolveCommand,
   registerUpdateCommand,
 } from './commands/index.js';
-import { defaultApiFactory, keystoreApiFactory, type ApiFactory } from './config.js';
+import { defaultApiFactory, keystoreApiFactory, resolveOutputFormat, type ApiFactory } from './config.js';
 import type { GlobalOptions } from './types.js';
 import { VERSION } from './version.js';
 
@@ -41,7 +41,7 @@ export class DidBtcr2Cli {
     this.program = new Command('btcr2')
       .version(`btcr2 ${VERSION}`, '-v, --version', 'Output the current version')
       .description('CLI tool for the did:btcr2 method')
-      .option('-o, --output <format>', 'Output format <json|text>', 'text')
+      .option('-o, --output <format>', 'Output format <json|text> (default: config defaults.output, else text)')
       .option('--verbose', 'Verbose output', false)
       .option('--quiet', 'Suppress non-essential output', false)
       .option('-c, --config <path>', 'Path to config file (default: $XDG_CONFIG_HOME/btcr2/config.json)')
@@ -52,11 +52,26 @@ export class DidBtcr2Cli {
       .option('--btc-rpc-pass <pass>', 'Bitcoin Core RPC password')
       .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads (read-only)')
       .option('--cas-rpc-url <url>', 'IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables --publish-to-cas)')
+      .option('--btc-timeout <ms>', 'Bitcoin REST/RPC request timeout in milliseconds (default: unbounded)')
+      .option('--cas-timeout <ms>', 'CAS request timeout in milliseconds (default: 30000; 0 disables)')
+      .option('--btc-rest-header <header>', 'Extra Bitcoin REST header "Key: Value" (repeatable)', collectHeader, [])
+      .option('--btc-rpc-wallet <name>', 'Bitcoin Core wallet name for wallet-scoped RPCs')
+      .option('--btc-rpc-header <header>', 'Extra Bitcoin Core RPC header "Key: Value" (repeatable)', collectHeader, [])
       .option('--keystore <path>', 'Path to the keystore file (default: $XDG_DATA_HOME/btcr2/keystore.json)')
       .option('--passphrase-file <path>', 'Read the keystore passphrase from a file (unattended use)')
       .option('--signing-key <ref>', 'Key for create/update/deactivate signing: a URN, fingerprint prefix, or name');
 
     const globals = (): GlobalOptions => this.program.opts() as GlobalOptions;
+
+    // Resolve the effective output format (flag -> BTCR2_OUTPUT -> config
+    // defaults.output -> 'text') before any command action runs, so a configured
+    // default is honored while an explicit flag still wins. The commander option
+    // carries no hard default (which would mask defaults.output); the resolved
+    // value is written back so every command reads it through globals().output.
+    this.program.hook('preAction', () => {
+      const opts = this.program.opts() as GlobalOptions;
+      opts.output = resolveOutputFormat({ output: opts.output, config: opts.config });
+    });
 
     registerCreateCommand(this.program, factory, keystoreFactory, globals);
     registerResolveCommand(this.program, factory, globals);
@@ -82,6 +97,14 @@ export class DidBtcr2Cli {
       handleError(error, Boolean(this.program.opts().verbose));
     }
   }
+}
+
+/**
+ * Commander collector for a repeatable header option: accumulates each
+ * `Key: Value` occurrence into an array, preserving order.
+ */
+function collectHeader(value: string, previous: string[]): string[] {
+  return [ ...previous, value ];
 }
 
 /**

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -5,15 +5,21 @@ import {
   CONFIG_SCHEMA_VERSION,
   defaultConfigPath,
   getConfigPath,
+  parseConfigFileRaw,
   readConfigFile,
+  resolveDefaultNetwork,
+  resolveEffectiveConfig,
+  runDoctor,
   setConfigPath,
   unsetConfigPath,
   writeConfigFile,
 } from '../config.js';
+import { findConfigIssues, validateConfigSet } from '../config-schema.js';
 import { CLIError } from '../error.js';
 import { ensureDir, writeFileAtomic } from '../keystore/atomic.js';
-import { formatResult } from '../output.js';
-import type { CommandResult, GlobalOptions } from '../types.js';
+import { defaultKeystorePath } from '../keystore/paths.js';
+import { formatResult, REDACTED, redactSecrets, scrubUrlUserinfo } from '../output.js';
+import type { CommandResult, GlobalOptions, NetworkOption } from '../types.js';
 import { SUPPORTED_NETWORKS } from '../types.js';
 
 /** Registers the `config` command group for reading and writing CLI configuration. */
@@ -44,16 +50,26 @@ export function registerConfigCommand(program: Command, globals: () => GlobalOpt
   config
     .command('get [path]')
     .description('Print a value at a dotted path, or the whole config.')
-    .action((dotted?: string) => {
+    .option('--show-secrets', 'Reveal secret values (RPC password, etc.) instead of redacting them.', false)
+    .action((dotted: string | undefined, opts: { showSecrets?: boolean }) => {
       const file = (readConfigFile(path()) ?? {}) as Record<string, unknown>;
-      print({ action: 'config-get', data: (dotted ? getConfigPath(file, dotted) : file) ?? null });
+      const raw = (dotted ? getConfigPath(file, dotted) : file) ?? null;
+      const leaf = dotted ? dotted.split('.').pop() : undefined;
+      print({ action: 'config-get', data: opts.showSecrets ? raw : redactSecrets(raw, leaf) });
     });
 
   config
     .command('set <path> <value>')
     .description('Set a value at a dotted path. The value is parsed as JSON when valid, else stored as a string.')
     .action((dotted: string, value: string) => {
-      writeConfigFile(path(), raw => setConfigPath(raw, dotted, parseValue(value)));
+      const parsed = parseValue(dotted, value);
+      // Reject an invalid enum value for a known key up-front; warn (but still
+      // write) an unknown path so forward-compatible and third-party keys work.
+      const { unknownPath } = validateConfigSet(dotted, parsed);
+      if (unknownPath && !globals().quiet) {
+        console.error(`Warning: "${dotted}" is not a known config path; writing it anyway.`);
+      }
+      writeConfigFile(path(), raw => setConfigPath(raw, dotted, parsed));
       print({ action: 'config-set', data: { path: dotted } });
     });
 
@@ -69,16 +85,127 @@ export function registerConfigCommand(program: Command, globals: () => GlobalOpt
     .command('list')
     .alias('ls')
     .description('Print the entire config file.')
+    .option('--show-secrets', 'Reveal secret values (RPC password, etc.) instead of redacting them.', false)
+    .action((opts: { showSecrets?: boolean }) => {
+      const file = readConfigFile(path()) ?? {};
+      print({ action: 'config-list', data: opts.showSecrets ? file : redactSecrets(file) });
+    });
+
+  config
+    .command('validate')
+    .description('Check the config for unknown keys, invalid enum values, and an unsupported schema version.')
     .action(() => {
-      print({ action: 'config-list', data: readConfigFile(path()) ?? {} });
+      // Read raw (bypassing the schema-version ceiling that readConfigFile
+      // enforces) so a newer-than-supported version is reported as a finding
+      // rather than aborting the very command meant to diagnose it.
+      const file = parseConfigFileRaw(path()) ?? {};
+      const issues = findConfigIssues(file, CONFIG_SCHEMA_VERSION);
+      if (issues.length > 0) process.exitCode ??= 1;
+      print({ action: 'config-validate', data: { ok: issues.length === 0, issues } });
+    });
+
+  config
+    .command('effective')
+    .description('Print the resolved connection config with per-value provenance (flag|env|file|default).')
+    .option('-n, --network <network>', 'Network to resolve for (default: config default network)')
+    .option('--show-secrets', 'Reveal secret values (RPC password) instead of redacting them.', false)
+    .action((opts: { network?: string; showSecrets?: boolean }) => {
+      const network = resolveIntrospectionNetwork(opts.network, globals());
+      const data = resolveEffectiveConfig(network, globals());
+      // Redact the resolved RPC password and any password embedded in an endpoint
+      // URL by default; provenance still shows where each value came from.
+      // --show-secrets reveals them for deliberate debugging.
+      if (!opts.showSecrets) {
+        if (data.btc.rpcPass.value !== undefined) {
+          data.btc.rpcPass = { ...data.btc.rpcPass, value: REDACTED };
+        }
+        for (const entry of [ data.btc.rest, data.btc.rpcUrl, data.cas.gateway, data.cas.rpcUrl ]) {
+          if (typeof entry.value === 'string') entry.value = scrubUrlUserinfo(entry.value);
+        }
+      }
+      print({ action: 'config-effective', data });
+    });
+
+  config
+    .command('path')
+    .description('Print the resolved config-file and keystore paths.')
+    .action(() => {
+      const data = {
+        config   : globals().config ?? defaultConfigPath(),
+        keystore : globals().keystore ?? defaultKeystorePath(),
+      };
+      print({ action: 'config-path', data });
+    });
+
+  config
+    .command('doctor')
+    .description('Probe reachability of the resolved endpoints (read-only; touches the network).')
+    .option('-n, --network <network>', 'Network to resolve for (default: config default network)')
+    .action(async (opts: { network?: string }) => {
+      const network = resolveIntrospectionNetwork(opts.network, globals());
+      const report = await runDoctor(network, globals());
+      if (report.checks.some(check => !check.ok)) process.exitCode ??= 1;
+      print({ action: 'config-doctor', data: report });
     });
 }
 
-/** Parses a value as JSON when valid, otherwise treats it as a plain string. */
-function parseValue(value: string): unknown {
+/**
+ * Resolves the network an introspection command (`effective`/`doctor`) operates
+ * on: an explicit `--network`, validated, else the config's default network.
+ */
+function resolveIntrospectionNetwork(explicit: string | undefined, globals: GlobalOptions): NetworkOption {
+  if (explicit) {
+    if (!SUPPORTED_NETWORKS.includes(explicit as NetworkOption)) {
+      throw new CLIError(
+        `Invalid network "${explicit}". Must be one of ${SUPPORTED_NETWORKS.join(', ')}.`,
+        'INVALID_ARGUMENT_ERROR',
+        { network: explicit },
+      );
+    }
+    return explicit as NetworkOption;
+  }
+  return resolveDefaultNetwork(globals);
+}
+
+/**
+ * Parses a `config set` value. Known scalar endpoint, credential, and defaults
+ * paths are stored as raw strings so a bare `8080` is not coerced to the number
+ * `8080` (which would flow into a host field as a non-string). Every other path
+ * is parsed as JSON when valid, else stored as a plain string, so structured
+ * values (objects, arrays, booleans, and genuinely numeric fields) still work.
+ */
+function parseValue(dotted: string, value: string): unknown {
+  if (isStringScalarPath(dotted)) return value;
   try {
     return JSON.parse(value);
   } catch {
     return value;
   }
+}
+
+/**
+ * Whether a dotted config path addresses a leaf that must be stored as a string
+ * (an endpoint URL, a credential, a network/profile/output name), so JSON
+ * coercion never turns it into a non-string.
+ */
+function isStringScalarPath(dotted: string): boolean {
+  const segments = dotted.split('.');
+
+  if (segments.length === 2 && segments[0] === 'defaults') {
+    return [ 'profile', 'network', 'output' ].includes(segments[1]);
+  }
+
+  if (segments.length === 3 && segments[0] === 'profiles' && segments[2] === 'network') {
+    return true;
+  }
+
+  if (segments.length === 4 && segments[0] === 'profiles') {
+    const group = segments[2];
+    const leaf = segments[3];
+    if (group === 'btc') return [ 'rest', 'rpcUrl', 'rpcUser', 'rpcPass', 'changeAddress', 'wallet' ].includes(leaf);
+    if (group === 'cas') return [ 'gateway', 'rpcUrl' ].includes(leaf);
+    if (group === 'identity') return [ 'keystore', 'default' ].includes(leaf);
+  }
+
+  return false;
 }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import type { Command } from 'commander';
 import type { ApiFactory, ConnectionOverrides } from '../config.js';
-import { resolveDefaultNetwork } from '../config.js';
+import { profileNetworkMismatch, resolveDefaultNetwork } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -62,6 +62,18 @@ export function registerCreateCommand(
       const overrides = overridesFromGlobals(g);
       const network = resolveNetwork(options.network, overrides);
       const signingKey = g.signingKey;
+
+      // Warn (never block) when the network being encoded disagrees with the
+      // active profile's declared network, so a `production` profile holding
+      // mainnet endpoints cannot silently mint a regtest DID.
+      const mismatch = profileNetworkMismatch(network, overrides);
+      if (mismatch && !g.quiet) {
+        process.stderr.write(
+          `Warning: creating a "${network}" identifier while the active profile `
+          + `"${mismatch.profile}" declares network "${mismatch.declared}". The `
+          + 'identifier\'s network and the profile\'s endpoints may not match.\n'
+        );
+      }
 
       /** Prints the result, plus a stderr provenance line in text mode. */
       const print = (result: CommandResult, note?: string): void => {

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -1,7 +1,7 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
-import { deriveNetwork, type ApiFactory } from '../config.js';
+import { deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -44,12 +44,24 @@ export function registerDeactivateCommand(
       parsePublishToCasMode,
       'never',
     )
+    .option(
+      '--fee-rate <satsPerVByte>',
+      'Fee rate in sats/vByte for the beacon transaction (default: 5). '
+        + 'Raise it under congestion so the transaction confirms.',
+    )
+    .option(
+      '--change-address <address>',
+      'Send transaction change to this address instead of the beacon address, '
+        + 'so a DID\'s announcements are not linked on-chain (ADR 044).',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
       verificationMethodId : string;
       beaconId             : unknown;
       publishToCas         : PublishToCasMode;
+      feeRate?             : string;
+      changeAddress?       : string;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -77,8 +89,15 @@ export function registerDeactivateCommand(
       // method has no separate deactivate path, so this routes through update.
       const network = deriveNetwork(did);
       const api = factory(network, globals());
-      const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
+      const keyId = resolveKeyRef(api.kms.kms, resolveSigningKeyRef(globals()));
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
+      // Resolve fee-rate/change-address through the flag -> env -> profile chain
+      // into beacon broadcast options. Undefined when neither is set, so the
+      // SDK defaults (5 sat/vB, change back to the beacon address) still apply.
+      const broadcastOptions = resolveBroadcastOptions(network, globals(), {
+        feeRate       : options.feeRate,
+        changeAddress : options.changeAddress,
+      });
       // CAS publication is optional and never required: every beacon update can
       // be completed and shared via sidecar alone. It is opt-in and defaults to
       // 'never'; pass --publish-to-cas auto|always to publish the signed update
@@ -93,6 +112,7 @@ export function registerDeactivateCommand(
         beaconId             : parsed.beaconId,
         signer,
         publishToCas         : options.publishToCas,
+        ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'deactivate', data }, globals()));
     });

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 import { defaultConfigPath, readConfigFile, writeConfigFile } from '../config.js';
 import { CLIError } from '../error.js';
-import { formatResult } from '../output.js';
+import { formatResult, redactSecrets } from '../output.js';
 import type { CommandResult, GlobalOptions } from '../types.js';
 
 /** Registers the `profile` command group for managing configuration profiles. */
@@ -37,7 +37,8 @@ export function registerProfileCommand(program: Command, globals: () => GlobalOp
   profile
     .command('show [name]')
     .description('Show a profile (defaults to the active profile).')
-    .action((name?: string) => {
+    .option('--show-secrets', 'Reveal secret values (RPC password, etc.) instead of redacting them.', false)
+    .action((name: string | undefined, opts: { showSecrets?: boolean }) => {
       const file = readConfigFile(path()) ?? {};
       const target = name ?? file.defaults?.profile;
       if (!target) {
@@ -47,7 +48,8 @@ export function registerProfileCommand(program: Command, globals: () => GlobalOp
       if (!data) {
         throw new CLIError(`Profile "${target}" not found.`, 'INVALID_ARGUMENT_ERROR', { profile: target });
       }
-      print({ action: 'profile-show', data: { profile: target, ...data } });
+      const payload = { profile: target, ...data };
+      print({ action: 'profile-show', data: opts.showSecrets ? payload : redactSecrets(payload) });
     });
 
   profile

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,7 +1,7 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
-import { deriveNetwork, type ApiFactory } from '../config.js';
+import { deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -45,6 +45,16 @@ export function registerUpdateCommand(
       parsePublishToCasMode,
       'never',
     )
+    .option(
+      '--fee-rate <satsPerVByte>',
+      'Fee rate in sats/vByte for the beacon transaction (default: 5). '
+        + 'Raise it under congestion so the transaction confirms.',
+    )
+    .option(
+      '--change-address <address>',
+      'Send transaction change to this address instead of the beacon address, '
+        + 'so a DID\'s announcements are not linked on-chain (ADR 044).',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
@@ -52,6 +62,8 @@ export function registerUpdateCommand(
       verificationMethodId : string;
       beaconId             : unknown;
       publishToCas         : PublishToCasMode;
+      feeRate?             : string;
+      changeAddress?       : string;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -77,8 +89,15 @@ export function registerUpdateCommand(
       }
       const network = deriveNetwork(did);
       const api = factory(network, globals());
-      const keyId = resolveKeyRef(api.kms.kms, globals().signingKey);
+      const keyId = resolveKeyRef(api.kms.kms, resolveSigningKeyRef(globals()));
       const signer = new KeyManagerSigner(api.kms.kms, keyId);
+      // Resolve fee-rate/change-address through the flag -> env -> profile chain
+      // into beacon broadcast options. Undefined when neither is set, so the
+      // SDK defaults (5 sat/vB, change back to the beacon address) still apply.
+      const broadcastOptions = resolveBroadcastOptions(network, globals(), {
+        feeRate       : options.feeRate,
+        changeAddress : options.changeAddress,
+      });
       // CAS publication is optional and never required: every beacon update can
       // be completed and shared via sidecar alone. It is opt-in and defaults to
       // 'never'; pass --publish-to-cas auto|always to publish the signed update
@@ -93,6 +112,7 @@ export function registerUpdateCommand(
         beaconId             : parsed.beaconId,
         signer,
         publishToCas         : options.publishToCas,
+        ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'update', data }, globals()));
     });

--- a/packages/cli/src/config-schema.ts
+++ b/packages/cli/src/config-schema.ts
@@ -1,0 +1,178 @@
+import { CLIError } from './error.js';
+import { SUPPORTED_NETWORKS } from './types.js';
+
+/**
+ * Declarative schema of the known config-file paths, used by both the write-time
+ * validation in `config set` and the strict `config validate` check so the two
+ * cannot disagree. Leaves name a value kind: `'string'`, `'number'`, `'object'`
+ * (a free-form map, e.g. headers), or `'enum:<name>'`. The `'*'` key under
+ * `profiles` matches any profile name.
+ */
+const CONFIG_SCHEMA: SchemaNode = {
+  schemaVersion : 'number',
+  defaults      : {
+    profile : 'string',
+    network : 'enum:network',
+    output  : 'enum:output',
+  },
+  profiles : {
+    '*' : {
+      network : 'enum:network',
+      btc     : {
+        rest          : 'string',
+        rpcUrl        : 'string',
+        rpcUser       : 'string',
+        rpcPass       : 'string',
+        feeRate       : 'number',
+        changeAddress : 'string',
+        timeoutMs     : 'number',
+        headers       : 'object',
+        wallet        : 'string',
+        rpcHeaders    : 'object',
+      },
+      cas : {
+        gateway   : 'string',
+        rpcUrl    : 'string',
+        timeoutMs : 'number',
+      },
+      identity : {
+        keystore : 'string',
+        default  : 'string',
+      },
+    },
+  },
+};
+
+type SchemaLeaf = 'string' | 'number' | 'object' | `enum:${string}`;
+type SchemaNode = { [key: string]: SchemaLeaf | SchemaNode };
+
+/** One problem found in a config file: the dotted path and a human-readable reason. */
+export interface ConfigIssue {
+  path  : string;
+  issue : string;
+}
+
+/**
+ * Resolves a dotted config path to its schema node: a leaf kind string, a nested
+ * {@link SchemaNode}, or `undefined` when the path is not part of the known
+ * schema. A segment under `profiles` matches the `'*'` template.
+ */
+function lookupSchemaNode(dotted: string): SchemaLeaf | SchemaNode | undefined {
+  let node: SchemaLeaf | SchemaNode | undefined = CONFIG_SCHEMA;
+  for (const segment of dotted.split('.')) {
+    if (typeof node !== 'object') return undefined;
+    // Own-property checks only: `in` would match inherited Object.prototype names
+    // (`toString`, `constructor`, `__proto__`), treating a builtin as a known key.
+    if (Object.hasOwn(node, segment)) {
+      node = node[segment];
+    } else if (Object.hasOwn(node, '*')) {
+      node = node['*'];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+/** Whether a dotted path is part of the known config schema (leaf or intermediate). */
+export function isKnownConfigPath(dotted: string): boolean {
+  return lookupSchemaNode(dotted) !== undefined;
+}
+
+/**
+ * Validates a value against a leaf kind, throwing a {@link CLIError} for a value
+ * that does not match: an out-of-range enum, a non-number for a `number` leaf, or
+ * a non-object for an `object` leaf (a map such as `headers`). A no-op for
+ * `string` leaves and for intermediate nodes.
+ */
+function assertLeafValue(kind: SchemaLeaf, dotted: string, value: unknown): void {
+  if (kind === 'enum:network' && !SUPPORTED_NETWORKS.includes(value as never)) {
+    throw new CLIError(
+      `Invalid value for ${dotted}: "${String(value)}". Expected one of ${SUPPORTED_NETWORKS.join(', ')}.`,
+      'INVALID_ARGUMENT_ERROR',
+      { path: dotted, value },
+    );
+  }
+  if (kind === 'enum:output' && value !== 'json' && value !== 'text') {
+    throw new CLIError(
+      `Invalid value for ${dotted}: "${String(value)}". Expected "json" or "text".`,
+      'INVALID_ARGUMENT_ERROR',
+      { path: dotted, value },
+    );
+  }
+  if (kind === 'number' && typeof value !== 'number') {
+    throw new CLIError(
+      `Invalid value for ${dotted}: expected a number, got ${typeof value}. `
+      + 'Pass a bare number (e.g. `config set ' + dotted + ' 5`).',
+      'INVALID_ARGUMENT_ERROR',
+      { path: dotted, value },
+    );
+  }
+  if (kind === 'object' && (typeof value !== 'object' || value === null || Array.isArray(value))) {
+    throw new CLIError(
+      `Invalid value for ${dotted}: expected a JSON object (e.g. \`config set ${dotted} '{"Key":"Value"}'\`).`,
+      'INVALID_ARGUMENT_ERROR',
+      { path: dotted, value },
+    );
+  }
+}
+
+/**
+ * Write-time validation for `config set`. An enum, number, or object leaf whose
+ * value has the wrong kind is a hard rejection (throws). An unknown path is
+ * permitted but reported, so `config set` can warn and still write (keeping
+ * forward-compatible and third-party keys usable). Returns `{ unknownPath }`.
+ */
+export function validateConfigSet(dotted: string, value: unknown): { unknownPath: boolean } {
+  const node = lookupSchemaNode(dotted);
+  if (node === undefined) return { unknownPath: true };
+  if (typeof node === 'string') {
+    assertLeafValue(node, dotted, value);
+  }
+  return { unknownPath: false };
+}
+
+/**
+ * Strict validation for `config validate`: walks a parsed config and collects
+ * every unknown key and out-of-enum value, plus a `schemaVersion` that is newer
+ * than this CLI supports. Never throws; returns the full list so the caller can
+ * report all problems at once.
+ */
+export function findConfigIssues(config: Record<string, unknown>, supportedSchemaVersion: number): ConfigIssue[] {
+  const issues: ConfigIssue[] = [];
+
+  const version = config.schemaVersion;
+  if (typeof version === 'number' && version > supportedSchemaVersion) {
+    issues.push({
+      path  : 'schemaVersion',
+      issue : `newer than supported (${version} > ${supportedSchemaVersion}); upgrade the CLI to use this file`,
+    });
+  }
+
+  walk(config, [], issues);
+  return issues;
+}
+
+/** Recursively collects unknown-key and bad-enum issues under `prefix`. */
+function walk(obj: Record<string, unknown>, prefix: string[], issues: ConfigIssue[]): void {
+  for (const [ key, value ] of Object.entries(obj)) {
+    const path = [ ...prefix, key ];
+    const dotted = path.join('.');
+    const node = lookupSchemaNode(dotted);
+
+    if (node === undefined) {
+      issues.push({ path: dotted, issue: 'unknown key' });
+      continue; // Do not descend into an unknown subtree.
+    }
+
+    if (typeof node === 'string') {
+      try {
+        assertLeafValue(node, dotted, value);
+      } catch (error) {
+        issues.push({ path: dotted, issue: (error as Error).message });
+      }
+    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      walk(value as Record<string, unknown>, path, issues);
+    }
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,7 @@
-import { createApi, Identifier, type BitcoinApiConfig, type CasConfig, type DidBtcr2Api } from '@did-btcr2/api';
+import { createApi, DEFAULT_BITCOIN_NETWORK_CONFIG, DEFAULT_CAS_GATEWAY, Identifier, type BitcoinApiConfig, type CasConfig, type DidBtcr2Api } from '@did-btcr2/api';
 import type { KeyManager } from '@did-btcr2/key-manager';
+import { StaticFeeEstimator } from '@did-btcr2/method';
+import type { BroadcastOptions } from '@did-btcr2/method';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -8,7 +10,7 @@ import { ensureDir, writeFileAtomic } from './keystore/atomic.js';
 import { FileBackedKeyManager } from './keystore/file-backed-key-manager.js';
 import { defaultKeystorePath } from './keystore/paths.js';
 import { acquirePassphrase } from './keystore/passphrase.js';
-import { SUPPORTED_NETWORKS, type NetworkOption, type OutputFormat } from './types.js';
+import { blankToUndef, SUPPORTED_NETWORKS, type NetworkOption, type OutputFormat } from './types.js';
 
 /**
  * Endpoint overrides provided via CLI flags, env vars, or config file.
@@ -27,12 +29,24 @@ export type ConnectionOverrides = {
   casGateway?     : string;
   /** IPFS HTTP RPC endpoint for a writable CAS (reads + writes). */
   casRpcUrl?      : string;
+  /** Bitcoin REST/RPC request timeout in milliseconds (raw flag/env string). */
+  btcTimeout?     : string;
+  /** CAS request timeout in milliseconds (raw flag/env string; `0` disables). */
+  casTimeout?     : string;
+  /** Extra Bitcoin REST headers as raw `Key: Value` flag values (repeatable). */
+  btcRestHeader?  : string[];
+  /** Bitcoin Core RPC wallet name for wallet-scoped RPCs. */
+  btcRpcWallet?   : string;
+  /** Extra Bitcoin Core RPC headers as raw `Key: Value` flag values (repeatable). */
+  btcRpcHeader?   : string[];
   config?         : string;
   profile?        : string;
   /** Keystore file path. Overrides the default `$XDG_DATA_HOME/btcr2/keystore.json`. */
   keystore?       : string;
   /** Path to a file holding the keystore passphrase (for unattended use). */
   passphraseFile? : string;
+  /** Signing key reference (URN, fingerprint prefix, or name) from `--signing-key`. */
+  signingKey?     : string;
 };
 
 /**
@@ -68,17 +82,38 @@ export type ConfigFile = {
     output?: OutputFormat;
   };
   profiles?: Record<string, {
+    /**
+     * The Bitcoin network this profile's endpoints target. Declaring it lets a
+     * profile that is not named after a network (e.g. `production`) still fix
+     * the network its `create` runs encode, and lets the CLI warn when the
+     * network being encoded disagrees with the profile's endpoints.
+     */
+    network? : NetworkOption;
     btc?: {
-      rest?    : string;
-      rpcUrl?  : string;
-      rpcUser? : string;
-      rpcPass? : string;
+      rest?          : string;
+      rpcUrl?        : string;
+      rpcUser?       : string;
+      rpcPass?       : string;
+      /** Fee rate in sats/vByte for beacon transactions (update/deactivate). */
+      feeRate?       : number;
+      /** Change address for beacon transactions (ADR 044 unlinkability opt-out). */
+      changeAddress? : string;
+      /** Request timeout in milliseconds for REST/RPC calls. No default (unbounded). */
+      timeoutMs?     : number;
+      /** Extra headers sent on REST (Esplora) requests, e.g. an API key. */
+      headers?       : Record<string, string>;
+      /** Bitcoin Core wallet name for wallet-scoped RPCs. */
+      wallet?        : string;
+      /** Extra headers sent on Bitcoin Core RPC requests. */
+      rpcHeaders?    : Record<string, string>;
     };
     cas?: {
       /** IPFS HTTP gateway for CAS reads (read-only). */
       gateway?: string;
       /** IPFS HTTP RPC endpoint for a writable CAS (reads + writes). */
       rpcUrl?: string;
+      /** Request timeout in milliseconds for CAS operations. Default 30000; `0` disables. */
+      timeoutMs?: number;
     };
     /** Signing identity references. Never embeds key material; the secret lives in the keystore. */
     identity?: {
@@ -95,6 +130,11 @@ export const CONFIG_SCHEMA_VERSION = 1;
  * Read-modify-write a config file, preserving unknown keys. Reads the raw JSON
  * (so keys outside {@link ConfigFile} survive a rewrite), applies `mutate`,
  * stamps the schema version, and writes atomically (file 0600, dir 0700).
+ *
+ * A file that exists but cannot be parsed makes {@link readConfigFile} throw, so
+ * a write never starts from `{}` over a malformed-but-recoverable file and can
+ * never clobber the other profiles and defaults it still holds. A genuinely
+ * absent file (ENOENT) still starts from `{}`.
  */
 export function writeConfigFile(path: string, mutate: (raw: Record<string, unknown>) => void): void {
   const raw: Record<string, unknown> = (readConfigFile(path) as Record<string, unknown> | undefined) ?? {};
@@ -112,9 +152,20 @@ export function getConfigPath(config: Record<string, unknown>, path: string): un
   );
 }
 
+/** Dotted-path segments that would let a write reach the prototype chain. */
+const UNSAFE_KEYS = new Set([ '__proto__', 'constructor', 'prototype' ]);
+
+/** Rejects a path segment that would let a `config set`/`unset` reach the prototype chain. */
+function assertSafeKey(key: string, path: string): void {
+  if (UNSAFE_KEYS.has(key)) {
+    throw new CLIError(`Illegal config path segment "${key}" in "${path}".`, 'INVALID_ARGUMENT_ERROR', { path, key });
+  }
+}
+
 /** Sets the value at a dotted path, creating intermediate objects. */
 export function setConfigPath(config: Record<string, unknown>, path: string, value: unknown): void {
   const keys = path.split('.');
+  keys.forEach(key => assertSafeKey(key, path));
   const last = keys.pop();
   if (!last) throw new CLIError('Config path must be non-empty.', 'INVALID_ARGUMENT_ERROR');
   let node = config;
@@ -128,6 +179,7 @@ export function setConfigPath(config: Record<string, unknown>, path: string, val
 /** Deletes the value at a dotted path. No-op if the path does not exist. */
 export function unsetConfigPath(config: Record<string, unknown>, path: string): void {
   const keys = path.split('.');
+  keys.forEach(key => assertSafeKey(key, path));
   const last = keys.pop();
   if (!last) return;
   let node: Record<string, unknown> | undefined = config;
@@ -160,6 +212,9 @@ export type ApiFactory = (network?: NetworkOption, overrides?: ConnectionOverrid
  * | `BTCR2_BTC_RPC_PASS`  | `--btc-rpc-pass`   |
  * | `BTCR2_CAS_GATEWAY`   | `--cas-gateway`    |
  * | `BTCR2_CAS_RPC_URL`   | `--cas-rpc-url`    |
+ * | `BTCR2_BTC_TIMEOUT`   | `--btc-timeout`    |
+ * | `BTCR2_CAS_TIMEOUT`   | `--cas-timeout`    |
+ * | `BTCR2_FEE_RATE`      | `--fee-rate`       |
  */
 export const ENV_VARS = {
   BTC_REST     : 'BTCR2_BTC_REST',
@@ -168,6 +223,9 @@ export const ENV_VARS = {
   BTC_RPC_PASS : 'BTCR2_BTC_RPC_PASS',
   CAS_GATEWAY  : 'BTCR2_CAS_GATEWAY',
   CAS_RPC_URL  : 'BTCR2_CAS_RPC_URL',
+  BTC_TIMEOUT  : 'BTCR2_BTC_TIMEOUT',
+  CAS_TIMEOUT  : 'BTCR2_CAS_TIMEOUT',
+  FEE_RATE     : 'BTCR2_FEE_RATE',
 } as const;
 
 /**
@@ -195,22 +253,75 @@ export function readEnvOverrides(): ConnectionOverrides {
  * 3. `~/.config/btcr2/config.json` (fallback)
  */
 export function defaultConfigPath(): string {
-  const base = process.env.XDG_CONFIG_HOME
-    ?? process.env.APPDATA
+  const base = blankToUndef(process.env.XDG_CONFIG_HOME)
+    ?? blankToUndef(process.env.APPDATA)
     ?? join(homedir(), '.config');
   return join(base, 'btcr2', 'config.json');
 }
 
 /**
- * Reads and parses a config file. Returns `undefined` if the file does
- * not exist or cannot be parsed.
+ * Reads and JSON-parses a config file without applying the schema-version
+ * ceiling check. Returns `undefined` only for a genuinely absent file (ENOENT).
+ * Any other read failure, and any JSON parse failure, throws a {@link CLIError}
+ * that names the file. Used by `config validate`, which reports a newer-than-
+ * supported `schemaVersion` as a finding rather than aborting on it.
+ */
+export function parseConfigFileRaw(path: string): Record<string, unknown> | undefined {
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf-8');
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code === 'ENOENT') return undefined;
+    throw new CLIError(
+      `Failed to read config file at ${path}: ${(error as Error).message}`,
+      'CONFIG_READ_ERROR',
+      { path },
+    );
+  }
+  try {
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch (error: unknown) {
+    throw new CLIError(
+      `Config file at ${path} is not valid JSON: ${(error as Error).message}. `
+      + 'Fix the file by hand; the CLI will not overwrite it while it is unparseable.',
+      'CONFIG_PARSE_ERROR',
+      { path },
+    );
+  }
+}
+
+/**
+ * Reads and parses a config file. Returns `undefined` only when the file is
+ * genuinely absent (ENOENT), so callers can safely treat "no file" as "use
+ * defaults". Any other read failure, and any JSON parse failure, throws a
+ * {@link CLIError} that names the file, rather than silently degrading to the
+ * public network defaults. A file written by a newer CLI (higher `schemaVersion`)
+ * is also refused.
  */
 export function readConfigFile(path: string): ConfigFile | undefined {
-  try {
-    const content = readFileSync(path, 'utf-8');
-    return JSON.parse(content) as ConfigFile;
-  } catch {
-    return undefined;
+  const parsed = parseConfigFileRaw(path);
+  if (parsed === undefined) return undefined;
+  migrateConfigShape(parsed, path);
+  return parsed as ConfigFile;
+}
+
+/**
+ * Validates a parsed config's `schemaVersion` against {@link CONFIG_SCHEMA_VERSION}
+ * and brings an older shape up to the current version in place. A file written by
+ * a newer CLI is refused so today's assumptions are never applied blindly to an
+ * unknown shape. An absent version is treated as the earliest and migrated
+ * forward. No structural migrations are registered yet (the schema is at version
+ * 1); future versions register their transforms here in ascending order.
+ */
+function migrateConfigShape(raw: Record<string, unknown>, path: string): void {
+  const version = typeof raw.schemaVersion === 'number' ? raw.schemaVersion : 0;
+  if (version > CONFIG_SCHEMA_VERSION) {
+    throw new CLIError(
+      `Config file at ${path} has schemaVersion ${version}, but this CLI supports up to `
+      + `${CONFIG_SCHEMA_VERSION}. Upgrade the btcr2 CLI to read it.`,
+      'CONFIG_SCHEMA_VERSION_ERROR',
+      { path, fileVersion: version, supported: CONFIG_SCHEMA_VERSION },
+    );
   }
 }
 
@@ -235,10 +346,35 @@ export function profileToOverrides(
 }
 
 /**
+ * Resolves the active profile name and the network it targets, shared by
+ * {@link resolveDefaultNetwork} and {@link resolveConnectionConfig} so the two
+ * can never disagree about which profile is active or which network it means.
+ *
+ * The active profile name is the explicit `--profile` flag, else the config
+ * file's `defaults.profile`. The network is the profile's own `network` field
+ * when set to a supported value, else the profile name itself when it is a
+ * network name (the historical convention). A profile that declares no network
+ * and is not named after one yields `network: undefined`.
+ */
+export function resolveActiveProfile(
+  file      : ConfigFile | undefined,
+  overrides?: ConnectionOverrides,
+): { name: string | undefined; network: NetworkOption | undefined } {
+  const name = blankToUndef(overrides?.profile) ?? file?.defaults?.profile;
+  if (!name) return { name: undefined, network: undefined };
+
+  const declared = file?.profiles?.[name]?.network;
+  const network = (declared && SUPPORTED_NETWORKS.includes(declared))
+    ? declared
+    : (SUPPORTED_NETWORKS.includes(name as NetworkOption) ? name as NetworkOption : undefined);
+  return { name, network };
+}
+
+/**
  * Resolves the default Bitcoin network for offline identifier creation when no
  * `--network` flag is given. Resolution order: the config file's
- * `defaults.network`, then an active profile named for a network (an explicit
- * `--profile` flag or `defaults.profile`), then `regtest` as the development
+ * `defaults.network`, then the active profile's network (its explicit `network`
+ * field, else its network-derived name), then `regtest` as the development
  * fallback. Generation itself is offline; this only fixes which network the
  * identifier encodes.
  */
@@ -249,12 +385,100 @@ export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkO
   const explicit = file?.defaults?.network;
   if (explicit && SUPPORTED_NETWORKS.includes(explicit)) return explicit;
 
-  const profile = overrides?.profile ?? file?.defaults?.profile;
-  if (profile && SUPPORTED_NETWORKS.includes(profile as NetworkOption)) {
-    return profile as NetworkOption;
-  }
+  const { network } = resolveActiveProfile(file, overrides);
+  if (network) return network;
 
   return 'regtest';
+}
+
+/**
+ * Reports a coherence conflict between the network a `create` run is about to
+ * encode and the network the active profile declares, so the CLI can warn
+ * instead of silently minting an identifier on one network while wiring
+ * endpoints for another. Returns `undefined` when the active profile declares
+ * no network or agrees with the one being encoded.
+ */
+export function profileNetworkMismatch(
+  network   : NetworkOption,
+  overrides?: ConnectionOverrides,
+): { profile: string; declared: NetworkOption } | undefined {
+  // This drives only a warning, so a malformed config must not break an otherwise
+  // offline `create`; a genuinely broken config is still surfaced loudly by any
+  // command that actually resolves a connection.
+  let file: ConfigFile | undefined;
+  try {
+    file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  } catch {
+    return undefined;
+  }
+  const { name, network: declared } = resolveActiveProfile(file, overrides);
+  if (name && declared && declared !== network) return { profile: name, declared };
+  return undefined;
+}
+
+/**
+ * Resolves the effective output format: the `-o/--output` flag, then the
+ * `BTCR2_OUTPUT` environment variable, then the config file's `defaults.output`,
+ * then `'text'`. A malformed config never blocks output resolution (the command's
+ * own read path surfaces it); output format falls back to `'text'` instead.
+ */
+export function resolveOutputFormat(options: { output?: string; config?: string }): OutputFormat {
+  const candidates: Array<string | undefined> = [
+    blankToUndef(options.output),
+    process.env.BTCR2_OUTPUT || undefined,
+  ];
+  try {
+    candidates.push(readConfigFile(options.config ?? defaultConfigPath())?.defaults?.output);
+  } catch {
+    // Output format is cosmetic; a broken config is reported by the command
+    // itself rather than aborting here (which would block a recovery command).
+  }
+  for (const candidate of candidates) {
+    if (candidate === 'json' || candidate === 'text') return candidate;
+  }
+  return 'text';
+}
+
+/**
+ * The resolved RPC credential unit: url, user, and pass drawn from a single
+ * precedence layer, tagged with that layer's provenance. `pass` is kept raw so a
+ * secret-ref (`env:`/`file:`) can be resolved by the caller.
+ */
+interface RpcUnit {
+  src   : Provenance;
+  url?  : string;
+  user? : string;
+  pass? : string;
+}
+
+/**
+ * Resolves the RPC credential unit atomically: the highest-precedence layer that
+ * supplies a url, else the highest that supplies a username or password. url,
+ * user, and pass therefore always come from one layer, so a host from one layer
+ * is never handed another layer's credentials (ADR 074). When no layer supplies a
+ * url, the credentials still resolve (so they reach the SDK's per-network default
+ * host, e.g. regtest's, without the url being restated). Returns `undefined` when
+ * no layer supplies a url or a credential.
+ */
+function resolveRpcUnit(
+  overrides?    : ConnectionOverrides,
+  env?          : ConnectionOverrides,
+  fileOverrides?: ConnectionOverrides,
+): RpcUnit | undefined {
+  const layers: Array<{ src: Provenance; url?: string; user?: string; pass?: string }> = [
+    { src: 'flag', url: overrides?.btcRpcUrl,     user: overrides?.btcRpcUser,     pass: overrides?.btcRpcPass },
+    { src: 'env',  url: env?.btcRpcUrl,           user: env?.btcRpcUser,           pass: env?.btcRpcPass },
+    { src: 'file', url: fileOverrides?.btcRpcUrl, user: fileOverrides?.btcRpcUser, pass: fileOverrides?.btcRpcPass },
+  ];
+  const withUrl = layers.find(l => blankToUndef(l.url) !== undefined);
+  if (withUrl) {
+    return { src: withUrl.src, url: blankToUndef(withUrl.url), user: blankToUndef(withUrl.user), pass: blankToUndef(withUrl.pass) };
+  }
+  const withCreds = layers.find(l => blankToUndef(l.user) !== undefined || blankToUndef(l.pass) !== undefined);
+  if (withCreds) {
+    return { src: withCreds.src, url: undefined, user: blankToUndef(withCreds.user), pass: blankToUndef(withCreds.pass) };
+  }
+  return undefined;
 }
 
 /**
@@ -268,54 +492,433 @@ export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkO
  * When no `--profile` is given, the network name is used as the profile key
  * (e.g. a regtest DID auto-selects the `"regtest"` profile).
  */
-function resolveConnectionConfig(
+export function resolveConnectionConfig(
   network?  : NetworkOption,
   overrides?: ConnectionOverrides,
 ): { btc?: BitcoinApiConfig; cas?: CasConfig } {
   if (!network) return {};
 
-  // Layer 1: Config file profile (lowest precedence of the three override layers)
+  // Layer 1: Config file profile (lowest precedence of the three override layers).
+  // The active-profile name is resolved through the same shared helper as
+  // resolveDefaultNetwork so the two cannot disagree about which profile is live.
   const configPath = overrides?.config ?? defaultConfigPath();
   const file = readConfigFile(configPath);
-  const profileName = overrides?.profile ?? file?.defaults?.profile ?? network;
+  const { name: activeProfile } = resolveActiveProfile(file, overrides);
+  const profileName = activeProfile ?? network;
   const fileOverrides = file ? profileToOverrides(file, profileName) : {};
 
   // Layer 2: Environment variables
   const env = readEnvOverrides();
 
-  // Merge: CLI flags -> env vars -> config file -> (network defaults handled by BitcoinConnection)
-  const merged: ConnectionOverrides = {
-    btcRest    : overrides?.btcRest    ?? env.btcRest    ?? fileOverrides.btcRest,
-    btcRpcUrl  : overrides?.btcRpcUrl  ?? env.btcRpcUrl  ?? fileOverrides.btcRpcUrl,
-    btcRpcUser : overrides?.btcRpcUser ?? env.btcRpcUser ?? fileOverrides.btcRpcUser,
-    btcRpcPass : overrides?.btcRpcPass ?? env.btcRpcPass ?? fileOverrides.btcRpcPass,
-    casGateway : overrides?.casGateway ?? env.casGateway ?? fileOverrides.casGateway,
-    casRpcUrl  : overrides?.casRpcUrl  ?? env.casRpcUrl  ?? fileOverrides.casRpcUrl,
-  };
+  // Blank-aware precedence merge: CLI flag -> env var -> config file. A blank at
+  // any layer defers to the next instead of masking it (mirrors the env layer's
+  // `|| undefined`), so an empty flag or profile field no longer silently reverts
+  // resolution to the SDK network default.
+  const pick = (flag?: string, envVal?: string, fileVal?: string): string | undefined =>
+    blankToUndef(flag) ?? blankToUndef(envVal) ?? blankToUndef(fileVal);
+
+  const profileBtc = file?.profiles?.[profileName]?.btc;
+  const profileCas = file?.profiles?.[profileName]?.cas;
 
   const btc: BitcoinApiConfig = { network };
 
-  if (merged.btcRest) {
-    btc.rest = { host: merged.btcRest };
+  // REST host and headers. Headers apply even without a host override, layering
+  // onto the per-network default host inside the api's config merge, so an
+  // authenticated Esplora/mempool endpoint can be reached with the default host.
+  const btcRest = pick(overrides?.btcRest, env.btcRest, fileOverrides.btcRest);
+  const restHeaders = mergeHeaders(profileBtc?.headers, parseHeaderList(overrides?.btcRestHeader, '--btc-rest-header'));
+  if (btcRest || restHeaders) {
+    btc.rest = { ...(btcRest ? { host: btcRest } : {}), ...(restHeaders ? { headers: restHeaders } : {}) };
   }
 
-  if (merged.btcRpcUrl) {
+  // Resolve the RPC endpoint as one atomic credential unit (url + user + pass from
+  // one layer), plus the orthogonal wallet and header augmentations.
+  const rpcUnit = resolveRpcUnit(overrides, env, fileOverrides);
+  const rpcWallet = pick(overrides?.btcRpcWallet, undefined, profileBtc?.wallet);
+  const rpcHeaders = mergeHeaders(profileBtc?.rpcHeaders, parseHeaderList(overrides?.btcRpcHeader, '--btc-rpc-header'));
+
+  // Build an RPC config only when a host will actually exist to talk to: either
+  // the unit supplies a url, or the network has a default RPC host (regtest).
+  // Wallet/header (or credential) knobs alone with no host would otherwise point
+  // a phantom client at the default 127.0.0.1:8332 and, on public networks, flip
+  // the connection to "has RPC" spuriously (and could leak a header credential
+  // meant for a remote proxy). The pass-file fallback is read lazily inside this
+  // block, so a set-but-unreadable BTCR2_BTC_RPC_PASS_FILE never aborts a command
+  // that uses no RPC at all.
+  const networkHasDefaultRpc = DEFAULT_BITCOIN_NETWORK_CONFIG[network].rpc !== undefined;
+  const wantsRpc = rpcUnit !== undefined || rpcWallet !== undefined || rpcHeaders !== undefined;
+  const hasRpcHost = rpcUnit?.url !== undefined || networkHasDefaultRpc;
+  if (wantsRpc && hasRpcHost) {
+    const password = resolveSecretRef(rpcUnit?.pass) ?? readRpcPassFile();
     btc.rpc = {
-      host     : merged.btcRpcUrl,
-      username : merged.btcRpcUser,
-      password : merged.btcRpcPass,
+      ...(rpcUnit?.url  !== undefined ? { host: rpcUnit.url } : {}),
+      ...(rpcUnit?.user !== undefined ? { username: rpcUnit.user } : {}),
+      ...(password      !== undefined ? { password } : {}),
+      ...(rpcWallet ? { wallet: rpcWallet } : {}),
+      ...(rpcHeaders ? { headers: rpcHeaders } : {}),
     };
   }
+
+  // Bitcoin request timeout. No default: honored only when explicitly set, so
+  // callers that rely on unbounded waits are unaffected (ADR 076).
+  const btcTimeout = resolveTimeout(overrides?.btcTimeout, process.env[ENV_VARS.BTC_TIMEOUT], profileBtc?.timeoutMs, '--btc-timeout', 1);
+  if (btcTimeout !== undefined) btc.timeoutMs = btcTimeout;
 
   // A configured RPC endpoint is writable and takes precedence over the
   // read-only gateway (matching the api's CasConfig priority: rpcUrl > gateway).
   // Both may be set; the api selects one executor from them.
+  const casGateway = pick(overrides?.casGateway, env.casGateway, fileOverrides.casGateway);
+  const casRpcUrl  = pick(overrides?.casRpcUrl,  env.casRpcUrl,  fileOverrides.casRpcUrl);
+  const casTimeout = resolveTimeout(overrides?.casTimeout, process.env[ENV_VARS.CAS_TIMEOUT], profileCas?.timeoutMs, '--cas-timeout');
   const cas: CasConfig = {};
-  if (merged.casGateway) cas.gateway = merged.casGateway;
-  if (merged.casRpcUrl) cas.rpcUrl = merged.casRpcUrl;
-  const hasCas = merged.casGateway || merged.casRpcUrl;
+  if (casGateway) cas.gateway = casGateway;
+  if (casRpcUrl)  cas.rpcUrl  = casRpcUrl;
+  if (casTimeout !== undefined) {
+    cas.timeoutMs = casTimeout;
+    // A timeout needs an endpoint to attach to. When none is configured, fall
+    // back to the same default gateway the api would otherwise apply, so the
+    // timeout is honored rather than dropped (the api only defaults the gateway
+    // when the whole cas config is absent).
+    if (!casGateway && !casRpcUrl) cas.gateway = DEFAULT_CAS_GATEWAY;
+  }
+  const hasCas = casGateway || casRpcUrl || casTimeout !== undefined;
 
   return { btc, ...(hasCas && { cas }) };
+}
+
+/**
+ * Resolves a millisecond timeout from a flag string, an env string, then a
+ * config-file number, in precedence order. Returns `undefined` when none is set
+ * (preserving unbounded behavior). Throws a {@link CLIError} for a value below
+ * `min` or not a finite number. `min` is `0` for CAS (where `0` disables the
+ * timeout) and `1` for the Bitcoin timeout (where `0` would abort every request
+ * immediately, which is never intended).
+ */
+function resolveTimeout(flag?: string, envVal?: string, fileVal?: number, flagName = 'timeout', min = 0): number | undefined {
+  const raw = blankToUndef(flag) ?? blankToUndef(envVal) ?? (typeof fileVal === 'number' ? String(fileVal) : undefined);
+  if (raw === undefined) return undefined;
+  const ms = Number(raw);
+  if (!Number.isFinite(ms) || ms < min) {
+    throw new CLIError(
+      `Invalid ${flagName} value "${raw}": expected a number of milliseconds >= ${min}.`,
+      'INVALID_ARGUMENT_ERROR',
+      { value: raw },
+    );
+  }
+  return ms;
+}
+
+/**
+ * Parses repeatable `Key: Value` header flag values into a header map. Returns
+ * `undefined` for an empty list. Throws a {@link CLIError} for an entry missing a
+ * colon or with an empty key.
+ */
+export function parseHeaderList(list?: string[], flagName = '--header'): Record<string, string> | undefined {
+  if (!list || list.length === 0) return undefined;
+  const headers: Record<string, string> = {};
+  for (const entry of list) {
+    const idx = entry.indexOf(':');
+    const key = idx === -1 ? '' : entry.slice(0, idx).trim();
+    if (idx === -1 || key === '') {
+      throw new CLIError(
+        `Invalid ${flagName} "${entry}": expected "Key: Value".`,
+        'INVALID_ARGUMENT_ERROR',
+        { header: entry },
+      );
+    }
+    headers[key] = entry.slice(idx + 1).trim();
+  }
+  return headers;
+}
+
+/**
+ * Merges a base header map (from the config-file profile) with an override map
+ * (from flags), with the override winning per key. Returns `undefined` when both
+ * are absent so callers can skip attaching an empty header map.
+ */
+function mergeHeaders(
+  base?     : Record<string, string>,
+  override? : Record<string, string>,
+): Record<string, string> | undefined {
+  if (!base && !override) return undefined;
+  return { ...base, ...override };
+}
+
+/** Environment variable naming a file whose contents are the Bitcoin Core RPC password. */
+export const ENV_RPC_PASS_FILE = 'BTCR2_BTC_RPC_PASS_FILE';
+
+/** Removes at most one trailing newline, matching the keystore-passphrase normalization. */
+function trimTrailingNewline(value: string): string {
+  return value.replace(/\r?\n$/, '');
+}
+
+/** Reads a secret file, throwing a {@link CLIError} (not a raw Node error) that names the path and source. */
+function readSecretFile(path: string, source: string): string {
+  try {
+    return trimTrailingNewline(readFileSync(path, 'utf-8'));
+  } catch (error: unknown) {
+    throw new CLIError(
+      `Could not read the RPC password ${source} at ${path}: ${(error as Error).message}`,
+      'CONFIG_READ_ERROR',
+      { path },
+    );
+  }
+}
+
+/**
+ * Resolves an RPC-password secret reference to its literal value: `env:<VAR>`
+ * reads the named environment variable, `file:<path>` reads the file, and any
+ * other value is returned as-is. A trailing newline is trimmed from file/env
+ * sources so a secret written by `echo` matches an inline value (ADR 077).
+ */
+export function resolveSecretRef(value?: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (value.startsWith('env:')) {
+    const fromEnv = process.env[value.slice(4)];
+    return fromEnv === undefined ? undefined : trimTrailingNewline(fromEnv);
+  }
+  if (value.startsWith('file:')) {
+    return readSecretFile(value.slice(5), 'file reference');
+  }
+  return value;
+}
+
+/** Reads the RPC password from an {@link ENV_RPC_PASS_FILE}-named file, if set. */
+function readRpcPassFile(): string | undefined {
+  const path = process.env[ENV_RPC_PASS_FILE];
+  if (!path) return undefined;
+  return readSecretFile(path, `file named by ${ENV_RPC_PASS_FILE}`);
+}
+
+/**
+ * Resolves the beacon {@link BroadcastOptions} for an update/deactivate from the
+ * fee-rate and change-address knobs, following the CLI precedence chain.
+ *
+ * - Fee rate: `--fee-rate` flag, then `BTCR2_FEE_RATE`, then profile
+ *   `btc.feeRate`. A positive sats/vByte value wrapped in a `StaticFeeEstimator`.
+ * - Change address: `--change-address` flag, then profile `btc.changeAddress`
+ *   (no env, since a change address is DID/network-specific). Validated against
+ *   the DID network by the beacon at broadcast time.
+ *
+ * Returns `undefined` when neither is set, so the SDK defaults (5 sat/vB, change
+ * back to the beacon address) still apply.
+ */
+export function resolveBroadcastOptions(
+  network  : NetworkOption,
+  overrides: ConnectionOverrides | undefined,
+  flags    : { feeRate?: string; changeAddress?: string },
+): BroadcastOptions | undefined {
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  const { name: activeProfile } = resolveActiveProfile(file, overrides);
+  const profileBtc = file?.profiles?.[activeProfile ?? network]?.btc;
+
+  const options: BroadcastOptions = {};
+
+  const feeRateRaw = blankToUndef(flags.feeRate)
+    ?? blankToUndef(process.env[ENV_VARS.FEE_RATE])
+    ?? (typeof profileBtc?.feeRate === 'number' ? String(profileBtc.feeRate) : undefined);
+  if (feeRateRaw !== undefined) options.feeEstimator = new StaticFeeEstimator(parseFeeRate(feeRateRaw));
+
+  const changeAddress = blankToUndef(flags.changeAddress) ?? blankToUndef(profileBtc?.changeAddress);
+  if (changeAddress) options.changeAddress = changeAddress;
+
+  return options.feeEstimator || options.changeAddress ? options : undefined;
+}
+
+/** Parses a positive sats/vByte fee rate, throwing a {@link CLIError} otherwise. */
+function parseFeeRate(raw: string): number {
+  const rate = Number(raw);
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new CLIError(
+      `Invalid --fee-rate "${raw}": expected a positive number of sats per vByte.`,
+      'INVALID_ARGUMENT_ERROR',
+      { value: raw },
+    );
+  }
+  return rate;
+}
+
+/** Which precedence layer a resolved value came from. */
+export type Provenance = 'flag' | 'env' | 'file' | 'default';
+
+/** A resolved value paired with the layer it came from. */
+export interface EffectiveEntry {
+  value  : string | number | undefined;
+  source : Provenance;
+}
+
+/**
+ * The resolved connection config with per-value provenance, the shape behind
+ * `config effective`. Values are read through the real resolver (the constructed
+ * api and {@link resolveConnectionConfig}) so they cannot drift from what a live
+ * command would use; the `source` tag names the layer the merge selected.
+ */
+export interface EffectiveConfig {
+  network : NetworkOption;
+  profile : string | undefined;
+  btc : {
+    rest      : EffectiveEntry;
+    rpcUrl    : EffectiveEntry;
+    rpcUser   : EffectiveEntry;
+    rpcPass   : EffectiveEntry;
+    rpcWallet : EffectiveEntry;
+    timeoutMs : EffectiveEntry;
+  };
+  cas : {
+    gateway   : EffectiveEntry;
+    rpcUrl    : EffectiveEntry;
+    timeoutMs : EffectiveEntry;
+  };
+}
+
+/**
+ * Resolves the effective connection config with provenance for `config effective`.
+ * The btc values are read back from the constructed api (so SDK network defaults
+ * are reflected), the cas and timeout values from {@link resolveConnectionConfig},
+ * and each `source` is derived by the same precedence order the merge uses.
+ */
+export function resolveEffectiveConfig(network: NetworkOption, overrides?: ConnectionOverrides): EffectiveConfig {
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  const { name: activeProfile } = resolveActiveProfile(file, overrides);
+  const profileName = activeProfile ?? network;
+  const fileOv = file ? profileToOverrides(file, profileName) : {};
+  const profileBtc = file?.profiles?.[profileName]?.btc;
+  const profileCas = file?.profiles?.[profileName]?.cas;
+  const env = readEnvOverrides();
+
+  const api = defaultApiFactory(network, overrides);
+  const restCfg = api.btc.connection.rest.config;
+  const rpcCfg = api.btc.connection.rpc?.config;
+  const conn = resolveConnectionConfig(network, overrides);
+
+  const src = (flag?: string, envVal?: string, fileVal?: unknown): Provenance =>
+    blankToUndef(flag) !== undefined ? 'flag'
+      : blankToUndef(envVal) !== undefined ? 'env'
+        : (fileVal !== undefined && fileVal !== null && String(fileVal).trim() !== '') ? 'file'
+          : 'default';
+
+  // CAS has no client to read back from; derive its resolved endpoint from the
+  // connection resolver, defaulting the gateway the way the api would.
+  const casGatewayVal = conn.cas?.gateway ?? (conn.cas?.rpcUrl ? undefined : DEFAULT_CAS_GATEWAY);
+
+  // RPC url/user/pass provenance follows the atomic-credential unit, so a value's
+  // reported source is the layer the merge actually bound it to (never an
+  // independent per-field guess that could disagree with the resolver). A password
+  // taken from BTCR2_BTC_RPC_PASS_FILE when the unit supplied none is env-sourced.
+  const rpcUnit = resolveRpcUnit(overrides, env, fileOv);
+  const rpcSrc = rpcUnit?.src ?? 'default';
+  const passFromFile = rpcUnit?.pass === undefined
+    && process.env[ENV_RPC_PASS_FILE] !== undefined
+    && rpcCfg?.password !== undefined;
+
+  return {
+    network,
+    profile : activeProfile,
+    btc     : {
+      rest      : { value: restCfg.host,     source: src(overrides?.btcRest, env.btcRest, fileOv.btcRest) },
+      rpcUrl    : { value: rpcCfg?.host,      source: rpcUnit?.url  !== undefined ? rpcSrc : 'default' },
+      rpcUser   : { value: rpcCfg?.username,  source: rpcUnit?.user !== undefined ? rpcSrc : 'default' },
+      rpcPass   : { value: rpcCfg?.password,  source: rpcUnit?.pass !== undefined ? rpcSrc : (passFromFile ? 'env' : 'default') },
+      rpcWallet : { value: rpcCfg?.wallet,    source: src(overrides?.btcRpcWallet, undefined, profileBtc?.wallet) },
+      timeoutMs : { value: conn.btc?.timeoutMs, source: src(overrides?.btcTimeout, process.env[ENV_VARS.BTC_TIMEOUT], profileBtc?.timeoutMs) },
+    },
+    cas : {
+      gateway   : { value: casGatewayVal,       source: src(overrides?.casGateway, env.casGateway,                    fileOv.casGateway) },
+      rpcUrl    : { value: conn.cas?.rpcUrl,     source: src(overrides?.casRpcUrl,  env.casRpcUrl,                     fileOv.casRpcUrl) },
+      timeoutMs : { value: conn.cas?.timeoutMs,  source: src(overrides?.casTimeout, process.env[ENV_VARS.CAS_TIMEOUT], profileCas?.timeoutMs) },
+    },
+  };
+}
+
+/** One endpoint reachability check produced by `config doctor`. */
+export interface DoctorCheck {
+  endpoint : 'btc-rest' | 'btc-rpc' | 'cas';
+  target   : string;
+  ok       : boolean;
+  detail?  : string;
+}
+
+/** Result of `config doctor`: per-endpoint reachability and any coherence warning. */
+export interface DoctorReport {
+  checks     : DoctorCheck[];
+  coherence? : { profile: string; declared: NetworkOption; encoding: NetworkOption };
+}
+
+/** Default per-probe timeout (ms) for `config doctor`. */
+const DOCTOR_PROBE_TIMEOUT_MS = 5000;
+
+/** Fetches a URL with a bounded timeout, reporting reachability rather than throwing. */
+async function probeEndpoint(
+  endpoint : DoctorCheck['endpoint'],
+  target   : string,
+  url      : string,
+  opts?    : { method?: 'GET' | 'POST'; headers?: Record<string, string> },
+): Promise<DoctorCheck> {
+  try {
+    const res = await fetch(url, {
+      method  : opts?.method ?? 'GET',
+      headers : opts?.headers,
+      signal  : AbortSignal.timeout(DOCTOR_PROBE_TIMEOUT_MS),
+    });
+    return res.ok
+      ? { endpoint, target, ok: true }
+      : { endpoint, target, ok: false, detail: `HTTP ${res.status}` };
+  } catch (error) {
+    return { endpoint, target, ok: false, detail: (error as Error).message };
+  }
+}
+
+/** Races a promise against a timeout so a stalled RPC call cannot hang `doctor`. */
+function withProbeTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([ promise, timeout ]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Probes reachability of the resolved endpoints for `config doctor`: a
+ * lightweight REST call against btc-rest, a `getblockchaininfo` against btc-rpc
+ * when configured, and a reachability check against the resolved CAS. Also
+ * surfaces the profile/network coherence warning. Reads and touches the network;
+ * never writes.
+ */
+export async function runDoctor(network: NetworkOption, overrides?: ConnectionOverrides): Promise<DoctorReport> {
+  const api = defaultApiFactory(network, overrides);
+  const checks: DoctorCheck[] = [];
+
+  const restHost = api.btc.connection.rest.config.host.replace(/\/+$/, '');
+  checks.push(await probeEndpoint('btc-rest', restHost, `${restHost}/blocks/tip/height`, { headers: api.btc.connection.rest.config.headers }));
+
+  const rpc = api.btc.connection.rpc;
+  if (rpc) {
+    const target = rpc.config.host ?? '(default rpc)';
+    try {
+      await withProbeTimeout(rpc.getBlockchainInfo(), DOCTOR_PROBE_TIMEOUT_MS);
+      checks.push({ endpoint: 'btc-rpc', target, ok: true });
+    } catch (error) {
+      checks.push({ endpoint: 'btc-rpc', target, ok: false, detail: (error as Error).message });
+    }
+  }
+
+  // A writable IPFS RPC (Kubo) answers only POST, so a bare GET would falsely
+  // report a healthy node as down; probe its version endpoint with POST. A
+  // read-only gateway answers a plain GET on its base URL.
+  const conn = resolveConnectionConfig(network, overrides);
+  if (conn.cas?.rpcUrl) {
+    const base = conn.cas.rpcUrl.replace(/\/+$/, '');
+    checks.push(await probeEndpoint('cas', conn.cas.rpcUrl, `${base}/api/v0/version`, { method: 'POST' }));
+  } else {
+    const gateway = (conn.cas?.gateway ?? DEFAULT_CAS_GATEWAY).replace(/\/+$/, '');
+    checks.push(await probeEndpoint('cas', gateway, gateway));
+  }
+
+  const mismatch = profileNetworkMismatch(network, overrides);
+  return {
+    checks,
+    ...(mismatch ? { coherence: { profile: mismatch.profile, declared: mismatch.declared, encoding: network } } : {}),
+  };
 }
 
 /**
@@ -340,9 +943,39 @@ export function defaultApiFactory(network?: NetworkOption, overrides?: Connectio
  */
 function buildKeystoreKms(overrides?: ConnectionOverrides): KeyManager {
   return new FileBackedKeyManager({
-    path          : overrides?.keystore ?? defaultKeystorePath(),
+    path          : resolveKeystorePath(overrides),
     getPassphrase : () => acquirePassphrase({ passphraseFile: overrides?.passphraseFile }),
   });
+}
+
+/**
+ * Resolves the keystore file path: the `--keystore` flag, else the active
+ * profile's `identity.keystore`, else the default XDG keystore path. The flag
+ * always wins over the profile default.
+ */
+export function resolveKeystorePath(overrides?: ConnectionOverrides): string {
+  return overrides?.keystore ?? activeProfileIdentity(overrides)?.keystore ?? defaultKeystorePath();
+}
+
+/**
+ * Reads the active profile's `identity` block (keystore + default signing key),
+ * or `undefined` when no profile is active. A profile is active only when
+ * selected by `--profile` or the config's `defaults.profile`.
+ */
+function activeProfileIdentity(overrides?: ConnectionOverrides): { keystore?: string; default?: string } | undefined {
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  const { name } = resolveActiveProfile(file, overrides);
+  return name ? file?.profiles?.[name]?.identity : undefined;
+}
+
+/**
+ * Resolves the signing-key reference for update/deactivate: the `--signing-key`
+ * flag, else the active profile's `identity.default`, else `undefined` (letting
+ * the KMS fall back to its active key). The flag always wins over the profile
+ * default, consistent with the flag -> profile precedence used elsewhere.
+ */
+export function resolveSigningKeyRef(overrides?: ConnectionOverrides): string | undefined {
+  return blankToUndef(overrides?.signingKey) ?? blankToUndef(activeProfileIdentity(overrides)?.default);
 }
 
 /**

--- a/packages/cli/src/keystore/paths.ts
+++ b/packages/cli/src/keystore/paths.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { blankToUndef } from '../types.js';
 
 /**
  * Default keystore file path, following the XDG Base Directory Specification's
@@ -13,8 +14,8 @@ import { join } from 'node:path';
  * 3. `~/.local/share/btcr2/keystore.json` (fallback)
  */
 export function defaultKeystorePath(): string {
-  const base = process.env.XDG_DATA_HOME
-    ?? process.env.LOCALAPPDATA
+  const base = blankToUndef(process.env.XDG_DATA_HOME)
+    ?? blankToUndef(process.env.LOCALAPPDATA)
     ?? join(homedir(), '.local', 'share');
   return join(base, 'btcr2', 'keystore.json');
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,5 +1,58 @@
 import type { CommandResult, GlobalOptions } from './types.js';
 
+/** Placeholder printed in place of a redacted secret value. */
+export const REDACTED = '********';
+
+/**
+ * Key names whose (scalar) values are treated as secrets and redacted in printed
+ * output. Covers RPC passwords plus header credentials (`Authorization`, API
+ * keys, bearer tokens) that a profile can now carry in `btc.headers`/`rpcHeaders`.
+ */
+const SECRET_KEY = /(pass|secret|token|auth|api[-_]?key|credential|bearer)/i;
+
+/** Whether a config key name looks like a secret (so its scalar value should be redacted). */
+export function isSecretKey(key: string): boolean {
+  return SECRET_KEY.test(key);
+}
+
+/**
+ * Masks the password in a `scheme://user:pass@host` URL, leaving the rest of the
+ * value verbatim. A credential embedded in an endpoint URL (e.g. `rpcUrl`) is not
+ * caught by key-name matching, so it is scrubbed here regardless of the key.
+ */
+export function scrubUrlUserinfo(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value.replace(/^([a-z][a-z0-9+.-]*:\/\/[^/@:]+):[^/@]*@/i, `$1:${REDACTED}@`);
+}
+
+/**
+ * Returns a deep copy of `value` with secret scalar values replaced by
+ * {@link REDACTED}, so routine introspection (`config get`/`list`/`effective`)
+ * does not print RPC passwords or other secrets into terminal scrollback and CI
+ * logs. A secret-named key redacts only a scalar value (an object under such a
+ * key, e.g. a profile named `access-token`, is still traversed, not wholesale
+ * masked). Passwords embedded in URL values are scrubbed regardless of key name.
+ * When `keyName` is a secret name, a directly-passed scalar value is redacted
+ * (used when a single leaf value is printed). Display-only: the stored config and
+ * the value used to connect are untouched.
+ */
+export function redactSecrets(value: unknown, keyName?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => redactSecrets(item));
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [ key, val ] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = redactSecrets(val, key);
+    }
+    return out;
+  }
+  if (keyName !== undefined && isSecretKey(keyName)) {
+    return value === undefined ? undefined : REDACTED;
+  }
+  return typeof value === 'string' ? scrubUrlUserinfo(value) : value;
+}
+
 /**
  * Formats a CommandResult for console output.
  * In 'json' mode, the full result is serialized.

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -2,6 +2,8 @@ import type { DidUpdateResult } from '@did-btcr2/api';
 import type { PatchOperation } from '@did-btcr2/common';
 import type { Btcr2DidDocument, ResolutionOptions } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
+import type { DoctorReport, EffectiveConfig } from './config.js';
+import type { ConfigIssue } from './config-schema.js';
 
 export type NetworkOption = 'bitcoin' | 'testnet3' | 'testnet4' | 'signet' | 'mutinynet' | 'regtest';
 export type OutputFormat = 'json' | 'text';
@@ -9,6 +11,17 @@ export type OutputFormat = 'json' | 'text';
 export const SUPPORTED_NETWORKS: NetworkOption[] = [
   'bitcoin', 'testnet3', 'testnet4', 'signet', 'mutinynet', 'regtest'
 ];
+
+/**
+ * Normalizes a blank value (empty or whitespace-only) to `undefined`, so a
+ * blank at any precedence layer defers to the next layer instead of masking it.
+ * A non-blank value is returned unchanged. This mirrors the `|| undefined`
+ * treatment the environment layer already applies in `readEnvOverrides`.
+ */
+export function blankToUndef(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value.trim() === '' ? undefined : value;
+}
 
 export interface ResolveCommandOptions {
   identifier : string;
@@ -40,6 +53,10 @@ export type CommandResult =
   | { action: 'config-set'; data: { path: string } }
   | { action: 'config-unset'; data: { path: string } }
   | { action: 'config-list'; data: unknown }
+  | { action: 'config-validate'; data: { ok: boolean; issues: ConfigIssue[] } }
+  | { action: 'config-effective'; data: EffectiveConfig }
+  | { action: 'config-path'; data: { config: string; keystore: string } }
+  | { action: 'config-doctor'; data: DoctorReport }
   | { action: 'profile-add'; data: { profile: string } }
   | { action: 'profile-use'; data: { profile: string } }
   | { action: 'profile-show'; data: unknown }
@@ -57,6 +74,11 @@ export interface GlobalOptions {
   btcRpcPass?    : string;
   casGateway?    : string;
   casRpcUrl?     : string;
+  btcTimeout?    : string;
+  casTimeout?    : string;
+  btcRestHeader? : string[];
+  btcRpcWallet?  : string;
+  btcRpcHeader?  : string[];
   keystore?      : string;
   passphraseFile?: string;
   signingKey?    : string;

--- a/packages/cli/tests/config-commands.spec.ts
+++ b/packages/cli/tests/config-commands.spec.ts
@@ -89,6 +89,190 @@ describe('config and profile commands', () => {
     expect(readCfg().profiles).to.not.have.property('signet');
   });
 
+  it('config set stores a known scalar path as a string (no JSON coercion)', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcUrl', '8080');
+    expect(readCfg().profiles.regtest.btc.rpcUrl).to.equal('8080');
+    expect(typeof readCfg().profiles.regtest.btc.rpcUrl).to.equal('string');
+  });
+
+  it('config set still JSON-parses a structured value at a non-scalar path', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'customFlag', 'true');
+    expect(readCfg().customFlag).to.equal(true);
+  });
+
+  it('a write refuses to clobber a malformed config file', async () => {
+    const malformed = '{ "profiles": {  ';
+    writeFileSync(cfg, malformed);
+    await run('config', 'set', 'defaults.network', 'regtest');
+    expect(err.join(' ')).to.match(/not valid JSON/i);
+    // The malformed-but-recoverable file is untouched, not overwritten with `{}`.
+    expect(readFileSync(cfg, 'utf-8')).to.equal(malformed);
+  });
+
+  it('honors config defaults.output for command output when no -o flag is given', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'defaults.output', 'json');
+    out = [];
+    const validKey = '02' + 'aa'.repeat(32);
+    await run('create', '-t', 'k', '-n', 'regtest', '-b', validKey);
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.action).to.equal('create');
+    expect(parsed.data).to.include('did:btcr2:');
+  });
+
+  it('config set rejects an invalid enum value for a known key', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'defaults.network', 'mainnett');
+    expect(err.join(' ')).to.match(/Expected one of/);
+    // The invalid value was not persisted.
+    expect(readCfg().defaults?.network).to.be.undefined;
+  });
+
+  it('config set warns but still writes an unknown path', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rset', 'http://typo');
+    expect(err.join(' ')).to.match(/not a known config path/);
+    expect(readCfg().profiles.regtest.btc.rset).to.equal('http://typo');
+  });
+
+  it('config validate passes on a freshly initialized config', async () => {
+    await run('config', 'init');
+    out = [];
+    await run('config', 'validate');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.ok).to.equal(true);
+    expect(parsed.issues).to.deep.equal([]);
+  });
+
+  it('config validate reports unknown keys', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rset', 'http://x'); // unknown path (warned)
+    out = [];
+    await run('config', 'validate');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.ok).to.equal(false);
+    expect(parsed.issues.some((i: { path: string }) => i.path === 'profiles.regtest.btc.rset')).to.equal(true);
+  });
+
+  it('config path prints the resolved config and keystore paths', async () => {
+    out = [];
+    await run('config', 'path');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.config).to.equal(cfg);
+    expect(parsed.keystore).to.be.a('string');
+  });
+
+  it('config effective reports resolved values with provenance', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rest', 'http://custom:3000');
+    out = [];
+    await run('config', 'effective', '-n', 'regtest');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.network).to.equal('regtest');
+    expect(parsed.btc.rest.value).to.equal('http://custom:3000');
+    expect(parsed.btc.rest.source).to.equal('file');
+  });
+
+  it('config doctor reports unreachable endpoints', async function () {
+    this.timeout(15000);
+    out = [];
+    await run(
+      '--btc-rest', 'http://127.0.0.1:1',
+      '--btc-rpc-url', 'http://127.0.0.1:1',
+      '--cas-gateway', 'http://127.0.0.1:1',
+      'config', 'doctor', '-n', 'regtest',
+    );
+    const parsed = JSON.parse(out.join('\n'));
+    const rest = parsed.checks.find((c: { endpoint: string }) => c.endpoint === 'btc-rest');
+    expect(rest.ok).to.equal(false);
+    expect(parsed.checks.every((c: { ok: boolean }) => c.ok === false)).to.equal(true);
+  });
+
+  it('config get redacts the rpc password by default', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');
+    out = [];
+    await run('config', 'get', 'profiles.regtest');
+    expect(out.join('\n')).to.not.contain('super-secret');
+    expect(out.join('\n')).to.contain('********');
+  });
+
+  it('config get --show-secrets reveals the rpc password', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');
+    out = [];
+    await run('config', 'get', 'profiles.regtest', '--show-secrets');
+    expect(out.join('\n')).to.contain('super-secret');
+  });
+
+  it('config get on the password leaf redacts it directly', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');
+    out = [];
+    await run('config', 'get', 'profiles.regtest.btc.rpcPass');
+    expect(out.join('\n')).to.not.contain('super-secret');
+    expect(out.join('\n')).to.contain('********');
+  });
+
+  it('config list redacts secrets by default', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');
+    out = [];
+    await run('config', 'list');
+    expect(out.join('\n')).to.not.contain('super-secret');
+    expect(out.join('\n')).to.contain('********');
+  });
+
+  it('config set rejects a prototype-polluting path', async () => {
+    await run('config', 'init');
+    await run('config', 'set', '__proto__.polluted', 'evil');
+    expect(err.join(' ')).to.match(/Illegal config path segment/);
+    expect(({} as Record<string, unknown>).polluted).to.be.undefined;
+  });
+
+  it('config set rejects a non-number for a numeric leaf', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.feeRate', 'lots');
+    expect(err.join(' ')).to.match(/expected a number/);
+    expect(readCfg().profiles.regtest.btc?.feeRate).to.be.undefined;
+  });
+
+  it('config set stores an identity path as a string (no numeric coercion)', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.identity.default', '12345');
+    expect(readCfg().profiles.regtest.identity.default).to.equal('12345');
+  });
+
+  it('config validate reports a newer-than-supported schemaVersion instead of throwing', async () => {
+    writeFileSync(cfg, JSON.stringify({ schemaVersion: 9999, profiles: {} }));
+    out = [];
+    await run('config', 'validate');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.ok).to.equal(false);
+    expect(parsed.issues.some((i: { path: string }) => i.path === 'schemaVersion')).to.equal(true);
+  });
+
+  it('profile show redacts the rpc password by default', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');
+    out = [];
+    await run('profile', 'show', 'regtest');
+    expect(out.join('\n')).to.not.contain('super-secret');
+    expect(out.join('\n')).to.contain('********');
+  });
+
+  it('config effective scrubs a password embedded in the rpc url', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcUrl', 'http://alice:s3cret@node:18443');
+    out = [];
+    await run('config', 'effective', '-n', 'regtest');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.btc.rpcUrl.value).to.not.contain('s3cret');
+    expect(parsed.btc.rpcUrl.value).to.contain('********');
+  });
+
   it('completion bash prints a completion script', async () => {
     await run('completion', 'bash');
     expect(out.join('\n')).to.contain('complete -F _btcr2 btcr2');

--- a/packages/cli/tests/config-schema.spec.ts
+++ b/packages/cli/tests/config-schema.spec.ts
@@ -1,0 +1,76 @@
+import { findConfigIssues, isKnownConfigPath, validateConfigSet } from '../src/config-schema.js';
+import { CLIError } from '../src/error.js';
+import { expect } from './helpers.js';
+
+describe('config-schema', () => {
+  describe('isKnownConfigPath', () => {
+    it('recognizes known leaf and intermediate paths', () => {
+      expect(isKnownConfigPath('defaults.network')).to.equal(true);
+      expect(isKnownConfigPath('profiles.regtest.btc.rest')).to.equal(true);
+      expect(isKnownConfigPath('profiles.anyname.cas.rpcUrl')).to.equal(true);
+      expect(isKnownConfigPath('profiles.anyname.btc')).to.equal(true);
+      expect(isKnownConfigPath('profiles.anyname.identity.keystore')).to.equal(true);
+    });
+
+    it('rejects unknown paths', () => {
+      expect(isKnownConfigPath('defaults.netwrok')).to.equal(false);
+      expect(isKnownConfigPath('profiles.regtest.btc.rset')).to.equal(false);
+      expect(isKnownConfigPath('nope')).to.equal(false);
+    });
+  });
+
+  describe('validateConfigSet', () => {
+    it('flags an unknown path (still writable)', () => {
+      expect(validateConfigSet('profiles.regtest.btc.rset', 'x')).to.deep.equal({ unknownPath: true });
+    });
+
+    it('accepts a known non-enum path', () => {
+      expect(validateConfigSet('profiles.regtest.btc.rest', 'http://x')).to.deep.equal({ unknownPath: false });
+    });
+
+    it('rejects an invalid network enum value', () => {
+      expect(() => validateConfigSet('defaults.network', 'mainnett')).to.throw(CLIError, /Expected one of/);
+    });
+
+    it('accepts a valid network enum value', () => {
+      expect(validateConfigSet('defaults.network', 'signet')).to.deep.equal({ unknownPath: false });
+    });
+
+    it('rejects an invalid output enum value', () => {
+      expect(() => validateConfigSet('defaults.output', 'yaml')).to.throw(CLIError, /"json" or "text"/);
+    });
+  });
+
+  describe('findConfigIssues', () => {
+    it('returns no issues for a clean config', () => {
+      const issues = findConfigIssues({
+        schemaVersion : 1,
+        defaults      : { network: 'regtest', output: 'text' },
+        profiles      : { regtest: { btc: { rest: 'http://x' } } },
+      }, 1);
+      expect(issues).to.deep.equal([]);
+    });
+
+    it('reports an unknown key', () => {
+      const issues = findConfigIssues({ profiles: { regtest: { btc: { rset: 'http://x' } } } }, 1);
+      expect(issues).to.have.length(1);
+      expect(issues[0].path).to.equal('profiles.regtest.btc.rset');
+      expect(issues[0].issue).to.match(/unknown/);
+    });
+
+    it('reports an invalid enum value', () => {
+      const issues = findConfigIssues({ defaults: { network: 'mainnett' } }, 1);
+      expect(issues.some(i => i.path === 'defaults.network')).to.equal(true);
+    });
+
+    it('reports a newer-than-supported schemaVersion', () => {
+      const issues = findConfigIssues({ schemaVersion: 99 }, 1);
+      expect(issues.some(i => i.path === 'schemaVersion')).to.equal(true);
+    });
+
+    it('reports an unknown subtree once, without descending into it', () => {
+      const issues = findConfigIssues({ weird: { a: 1, b: 2 } }, 1);
+      expect(issues).to.deep.equal([ { path: 'weird', issue: 'unknown key' } ]);
+    });
+  });
+});

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -1,15 +1,29 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
+import { StaticFeeEstimator } from '@did-btcr2/method';
 import {
   defaultApiFactory,
   defaultConfigPath,
   ENV_VARS,
+  parseHeaderList,
+  profileNetworkMismatch,
   profileToOverrides,
   readConfigFile,
   readEnvOverrides,
+  resolveActiveProfile,
+  resolveBroadcastOptions,
+  resolveConnectionConfig,
+  resolveDefaultNetwork,
+  resolveKeystorePath,
+  resolveOutputFormat,
+  resolveSecretRef,
+  resolveSigningKeyRef,
 } from '../src/config.js';
 import type { ConfigFile } from '../src/config.js';
+import { CLIError } from '../src/error.js';
+import { defaultKeystorePath } from '../src/keystore/paths.js';
+import { blankToUndef } from '../src/types.js';
 import { expect } from './helpers.js';
 
 describe('readEnvOverrides', () => {
@@ -100,16 +114,30 @@ describe('readConfigFile', () => {
     expect(result).to.deep.equal(content);
   });
 
-  it('returns undefined for missing file', () => {
+  it('returns undefined only for a genuinely missing file (ENOENT)', () => {
     const result = readConfigFile(join(tempDir, 'nope.json'));
     expect(result).to.be.undefined;
   });
 
-  it('returns undefined for invalid JSON', () => {
+  it('throws (never silently undefined) for invalid JSON, naming the file', () => {
     const path = join(tempDir, 'bad.json');
     writeFileSync(path, 'not json');
+    expect(() => readConfigFile(path)).to.throw(CLIError, /not valid JSON/);
+    expect(() => readConfigFile(path)).to.throw(path);
+  });
+
+  it('reads a config whose schemaVersion is absent (migrated forward as earliest)', () => {
+    const path = join(tempDir, 'no-version.json');
+    writeFileSync(path, JSON.stringify({ profiles: { regtest: { btc: { rest: 'http://x' } } } }));
     const result = readConfigFile(path);
-    expect(result).to.be.undefined;
+    expect(result?.profiles?.regtest?.btc?.rest).to.equal('http://x');
+  });
+
+  it('refuses a config written by a newer schema version', () => {
+    const path = join(tempDir, 'future.json');
+    writeFileSync(path, JSON.stringify({ schemaVersion: 9999, profiles: {} }));
+    expect(() => readConfigFile(path)).to.throw(CLIError, /schemaVersion 9999/);
+    expect(() => readConfigFile(path)).to.throw(/Upgrade/);
   });
 });
 
@@ -327,5 +355,568 @@ describe('defaultApiFactory', () => {
     process.env[ENV_VARS.CAS_RPC_URL] = 'http://127.0.0.1:5001';
     const api = defaultApiFactory('regtest', { config: configPath });
     expect(api.cas.writable).to.equal(true);
+  });
+});
+
+describe('blankToUndef', () => {
+  it('maps empty and whitespace-only strings to undefined', () => {
+    expect(blankToUndef('')).to.be.undefined;
+    expect(blankToUndef('   ')).to.be.undefined;
+    expect(blankToUndef('\t\n')).to.be.undefined;
+    expect(blankToUndef(undefined)).to.be.undefined;
+  });
+
+  it('passes a non-blank value through unchanged', () => {
+    expect(blankToUndef('http://x')).to.equal('http://x');
+  });
+});
+
+describe('defaultConfigPath / defaultKeystorePath (empty XDG is unset)', () => {
+  const keys = [ 'XDG_CONFIG_HOME', 'APPDATA', 'XDG_DATA_HOME', 'LOCALAPPDATA' ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of keys) { saved[k] = process.env[k]; delete process.env[k]; }
+  });
+
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k];
+    }
+  });
+
+  it('treats an empty XDG_CONFIG_HOME as unset (absolute home path, never CWD-relative)', () => {
+    process.env.XDG_CONFIG_HOME = '';
+    const p = defaultConfigPath();
+    expect(isAbsolute(p)).to.equal(true);
+    expect(p).to.match(/[/\\]\.config[/\\]btcr2[/\\]config\.json$/);
+  });
+
+  it('honors a non-blank XDG_CONFIG_HOME', () => {
+    process.env.XDG_CONFIG_HOME = join(tmpdir(), 'xdg-custom');
+    expect(defaultConfigPath()).to.equal(join(tmpdir(), 'xdg-custom', 'btcr2', 'config.json'));
+  });
+
+  it('treats an empty XDG_DATA_HOME as unset for the keystore path', () => {
+    process.env.XDG_DATA_HOME = '';
+    const p = defaultKeystorePath();
+    expect(isAbsolute(p)).to.equal(true);
+    expect(p).to.match(/[/\\]\.local[/\\]share[/\\]btcr2[/\\]keystore\.json$/);
+  });
+});
+
+describe('resolveActiveProfile (unified profile/network resolution)', () => {
+  it('derives the network from the profile network field', () => {
+    const file: ConfigFile = { defaults: { profile: 'production' }, profiles: { production: { network: 'bitcoin' } } };
+    expect(resolveActiveProfile(file)).to.deep.equal({ name: 'production', network: 'bitcoin' });
+  });
+
+  it('falls back to the profile name when it is itself a network name', () => {
+    const file: ConfigFile = { defaults: { profile: 'signet' }, profiles: { signet: {} } };
+    expect(resolveActiveProfile(file)).to.deep.equal({ name: 'signet', network: 'signet' });
+  });
+
+  it('yields an undefined network for a non-network-named profile with no network field', () => {
+    const file: ConfigFile = { defaults: { profile: 'custom' }, profiles: { custom: {} } };
+    expect(resolveActiveProfile(file)).to.deep.equal({ name: 'custom', network: undefined });
+  });
+
+  it('prefers an explicit --profile flag over defaults.profile', () => {
+    const file: ConfigFile = {
+      defaults : { profile: 'signet' },
+      profiles : { signet: {}, staging: { network: 'testnet4' } },
+    };
+    expect(resolveActiveProfile(file, { profile: 'staging' })).to.deep.equal({ name: 'staging', network: 'testnet4' });
+  });
+});
+
+describe('resolveDefaultNetwork / profileNetworkMismatch', () => {
+  const tempDir = join(tmpdir(), 'btcr2-network-test');
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  const writeCfg = (name: string, content: ConfigFile): string => {
+    const p = join(tempDir, name);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  it('returns the active profile network field when set (the two resolvers agree)', () => {
+    const cfg = writeCfg('prod.json', { defaults: { profile: 'production' }, profiles: { production: { network: 'bitcoin' } } });
+    expect(resolveDefaultNetwork({ config: cfg })).to.equal('bitcoin');
+  });
+
+  it('lets defaults.network win over the active profile network', () => {
+    const cfg = writeCfg('both.json', {
+      defaults : { network: 'signet', profile: 'production' },
+      profiles : { production: { network: 'bitcoin' } },
+    });
+    expect(resolveDefaultNetwork({ config: cfg })).to.equal('signet');
+  });
+
+  it('falls back to regtest with no config file', () => {
+    expect(resolveDefaultNetwork({ config: join(tempDir, 'nope.json') })).to.equal('regtest');
+  });
+
+  it('flags a create-network / active-profile-network disagreement', () => {
+    const cfg = writeCfg('mismatch.json', { defaults: { profile: 'production' }, profiles: { production: { network: 'bitcoin' } } });
+    expect(profileNetworkMismatch('regtest', { config: cfg })).to.deep.equal({ profile: 'production', declared: 'bitcoin' });
+  });
+
+  it('returns undefined when the networks agree', () => {
+    const cfg = writeCfg('agree.json', { defaults: { profile: 'production' }, profiles: { production: { network: 'bitcoin' } } });
+    expect(profileNetworkMismatch('bitcoin', { config: cfg })).to.be.undefined;
+  });
+
+  it('returns undefined when the active profile declares no network', () => {
+    const cfg = writeCfg('nonet.json', { defaults: { profile: 'custom' }, profiles: { custom: {} } });
+    expect(profileNetworkMismatch('regtest', { config: cfg })).to.be.undefined;
+  });
+});
+
+describe('resolveOutputFormat', () => {
+  const tempDir = join(tmpdir(), 'btcr2-output-test');
+  let savedOutput: string | undefined;
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => { savedOutput = process.env.BTCR2_OUTPUT; delete process.env.BTCR2_OUTPUT; });
+
+  afterEach(() => {
+    if (savedOutput !== undefined) process.env.BTCR2_OUTPUT = savedOutput; else delete process.env.BTCR2_OUTPUT;
+  });
+
+  const writeCfg = (name: string, content: unknown): string => {
+    const p = join(tempDir, name);
+    writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content));
+    return p;
+  };
+
+  it('lets the flag win over env and config', () => {
+    const cfg = writeCfg('json-default.json', { defaults: { output: 'json' } });
+    process.env.BTCR2_OUTPUT = 'json';
+    expect(resolveOutputFormat({ output: 'text', config: cfg })).to.equal('text');
+  });
+
+  it('lets BTCR2_OUTPUT win over config defaults.output', () => {
+    const cfg = writeCfg('text-default.json', { defaults: { output: 'text' } });
+    process.env.BTCR2_OUTPUT = 'json';
+    expect(resolveOutputFormat({ config: cfg })).to.equal('json');
+  });
+
+  it('honors config defaults.output when no flag or env is set', () => {
+    const cfg = writeCfg('json-only.json', { defaults: { output: 'json' } });
+    expect(resolveOutputFormat({ config: cfg })).to.equal('json');
+  });
+
+  it('falls back to text when nothing is configured', () => {
+    expect(resolveOutputFormat({ config: join(tempDir, 'nope.json') })).to.equal('text');
+  });
+
+  it('never throws on a malformed config (falls back to text)', () => {
+    const cfg = writeCfg('broken.json', '{bad');
+    expect(resolveOutputFormat({ config: cfg })).to.equal('text');
+  });
+});
+
+describe('connection resolution (non-vacuous precedence)', () => {
+  const tempDir = join(tmpdir(), 'btcr2-precedence-test');
+  const saved: Record<string, string | undefined> = {};
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    for (const k of Object.values(ENV_VARS)) { saved[k] = process.env[k]; delete process.env[k]; }
+  });
+
+  afterEach(() => {
+    for (const k of Object.values(ENV_VARS)) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k];
+    }
+  });
+
+  const writeCfg = (name: string, content: ConfigFile): string => {
+    const p = join(tempDir, name);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  it('resolves the REST host from the config-file profile (not merely the network name)', () => {
+    const cfg = writeCfg('rest-host.json', { profiles: { regtest: { btc: { rest: 'http://profile-rest:3000' } } } });
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rest.config.host).to.equal('http://profile-rest:3000');
+  });
+
+  it('a CLI flag REST host wins over env and file (asserted on the resolved host)', () => {
+    const cfg = writeCfg('rest-flag.json', { profiles: { regtest: { btc: { rest: 'http://file-rest:3000' } } } });
+    process.env[ENV_VARS.BTC_REST] = 'http://env-rest:4000';
+    const api = defaultApiFactory('regtest', { config: cfg, btcRest: 'http://flag-rest:5000' });
+    expect(api.btc.connection.rest.config.host).to.equal('http://flag-rest:5000');
+  });
+
+  it('an env REST host wins over the file (asserted on the resolved host)', () => {
+    const cfg = writeCfg('rest-env.json', { profiles: { regtest: { btc: { rest: 'http://file-rest:3000' } } } });
+    process.env[ENV_VARS.BTC_REST] = 'http://env-rest:4000';
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rest.config.host).to.equal('http://env-rest:4000');
+  });
+
+  it('RPC url, user, and pass from a profile all reach the RPC client', () => {
+    const cfg = writeCfg('rpc-creds.json', {
+      profiles : { regtest: { btc: { rpcUrl: 'http://node-a:18443', rpcUser: 'alice', rpcPass: 's3cret' } } },
+    });
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rpc?.config.host).to.equal('http://node-a:18443');
+    expect(api.btc.connection.rpc?.config.username).to.equal('alice');
+    expect(api.btc.connection.rpc?.config.password).to.equal('s3cret');
+  });
+
+  it('a flag RPC url never inherits a profile\'s credentials (atomic credential unit)', () => {
+    const cfg = writeCfg('rpc-atomic.json', {
+      profiles : { regtest: { btc: { rpcUrl: 'http://node-a:18443', rpcUser: 'alice', rpcPass: 's3cret' } } },
+    });
+    const api = defaultApiFactory('regtest', { config: cfg, btcRpcUrl: 'http://node-b:18443' });
+    expect(api.btc.connection.rpc?.config.host).to.equal('http://node-b:18443');
+    expect(api.btc.connection.rpc?.config.username).to.be.undefined;
+    expect(api.btc.connection.rpc?.config.password).to.be.undefined;
+  });
+
+  it('a config-file defaults.profile selects a non-network-named profile\'s endpoints', () => {
+    const cfg = writeCfg('default-profile.json', {
+      defaults : { profile: 'custom' },
+      profiles : { custom: { btc: { rest: 'http://custom-rest:9000' } } },
+    });
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rest.config.host).to.equal('http://custom-rest:9000');
+  });
+
+  it('a blank flag defers to the configured layer instead of masking it', () => {
+    const cfg = writeCfg('blank-flag.json', { profiles: { regtest: { btc: { rest: 'http://file-rest:3000' } } } });
+    const api = defaultApiFactory('regtest', { config: cfg, btcRest: '   ' });
+    expect(api.btc.connection.rest.config.host).to.equal('http://file-rest:3000');
+  });
+
+  it('a profile REST header reaches the resolved REST client', () => {
+    const cfg = writeCfg('rest-header.json', {
+      profiles : { regtest: { btc: { headers: { Authorization: 'Bearer file' } } } },
+    });
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rest.config.headers).to.deep.equal({ Authorization: 'Bearer file' });
+  });
+
+  it('a profile RPC wallet reaches the resolved RPC client', () => {
+    const cfg = writeCfg('rpc-wallet.json', {
+      profiles : { regtest: { btc: { rpcUrl: 'http://node:18443', wallet: 'primary' } } },
+    });
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rpc?.config.wallet).to.equal('primary');
+  });
+});
+
+describe('parseHeaderList', () => {
+  it('parses "Key: Value" pairs into a header map', () => {
+    expect(parseHeaderList([ 'Authorization: Bearer abc', 'X-Api-Key: k1' ])).to.deep.equal({
+      Authorization : 'Bearer abc',
+      'X-Api-Key'   : 'k1',
+    });
+  });
+
+  it('returns undefined for an empty or missing list', () => {
+    expect(parseHeaderList([])).to.be.undefined;
+    expect(parseHeaderList(undefined)).to.be.undefined;
+  });
+
+  it('throws for an entry missing a colon', () => {
+    expect(() => parseHeaderList([ 'no-colon' ], '--btc-rest-header')).to.throw(CLIError, /Invalid --btc-rest-header/);
+  });
+
+  it('throws for an empty header name', () => {
+    expect(() => parseHeaderList([ ': value' ])).to.throw(CLIError, /expected "Key: Value"/);
+  });
+});
+
+describe('resolveConnectionConfig (I/O knobs)', () => {
+  const tempDir = join(tmpdir(), 'btcr2-knobs-test');
+  const saved: Record<string, string | undefined> = {};
+  const cfgPath = join(tempDir, 'nope.json');
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    for (const k of Object.values(ENV_VARS)) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of Object.values(ENV_VARS)) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k];
+    }
+  });
+
+  it('maps --btc-timeout to BitcoinApiConfig.timeoutMs', () => {
+    const { btc } = resolveConnectionConfig('regtest', { config: cfgPath, btcTimeout: '5000' });
+    expect(btc?.timeoutMs).to.equal(5000);
+  });
+
+  it('leaves timeoutMs unset (unbounded) when no timeout is given', () => {
+    const { btc } = resolveConnectionConfig('regtest', { config: cfgPath });
+    expect(btc?.timeoutMs).to.be.undefined;
+  });
+
+  it('rejects a non-numeric --btc-timeout', () => {
+    expect(() => resolveConnectionConfig('regtest', { config: cfgPath, btcTimeout: 'soon' }))
+      .to.throw(CLIError, /number of milliseconds/);
+  });
+
+  it('rejects --btc-timeout 0 (would abort every request immediately)', () => {
+    expect(() => resolveConnectionConfig('regtest', { config: cfgPath, btcTimeout: '0' }))
+      .to.throw(CLIError, /milliseconds >= 1/);
+  });
+
+  it('does not build an RPC config from wallet/headers alone on a public network (no phantom client)', () => {
+    const { btc } = resolveConnectionConfig('bitcoin', { config: cfgPath, btcRpcWallet: 'w1' });
+    expect(btc?.rpc).to.be.undefined;
+  });
+
+  it('reaches the regtest default RPC host with env credentials and no url', () => {
+    const { btc } = resolveConnectionConfig('regtest', {
+      config     : cfgPath,
+      btcRpcUser : 'polaruser',
+      btcRpcPass : 'polarpass',
+    });
+    // No url in any layer, but regtest has a default RPC host, so credentials are kept.
+    expect(btc?.rpc?.username).to.equal('polaruser');
+    expect(btc?.rpc?.password).to.equal('polarpass');
+    expect(btc?.rpc?.host).to.be.undefined; // host comes from the SDK default in the api merge
+  });
+
+  it('maps --cas-timeout to CasConfig.timeoutMs and attaches the default gateway', () => {
+    const { cas } = resolveConnectionConfig('regtest', { config: cfgPath, casTimeout: '0' });
+    expect(cas?.timeoutMs).to.equal(0);
+    // A timeout needs an endpoint; the default gateway is attached so it is honored.
+    expect(cas?.gateway).to.be.a('string');
+  });
+
+  it('maps --btc-rest-header into RestConfig.headers (no host override needed)', () => {
+    const { btc } = resolveConnectionConfig('regtest', { config: cfgPath, btcRestHeader: [ 'Authorization: Bearer t' ] });
+    expect(btc?.rest?.headers).to.deep.equal({ Authorization: 'Bearer t' });
+  });
+
+  it('merges profile REST headers under flag headers (flag wins per key)', () => {
+    const cfg = join(tempDir, 'headers.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { headers: { 'X-Api-Key': 'file', 'X-Env': 'prod' } } } },
+    }));
+    const { btc } = resolveConnectionConfig('regtest', { config: cfg, btcRestHeader: [ 'X-Api-Key: flag' ] });
+    expect(btc?.rest?.headers).to.deep.equal({ 'X-Api-Key': 'flag', 'X-Env': 'prod' });
+  });
+
+  it('maps --btc-rpc-wallet and --btc-rpc-header into RpcConfig alongside the url', () => {
+    const { btc } = resolveConnectionConfig('regtest', {
+      config       : cfgPath,
+      btcRpcUrl    : 'http://node:18443',
+      btcRpcWallet : 'w1',
+      btcRpcHeader : [ 'X-Auth: z' ],
+    });
+    expect(btc?.rpc?.host).to.equal('http://node:18443');
+    expect(btc?.rpc?.wallet).to.equal('w1');
+    expect(btc?.rpc?.headers).to.deep.equal({ 'X-Auth': 'z' });
+  });
+
+  it('reads btc.timeoutMs and cas.timeoutMs from the config-file profile', () => {
+    const cfg = join(tempDir, 'timeouts.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { timeoutMs: 1234 }, cas: { gateway: 'https://g', timeoutMs: 4321 } } },
+    }));
+    const { btc, cas } = resolveConnectionConfig('regtest', { config: cfg });
+    expect(btc?.timeoutMs).to.equal(1234);
+    expect(cas?.timeoutMs).to.equal(4321);
+  });
+});
+
+describe('resolveBroadcastOptions', () => {
+  const tempDir = join(tmpdir(), 'btcr2-broadcast-test');
+  const cfgPath = join(tempDir, 'nope.json');
+  let savedFee: string | undefined;
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => { savedFee = process.env.BTCR2_FEE_RATE; delete process.env.BTCR2_FEE_RATE; });
+
+  afterEach(() => {
+    if (savedFee !== undefined) process.env.BTCR2_FEE_RATE = savedFee; else delete process.env.BTCR2_FEE_RATE;
+  });
+
+  it('returns undefined when neither fee-rate nor change-address is set', () => {
+    expect(resolveBroadcastOptions('regtest', { config: cfgPath }, {})).to.be.undefined;
+  });
+
+  it('wraps a flag --fee-rate in a StaticFeeEstimator', () => {
+    const opts = resolveBroadcastOptions('regtest', { config: cfgPath }, { feeRate: '9' });
+    expect(opts?.feeEstimator).to.be.instanceOf(StaticFeeEstimator);
+    expect((opts?.feeEstimator as StaticFeeEstimator).satsPerVbyte).to.equal(9);
+  });
+
+  it('reads the fee rate from BTCR2_FEE_RATE when no flag is given', () => {
+    process.env.BTCR2_FEE_RATE = '15';
+    const opts = resolveBroadcastOptions('regtest', { config: cfgPath }, {});
+    expect((opts?.feeEstimator as StaticFeeEstimator).satsPerVbyte).to.equal(15);
+  });
+
+  it('reads the fee rate and change address from the config-file profile', () => {
+    const cfg = join(tempDir, 'broadcast.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { feeRate: 21, changeAddress: 'bcrt1qchange' } } },
+    }));
+    const opts = resolveBroadcastOptions('regtest', { config: cfg }, {});
+    expect((opts?.feeEstimator as StaticFeeEstimator).satsPerVbyte).to.equal(21);
+    expect(opts?.changeAddress).to.equal('bcrt1qchange');
+  });
+
+  it('lets the flag fee rate win over env and profile', () => {
+    const cfg = join(tempDir, 'broadcast2.json');
+    writeFileSync(cfg, JSON.stringify({ profiles: { regtest: { btc: { feeRate: 21 } } } }));
+    process.env.BTCR2_FEE_RATE = '15';
+    const opts = resolveBroadcastOptions('regtest', { config: cfg }, { feeRate: '3' });
+    expect((opts?.feeEstimator as StaticFeeEstimator).satsPerVbyte).to.equal(3);
+  });
+
+  it('throws for a non-positive fee rate', () => {
+    expect(() => resolveBroadcastOptions('regtest', { config: cfgPath }, { feeRate: '0' }))
+      .to.throw(CLIError, /positive number of sats/);
+  });
+});
+
+describe('resolveSecretRef and RPC password sources', () => {
+  const tempDir = join(tmpdir(), 'btcr2-secret-test');
+  const envKeys = [ ...Object.values(ENV_VARS), 'BTCR2_BTC_RPC_PASS_FILE', 'MY_RPC_PASS' ];
+  const saved: Record<string, string | undefined> = {};
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k];
+    }
+  });
+
+  it('returns a literal value unchanged and undefined for undefined', () => {
+    expect(resolveSecretRef('plain')).to.equal('plain');
+    expect(resolveSecretRef(undefined)).to.be.undefined;
+  });
+
+  it('reads an env: reference and trims a trailing newline', () => {
+    process.env.MY_RPC_PASS = 'from-env\n';
+    expect(resolveSecretRef('env:MY_RPC_PASS')).to.equal('from-env');
+  });
+
+  it('reads a file: reference and trims a trailing newline', () => {
+    const file = join(tempDir, 'pass.txt');
+    writeFileSync(file, 'from-file\n');
+    expect(resolveSecretRef(`file:${file}`)).to.equal('from-file');
+  });
+
+  it('throws a CLIError (not a raw error) for an unreadable file: reference', () => {
+    expect(() => resolveSecretRef('file:/no/such/rpc/pass/file'))
+      .to.throw(CLIError, /Could not read the RPC password/);
+  });
+
+  it('resolves a profile rpcPass env: ref into the RPC client password', () => {
+    process.env.MY_RPC_PASS = 'resolved-secret';
+    const cfg = join(tempDir, 'ref.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { rpcUrl: 'http://node:18443', rpcUser: 'u', rpcPass: 'env:MY_RPC_PASS' } } },
+    }));
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rpc?.config.password).to.equal('resolved-secret');
+  });
+
+  it('reads the RPC password from BTCR2_BTC_RPC_PASS_FILE when the layer supplies none', () => {
+    const file = join(tempDir, 'passfile.txt');
+    writeFileSync(file, 'file-secret\n');
+    process.env.BTCR2_BTC_RPC_PASS_FILE = file;
+    const cfg = join(tempDir, 'nopass.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { rpcUrl: 'http://node:18443', rpcUser: 'u' } } },
+    }));
+    const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rpc?.config.password).to.equal('file-secret');
+  });
+});
+
+describe('profile identity wiring (keystore + default signing key)', () => {
+  const tempDir = join(tmpdir(), 'btcr2-identity-test');
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  const writeCfg = (name: string, content: ConfigFile): string => {
+    const p = join(tempDir, name);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  it('resolveKeystorePath honors the active profile identity.keystore', () => {
+    const cfg = writeCfg('id-keystore.json', {
+      defaults : { profile: 'custom' },
+      profiles : { custom: { identity: { keystore: '/tmp/custom-keystore.json' } } },
+    });
+    expect(resolveKeystorePath({ config: cfg })).to.equal('/tmp/custom-keystore.json');
+  });
+
+  it('resolveKeystorePath lets the --keystore flag win over identity.keystore', () => {
+    const cfg = writeCfg('id-keystore-flag.json', {
+      defaults : { profile: 'custom' },
+      profiles : { custom: { identity: { keystore: '/tmp/custom-keystore.json' } } },
+    });
+    expect(resolveKeystorePath({ config: cfg, keystore: '/tmp/flag-keystore.json' })).to.equal('/tmp/flag-keystore.json');
+  });
+
+  it('resolveKeystorePath falls back to the default when no profile identity is set', () => {
+    const cfg = writeCfg('id-none.json', { defaults: { profile: 'custom' }, profiles: { custom: {} } });
+    expect(resolveKeystorePath({ config: cfg })).to.match(/btcr2[/\\]keystore\.json$/);
+  });
+
+  it('resolveSigningKeyRef falls back to the active profile identity.default', () => {
+    const cfg = writeCfg('id-default.json', {
+      defaults : { profile: 'custom' },
+      profiles : { custom: { identity: { default: 'profile-key' } } },
+    });
+    expect(resolveSigningKeyRef({ config: cfg })).to.equal('profile-key');
+  });
+
+  it('resolveSigningKeyRef lets the --signing-key flag win over identity.default', () => {
+    const cfg = writeCfg('id-default-flag.json', {
+      defaults : { profile: 'custom' },
+      profiles : { custom: { identity: { default: 'profile-key' } } },
+    });
+    expect(resolveSigningKeyRef({ config: cfg, signingKey: 'flag-key' })).to.equal('flag-key');
+  });
+
+  it('resolveSigningKeyRef returns undefined when neither flag nor identity.default is set', () => {
+    const cfg = writeCfg('id-default-none.json', { defaults: { profile: 'custom' }, profiles: { custom: {} } });
+    expect(resolveSigningKeyRef({ config: cfg })).to.be.undefined;
   });
 });

--- a/packages/cli/tests/output.spec.ts
+++ b/packages/cli/tests/output.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from './helpers.js';
-import { formatResult } from '../src/output.js';
+import { formatResult, isSecretKey, REDACTED, redactSecrets } from '../src/output.js';
 import type { CommandResult, GlobalOptions } from '../src/types.js';
 
 const textOpts: GlobalOptions = { output: 'text', verbose: false, quiet: false };
@@ -38,5 +38,53 @@ describe('formatResult', () => {
     const parsed = JSON.parse(output);
     expect(parsed.action).to.equal('create');
     expect(parsed.data).to.equal('did:btcr2:abc');
+  });
+});
+
+describe('redactSecrets', () => {
+  it('redacts secret-named keys in a nested object', () => {
+    const out = redactSecrets({ btc: { rpcUser: 'u', rpcPass: 's3cret' } }) as { btc: { rpcUser: string; rpcPass: string } };
+    expect(out.btc.rpcUser).to.equal('u');
+    expect(out.btc.rpcPass).to.equal(REDACTED);
+  });
+
+  it('redacts a directly-passed secret leaf value', () => {
+    expect(redactSecrets('s3cret', 'rpcPass')).to.equal(REDACTED);
+  });
+
+  it('leaves a non-secret leaf value untouched', () => {
+    expect(redactSecrets('http://x', 'rest')).to.equal('http://x');
+  });
+
+  it('does not mutate the input object', () => {
+    const input = { rpcPass: 's3cret' };
+    redactSecrets(input);
+    expect(input.rpcPass).to.equal('s3cret');
+  });
+
+  it('isSecretKey matches pass/secret/token/auth/apikey names, not others', () => {
+    expect(isSecretKey('rpcPass')).to.equal(true);
+    expect(isSecretKey('apiToken')).to.equal(true);
+    expect(isSecretKey('clientSecret')).to.equal(true);
+    expect(isSecretKey('Authorization')).to.equal(true);
+    expect(isSecretKey('X-Api-Key')).to.equal(true);
+    expect(isSecretKey('rpcUser')).to.equal(false);
+    expect(isSecretKey('rest')).to.equal(false);
+  });
+
+  it('scrubs a password embedded in a URL value (any key)', () => {
+    const out = redactSecrets({ btc: { rpcUrl: 'http://alice:s3cret@node:8332' } }) as { btc: { rpcUrl: string } };
+    expect(out.btc.rpcUrl).to.equal('http://alice:********@node:8332');
+  });
+
+  it('redacts header credentials inside a headers map', () => {
+    const out = redactSecrets({ btc: { headers: { Authorization: 'Bearer xyz', 'X-Api-Key': 'k' } } }) as { btc: { headers: Record<string, string> } };
+    expect(out.btc.headers.Authorization).to.equal(REDACTED);
+    expect(out.btc.headers['X-Api-Key']).to.equal(REDACTED);
+  });
+
+  it('does not wholesale-redact an object under a secret-named key (e.g. a profile named with a secret word)', () => {
+    const out = redactSecrets({ profiles: { 'access-token': { btc: { rest: 'http://x' } } } }) as { profiles: Record<string, { btc: { rest: string } }> };
+    expect(out.profiles['access-token'].btc.rest).to.equal('http://x');
   });
 });

--- a/packages/cli/tests/update.spec.ts
+++ b/packages/cli/tests/update.spec.ts
@@ -1,6 +1,7 @@
 import { createApi, type DidBtcr2Api } from '@did-btcr2/api';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
+import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { Command } from 'commander';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -153,5 +154,62 @@ describe('update and deactivate (signing)', () => {
       ),
     ).to.be.rejectedWith(CLIError, /must be one of "auto", "always", or "never"/);
     expect(captured.params).to.equal(undefined);
+  });
+
+  it('update forwards --fee-rate as a StaticFeeEstimator in broadcastOptions', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'update').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"',
+        '--fee-rate', '12'],
+      { from: 'user' },
+    );
+    expect(captured.params.broadcastOptions.feeEstimator).to.be.instanceOf(StaticFeeEstimator);
+    expect(captured.params.broadcastOptions.feeEstimator.satsPerVbyte).to.equal(12);
+  });
+
+  it('update forwards --change-address in broadcastOptions', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'update').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"',
+        '--change-address', 'bcrt1qexamplechangeaddr'],
+      { from: 'user' },
+    );
+    expect(captured.params.broadcastOptions.changeAddress).to.equal('bcrt1qexamplechangeaddr');
+  });
+
+  it('update omits broadcastOptions when neither fee-rate nor change-address is set', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'update').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"'],
+      { from: 'user' },
+    );
+    expect(captured.params.broadcastOptions).to.equal(undefined);
+  });
+
+  it('update rejects an invalid --fee-rate before calling update', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await expect(
+      sub(cli, 'update').parseAsync(
+        ['-s', sourceDoc(), '--source-version-id', '2', '-p', PATCHES, '-m', '#k0', '-b', '"#beacon-0"',
+          '--fee-rate', '-5'],
+        { from: 'user' },
+      ),
+    ).to.be.rejectedWith(CLIError, /positive number of sats/);
+    expect(captured.params).to.equal(undefined);
+  });
+
+  it('deactivate forwards --fee-rate as a StaticFeeEstimator in broadcastOptions', async () => {
+    seedActiveKey();
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'deactivate').parseAsync(
+      ['-s', sourceDoc(), '--source-version-id', '3', '-m', '#k0', '-b', '"#beacon-0"',
+        '--fee-rate', '7'],
+      { from: 'user' },
+    );
+    expect(captured.params.broadcastOptions.feeEstimator.satsPerVbyte).to.equal(7);
   });
 });

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @did-btcr2/method
 
+## 0.54.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.9.0
+
 ## 0.54.0
 
 ### Minor Changes

--- a/packages/method/lib/bitcoin-endpoints.ts
+++ b/packages/method/lib/bitcoin-endpoints.ts
@@ -33,7 +33,7 @@ export function connectBitcoin(
     throw new Error(`No default REST endpoint for network "${network}". Pass options.restHost explicitly.`);
   }
   const rpc = options.rpc
-    ? { host: REGTEST_RPC_HOST, allowDefaultWallet: true, ...options.rpc } as RpcConfig
+    ? { host: REGTEST_RPC_HOST, ...options.rpc } as RpcConfig
     : undefined;
   return new BitcoinConnection({ network: network as NetworkName, rest: { host }, ...(rpc && { rpc }) });
 }

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.54.0",
+    "version": "0.54.1",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",


### PR DESCRIPTION
* chore(release): bump cli 0.15.0, bitcoin 0.9.0, api 0.16.1
* test(cli,bitcoin): +110 cli tests, RPC wallet/header tests
* feat(bitcoin): wire RpcConfig wallet+headers, drop allowDefaultWallet; profile identity (ADR 078)
* feat(cli): config correctness, I/O knobs, introspection, secret handling (ADRs 074-077)
* docs(adr): 074-078 Accepted; cli README config surface