### PR TITLE
single-home CLI state + keystore lifecycle with dev keystores

### DIFF
--- a/docs/adr/079-cli-state-directory-consolidation.md
+++ b/docs/adr/079-cli-state-directory-consolidation.md
@@ -1,0 +1,55 @@
+---
+title: "ADR 079: Consolidate CLI State Under a Single ~/.btcr2 Home Directory"
+---
+
+# ADR 079: Consolidate CLI State Under a Single ~/.btcr2 Home Directory
+
+**Status:** Accepted
+
+**Date:** 2026-07-08
+
+**Branch / PR:** `feat/cli-home-keystore-lifecycle`
+
+**References:** [ADR 074](074-cli-config-resolution-correctness.md), [ADR 078](078-wire-dead-config-surface.md), [ADR 080](080-keystore-lifecycle-and-dev-keystores.md)
+
+## Context
+
+The CLI keeps two pieces of on-disk state in two different directories. The config file follows the XDG *config* directory (`$XDG_CONFIG_HOME/btcr2/config.json`, falling back to `~/.config/btcr2/config.json`), and the keystore follows the XDG *data* directory (`$XDG_DATA_HOME/btcr2/keystore.json`, falling back to `~/.local/share/btcr2/keystore.json`). `defaultConfigPath` and `defaultKeystorePath` encode the two roots independently, and neither is influenced by any single "where does btcr2 keep its things" knob.
+
+The split is XDG-correct, and defensible on a workstation the operator already understands. It is exactly wrong for the situation this change targets: a live, follow-along workshop where a room of mixed-OS attendees must find, inspect, back up, and reset their CLI state without getting stuck. "Your config is in one hidden directory and your keys are in a different hidden directory, and which directory depends on two environment variables that may or may not be set" is a support burden per attendee. Every other identity-bearing CLI an attendee is likely to have seen keeps its state in one discoverable, tool-named home: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gh`. There is one place to look, one directory to `chmod`, one directory to delete to start over.
+
+There is also a subtler cost. Because the two roots are derived independently, `--config` and `--keystore` are the only way to relocate state as a unit, and there is no single override that says "put all btcr2 state here" - useful for throwaway per-demo homes, CI sandboxes, and `BTCR2_HOME=$(mktemp -d)`-style isolation in tests and scripts.
+
+## Decision
+
+1. **Introduce a single home root and colocate both files under it.** The config file and the keystore live side by side in one directory: `<home>/config.json` and `<home>/keystore.json`. The home root resolves in this order (highest wins):
+   1. `--home <dir>` global flag
+   2. `$BTCR2_HOME` environment variable
+   3. the **platform default**: `~/.btcr2` on Linux and macOS (the short, teachable dot-directory in the family of `~/.ssh`, `~/.aws`, `~/.gnupg`); `%LOCALAPPDATA%\btcr2` on Windows (its native per-user application-state location, with `%APPDATA%\btcr2` then the user profile as fallbacks).
+
+   A blank value at any layer defers to the next (the same `blankToUndef` treatment ADR 074 applies to every other layer), so an exported-but-empty `BTCR2_HOME` does not resolve the home to a bare filename. The default is platform-aware rather than a uniform `~/.btcr2` so Windows state lands in its native `AppData\Local` tree instead of a profile-root dot-directory, while Unix keeps the short path. Colocation (both files in one dir) is the invariant; the exact base is per-OS, and `btcr2 config path` prints the resolved home so operators never have to memorize it.
+
+2. **Keep the per-file flags as unit-independent overrides.** `--config <file>` and `--keystore <file>` continue to point at a specific file and win over the home-derived default for that file only. An operator who wants the historical XDG split runs with explicit paths (or points `BTCR2_HOME` at a chosen directory), and a profile's `identity.keystore` (ADR 078) still relocates the keystore per profile. The precedence for each file is: its own flag, then (for the keystore) the active profile's `identity.keystore`, then `<home>/<file>`.
+
+3. **Drop the XDG default outright; do not consult `XDG_CONFIG_HOME` / `XDG_DATA_HOME` for the default anymore.** The old defaults read those variables (and the `~/.config` / `~/.local/share` fallbacks) directly; the new default is the platform home regardless of the XDG environment. This is a clean cutover, not a migration: there is no released consumer of the CLI whose state must be carried forward, so there is deliberately **no legacy-location detection and no `config migrate` command**. A predictable single default that does not depend on ambient environment is the point; a Linux operator who genuinely wants their state under `$XDG_DATA_HOME` sets `BTCR2_HOME` to it.
+
+4. **Add a `--home <dir>` global flag and a `home?` field to the override/globals types**, and thread the resolved overrides into every `defaultConfigPath` / `defaultKeystorePath` call site so `--home` and `BTCR2_HOME` are actually honored (a default-path helper that ignores the flag would advertise a knob that does nothing, the ADR 078 failure mode). Home, config-path, and keystore-path resolution live in one `src/paths.ts` module so config and keystore can never disagree about the root.
+
+5. **`btcr2 config path` reports the home root** alongside the resolved config and keystore paths, so `path` answers "where is everything" in one call.
+
+This is a CLI-only change and ships as a **cli minor** bump. It is breaking for anyone who relied on the old XDG default locations; because there is no released consumer to carry forward, the remedy for a pre-existing install is simply to re-run `btcr2 init` (ADR 080) against the new home, or to point `--config` / `--keystore` / `BTCR2_HOME` at the old paths. The bump is a minor per the project's 0.x "minor carries breaking" cadence.
+
+## Consequences
+
+- A fresh install keeps all state in one discoverable, tool-named directory. "Where are my keys / my config / how do I start over" each have a one-directory answer, and `BTCR2_HOME=$(mktemp -d)` isolates a whole btcr2 environment for a demo, a test, or CI in one variable.
+- `--config` and `--keystore` keep working exactly as before, so any script or profile already pinning explicit paths is unaffected by the default change; the historical XDG split is reproducible by pointing those flags (or `BTCR2_HOME`) at the old locations.
+- One new module (`src/paths.ts`) is the single source of truth for state locations; `defaultConfigPath` / `defaultKeystorePath` are re-exported from their current modules for import-surface compatibility but now derive from the shared home resolver.
+- The consolidation is a precondition for the keystore lifecycle work in [ADR 080](080-keystore-lifecycle-and-dev-keystores.md) and the `btcr2 init` happy-path entry point: `init` creates one home directory and seeds both files in it.
+- Tests: home resolution precedence (`--home` > `BTCR2_HOME` > platform default, with blank-defers-to-next); the platform default is `~/.btcr2` off-Windows and `%LOCALAPPDATA%\btcr2` (falling back to `%APPDATA%\btcr2`) on Windows; config and keystore both land under a `BTCR2_HOME` override; `--config` / `--keystore` still override per file.
+
+## Rejected alternatives
+
+- **Keep the XDG split.** This leaves the two-directory support burden in place for every attendee and every future user, which is the entire problem. The split's correctness does not outweigh the teachability cost for this tool's audience, and operators who genuinely want XDG can reproduce it with `--config` / `--keystore` or `BTCR2_HOME`.
+- **Keep auto-consulting `XDG_CONFIG_HOME` / `XDG_DATA_HOME` when set, and only default to the platform home when they are unset.** This looks backward-compatible but defeats the goal for the exact users it claims to help: a Linux workstation with `XDG_CONFIG_HOME` exported would keep the split, so the consolidation would not apply to the people most likely to have it set. A predictable single default that does not depend on ambient environment is the point.
+- **Detect the old XDG locations and add a `config migrate` command.** An earlier draft did exactly this: auto-detect legacy state, nudge the operator on standard error, and copy it non-destructively into the new home. It was removed. There is no released CLI whose state needs migrating, so the detection code, the one-time notice, and the `migrate` command were speculative back-compat with no consumer - carrying real cost (extra command surface, TTY/`--quiet`/JSON suppression rules, per-file override subtleties, extra tests) for a scenario that does not exist. A clean cutover plus `btcr2 init` is simpler and has nothing to get subtly wrong.
+- **A uniform `~/.btcr2` on every OS, including Windows.** Simplest to teach (one path string for the whole room) and works on Windows as a profile dot-directory, exactly as `~/.ssh` and `~/.aws` do. Rejected only because a native Windows tool should keep per-user state in `AppData\Local`, not a dot-directory in the profile root; the platform-aware default costs a few lines and gives Windows attendees the idiomatic location while leaving the Unix path short. `config path` makes the per-OS location discoverable in one command.

--- a/docs/adr/080-keystore-lifecycle-and-dev-keystores.md
+++ b/docs/adr/080-keystore-lifecycle-and-dev-keystores.md
@@ -1,0 +1,76 @@
+---
+title: "ADR 080: Keystore Lifecycle, a Confirmed First Passphrase, and Opt-In Dev Keystores"
+---
+
+# ADR 080: Keystore Lifecycle, a Confirmed First Passphrase, and Opt-In Dev Keystores
+
+**Status:** Accepted
+
+**Date:** 2026-07-08
+
+**Branch / PR:** `feat/cli-home-keystore-lifecycle`
+
+**References:** [ADR 052](052-cli-keystore-file-locking.md), [ADR 077](077-cli-rpc-secret-handling.md), [ADR 079](079-cli-state-directory-consolidation.md)
+
+## Context
+
+The encrypted keystore protects each secret key with an independent argon2id + XChaCha20-Poly1305 envelope (`keystore/envelope.ts`), all opened by one shared passphrase acquired lazily through `getPassphrase` (`config.ts`). Three problems in that lifecycle surfaced while preparing a live CRUD workshop, and one of them silently destroyed keys.
+
+1. **The first passphrase is never confirmed, so a typo permanently seals the keystore.** `buildKeystoreKms` wired `getPassphrase: () => acquirePassphrase({ passphraseFile })` with no `confirm: true`. `acquirePassphrase` *has* a confirm mode (prompt twice, require a match), but nothing turned it on. The first `key generate` on a fresh keystore therefore sealed the new key under whatever the operator typed once, with no second entry to catch a slip. If they mistyped, the keystore was now sealed with a passphrase nobody knows, and the key was unrecoverable. This is not hypothetical: it is how four throwaway test keys were lost.
+
+2. **A returning-user typo is just as destructive, and confirm alone does not fix it.** Even with confirm on the first key, the second `key generate` prompts once and seals key 2 under whatever was typed. Because each key carries its own envelope and there was no check that the passphrase matched the one the *other* keys use, a typo on key 2 sealed it under a divergent passphrase. Later, key 1 opens fine and key 2 fails to decrypt, with no explanation. There was nothing in the file that a candidate passphrase could be checked against before it is used to seal or open a secret.
+
+3. **There is no keystore lifecycle surface and no way to run without a passphrase for throwaway keys.** There was no command group to establish, inspect, or re-key the keystore: no `init`, no `status`, no `change-passphrase`. And every key operation was gated on a passphrase even when the keys are disposable testnet material - which for the workshop means every attendee fights the passphrase prompt (or leaks it via `BTCR2_KEYSTORE_PASSPHRASE` in shell history) before they can create their first DID. The mainnet default must stay encryption-at-rest; the demo needs a sanctioned, loud, testnet-only escape hatch.
+
+## Decision
+
+### A passphrase verifier makes establishment confirmed and every later use checked
+
+Add a self-describing protection header to the keystore file (the format stays `v: 1`; the new fields are the keystore's own description of how its secrets are stored):
+
+- `protection`: `'passphrase'` (encrypted, the default) or `'none'` (dev, plaintext). **Every keystore this CLI writes carries it.**
+- `verifier`: a `SecretEnvelope` sealing a fixed sentinel plaintext under the keystore passphrase, written when the passphrase is established. **Every encrypted keystore that holds keys carries one.**
+
+The store's passphrase handling is binary:
+
+1. **Establishing a fresh encrypted keystore** (no `verifier` yet): acquire the passphrase in **confirm** mode (prompt twice, require a match) and write the `verifier` in the same locked, atomic flush as the first key. This is the first-seal confirm fix, and it applies whether establishment happens through an explicit `keystore init` or implicitly through the first `key generate`.
+2. **Using an established encrypted keystore** (a `verifier` is present): acquire the passphrase once, then **decrypt the verifier first**. A wrong passphrase fails there, loudly (`Incorrect passphrase`), *before* any key is sealed or opened - so a returning-user typo can no longer seal a key under a divergent passphrase or silently fail later.
+
+There is deliberately **no third "sealed keys but no verifier" state**. A keystore always self-describes, and the loader refuses a file that lacks a recognized `protection` header, that carries sealed keys without a verifier, or whose per-entry secret form (a sealed envelope vs. a plaintext `plainSecret`) disagrees with its protection mode. Such a file was not written by this CLI: there is no pre-header keystore format to accommodate and no released consumer to be backward-compatible with, so refusing it is correct. This removes an entire class of "which passphrase is this key under" ambiguity, including the concurrent-establish / concurrent-rotate race that ambiguity created: because a sealed-but-unverified keystore cannot exist on disk, `set()` only ever either *establishes* (mint and record the verifier, no writer having beaten it) or *verifies* against the existing one, so a key can never be persisted under a passphrase that diverges from the keystore verifier.
+
+`getPassphrase` gains an optional `{ confirm }` argument so the store, which alone knows whether it is establishing or reusing, controls when the second prompt happens. `confirm` is a no-op for the non-interactive sources (`BTCR2_KEYSTORE_PASSPHRASE`, `--passphrase-file`), which have nothing to prompt twice.
+
+### A `keystore` command group owns the lifecycle
+
+- **`keystore init`**: establish the keystore explicitly. Encrypted by default (prompt-and-confirm, write the verifier, create an empty key set). `--dev` establishes an unencrypted dev keystore instead (see below). Refuses to touch an existing keystore unless `--force`.
+- **`keystore status`**: report the resolved path, protection mode (`encrypted` / `dev` / `absent`), whether a passphrase is established, the key count, and the active key id. It reads only public structure - it never decrypts, never prompts, and never throws (a missing or unrecognized file reports `absent`).
+- **`keystore change-passphrase`**: verify the current passphrase against the verifier, acquire a new one in confirm mode, re-seal every secret and the verifier under the new passphrase, and flush atomically under the existing write lock. Encrypted keystores only; a dev keystore has no passphrase to change.
+
+### Opt-in, loudly-marked dev keystores, hard-refused on mainnet
+
+A dev keystore (`protection: 'none'`) stores each secret as plaintext bytes (`plainSecret`, base64url) instead of an envelope. It never prompts for a passphrase, on read or write. Its file is still created `0600` and still fails closed on loose permissions, and `keystore init --dev` and `keystore status` both print a prominent warning that keys are stored unencrypted.
+
+Because plaintext keys are only acceptable for disposable testnet material, the CLI **hard-refuses to use a dev keystore for mainnet**: any `update` or `deactivate` whose DID network is `bitcoin`, and any `create` that would generate and seal a new key into a dev keystore on `bitcoin`, throws before signing or sealing. The refusal is a hard error, not a warning - a plaintext mainnet key is a foot-gun with no legitimate use here. The check reads the keystore's `protection` field without decrypting, so it costs nothing and never prompts. Testnet, signet, mutinynet, and regtest are unaffected.
+
+### `btcr2 init` is the one-command happy-path entry point
+
+Add a top-level `btcr2 init` that creates the home directory (ADR 079), writes a default config if none exists (the same scaffold as `config init`), and establishes the keystore if none exists: encrypted with a confirmed passphrase by default, or `--dev` for an unencrypted testnet keystore. It is idempotent - existing files are left untouched - and prints the home path and the next step. This makes the workshop's first line a single `btcr2 init`, after which `key generate` never hits the accidental-first-seal path because the passphrase was already established, with confirmation, up front.
+
+Crucially, `btcr2 init` never destroys secret keys. Its `--force` re-scaffolds the (regenerable) config, but it does **not** overwrite an existing keystore: re-establishing a keystore, which discards its keys, is only ever the explicit `keystore init --force`, and even that warns on standard error when it would discard keys. Coupling a routine "reset my config" gesture to unrecoverable key loss is exactly the footgun this lifecycle work exists to remove.
+
+## Consequences
+
+- The key-loss bug is closed at its root: the first passphrase is confirmed, and once a keystore is established, every later passphrase is checked against the verifier before it can seal or open anything. A typo becomes a loud, non-destructive `Incorrect passphrase` instead of an unrecoverable key.
+- A keystore self-describes and is validated on load: every file carries a protection header, an encrypted keystore that holds keys carries a verifier, and a file that fails either invariant (or mixes sealed and plaintext secrets) is refused rather than opened on a guess. `keystore status` answers "encrypted, dev, or none; passphrase set; how many keys" without a prompt, and `change-passphrase` makes rotation a supported operation rather than a hand-edit.
+- The concurrent-write reconciliation is simpler and provably safe: because a sealed-but-unverified state cannot exist on disk, `set()` either establishes a verifier or verifies against the existing one, and a key can never be persisted under a passphrase that diverges from the keystore verifier (including under a race with a concurrent `change-passphrase`, which aborts rather than corrupting).
+- The workshop gets a frictionless, sanctioned path (`btcr2 init --dev` on mutinynet) without weakening the mainnet posture: encryption-at-rest stays the default, and mainnet flatly refuses a dev keystore.
+- The on-disk format stays `v: 1`. The `protection`, `verifier`, and `plainSecret` fields are the keystore's self-description. There is deliberately no compatibility path for a header-less or verifier-less keystore: none was ever released, and accepting one would reintroduce the passphrase ambiguity this ADR removes.
+- Tests: a mistyped confirmation on establishment aborts without writing a key; a wrong passphrase against an established keystore throws before sealing a second key; a dev keystore round-trips a key with no passphrase; mainnet `update` / `deactivate` / generating `create` refuse a dev keystore while testnet allows it; `keystore status` reports each mode without prompting; `change-passphrase` re-seals every key and the verifier and rejects a wrong current passphrase; a file with no recognized protection header, an encrypted keystore missing its verifier, and a plaintext secret inside an encrypted keystore are each refused on load; `btcr2 init` is idempotent and seeds home + config + keystore.
+
+## Rejected alternatives
+
+- **Only add `confirm: true` to the first seal (the minimal fix).** This catches a first-key typo but leaves problem 2 fully open: a returning-user typo still seals a key under a divergent passphrase with no check and a silent later failure. The verifier is a few lines more and closes the whole class, and it is also what makes `status` and `change-passphrase` able to reason about the passphrase at all. The minimal fix would have to be redone the moment those commands were added.
+- **Derive one shared key once and encrypt all secrets under it (drop per-key envelopes).** This is a larger re-architecture of a security-sensitive format for no additional safety here; the verifier gives the "is this the right passphrase" check without disturbing the per-key envelope model, which keeps each secret independently sealed and lets the argon2id cost be raised per key over time.
+- **Warn instead of refuse for a dev keystore on mainnet.** A warning is ignorable and normalizes plaintext mainnet keys. There is no legitimate reason to sign a mainnet did:btcr2 update with an unencrypted key from this tool, so the safe default is a hard error with a clear message pointing at an encrypted keystore.
+- **Support pre-header "legacy" keystores instead of refusing them.** An earlier draft loaded a header-less or verifier-less keystore as encrypted and let it gain a verifier opportunistically the next time the passphrase was used. That keeps a keystore whose passphrase cannot be checked before use - the exact hole this ADR closes - and it created a concurrent-write race in which a key could still be sealed under a divergent passphrase. Since no released CLI ever wrote such a file, the compatibility it bought was imaginary; refusing an unrecognized file is both simpler and strictly safer.
+- **Make `keystore unlock` / session caching part of this ADR.** Session unlock (a TTL-cached derived key so a returning user is not re-prompted every invocation) is real convenience, but it is a distinct mechanism with its own on-disk-vs-in-memory trade-offs. It is deferred to its own ADR so this one stays focused on correctness (confirmed, verified passphrases) and the dev-keystore escape hatch.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -155,3 +155,5 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 076 | 2026-07-07 | [CLI Bitcoin and CAS I/O Passthrough Knobs](076-cli-io-passthrough-knobs.md) |
 | 077 | 2026-07-07 | [CLI Secret Handling for Bitcoin RPC Credentials](077-cli-rpc-secret-handling.md) |
 | 078 | 2026-07-07 | [Wire the Advertised-but-Dead Bitcoin RPC and Profile-Identity Config Surface](078-wire-dead-config-surface.md) |
+| 079 | 2026-07-08 | [Consolidate CLI State Under a Single ~/.btcr2 Home Directory](079-cli-state-directory-consolidation.md) |
+| 080 | 2026-07-08 | [Keystore Lifecycle, a Confirmed First Passphrase, and Opt-In Dev Keystores](080-keystore-lifecycle-and-dev-keystores.md) |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @did-btcr2/cli
 
+## 0.16.0
+
+### Minor Changes
+
+- Consolidate CLI state under one home directory and add a keystore lifecycle with a confirmed, verified passphrase and opt-in dev keystores (ADRs 079, 080).
+
+  - **Single home directory (ADR 079, breaking default).** `config.json` and `keystore.json` now live side by side under one home: `~/.btcr2` on Linux/macOS, `%LOCALAPPDATA%\btcr2` on Windows, overridable with `--home` / `$BTCR2_HOME`. The old XDG config/data split is dropped outright (no migration path: re-run `btcr2 init` against the new home); `--config` / `--keystore` still override each file, so the split is reproducible explicitly. `btcr2 config path` now reports the home root.
+  - **Confirmed, verified keystore passphrase (ADR 080).** The first passphrase is now established with a confirm prompt, and a keystore verifier makes every later use fail loudly (`Incorrect passphrase`) instead of sealing a key under an unknown or divergent passphrase, closing a key-loss bug where a first-key typo permanently sealed the keystore.
+  - **`keystore` command group.** `keystore init` (encrypted by default, `--dev` for unencrypted), `keystore status`, and `keystore change-passphrase`.
+  - **Opt-in dev keystores.** `--dev` establishes an unencrypted keystore (plaintext keys, no passphrase) for disposable testnet material; the CLI hard-refuses to sign or generate a mainnet (`bitcoin`) key with one.
+  - **`btcr2 init`.** One-command setup that creates the home, a default config, and establishes the keystore (encrypted by default, `--dev` for testnet).
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,11 +36,13 @@ npx @did-btcr2/cli resolve -i did:btcr2:k1qq...
 
 | Command | Alias | Description |
 |---|---|---|
+| `init` | - | Set up the btcr2 home: create the directory, a default config, and establish the keystore |
 | `create` | - | Create an identifier and initial DID document |
 | `resolve` | `read` | Resolve a DID document |
 | `update` | - | Update a DID document (signs via the keystore) |
 | `deactivate` | `delete` | Deactivate a DID permanently (signs via the keystore) |
-| `key` | - | Manage keypairs in the encrypted keystore |
+| `key` | - | Manage keypairs in the keystore |
+| `keystore` | - | Establish, inspect, and re-key the keystore |
 | `config` | - | Read and write CLI configuration |
 | `profile` | - | Manage configuration profiles |
 | `completion` | - | Print a shell completion script |
@@ -96,9 +98,29 @@ Permanently deactivates a DID. This is irreversible. Deactivation applies the `{
 
 Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>`, `--fee-rate <satsPerVByte>`, `--change-address <address>` (same as `update`).
 
+### init
+
+`btcr2 init` is the one-command setup: it creates the btcr2 home directory, writes a default config if none exists, and establishes the keystore if none exists. It is idempotent (existing files are left untouched unless `--force`).
+
+| Flag | Description |
+|---|---|
+| `--dev` | Establish an **unencrypted** dev keystore (plaintext keys, no passphrase). Testnet/regtest only; mainnet operations are refused |
+| `--force` | Re-create the config and keystore even if they already exist |
+
+By default `init` establishes an **encrypted** keystore and prompts (with confirmation) for a passphrase up front, so the first `key generate` never seals the keystore under an unconfirmed, mistyped passphrase. Supply the passphrase non-interactively with `BTCR2_KEYSTORE_PASSPHRASE` or `--passphrase-file` for scripted setup.
+
+The workshop happy path:
+
+```bash
+btcr2 init --dev --network mutinynet   # (or: btcr2 init  for an encrypted keystore)
+btcr2 key generate --set-active
+btcr2 create --network mutinynet
+# ...fund the beacon, resolve, update, deactivate...
+```
+
 ### key
 
-Manage keypairs in the encrypted keystore. All subcommands operate offline (no Bitcoin connection).
+Manage keypairs in the keystore. All subcommands operate offline (no Bitcoin connection).
 
 | Subcommand | Alias | Description |
 |---|---|---|
@@ -111,6 +133,18 @@ Manage keypairs in the encrypted keystore. All subcommands operate offline (no B
 | `key use <ref>` | - | Set the active key, persisted across invocations |
 
 A key reference is a full URN, a unique `name` tag, or a unique fingerprint prefix.
+
+### keystore
+
+Establish, inspect, and re-key the keystore. These operate on the keystore file directly (no Bitcoin connection).
+
+| Subcommand | Alias | Description |
+|---|---|---|
+| `keystore init` | - | Establish the keystore (encrypted by default; prompts and confirms the passphrase). `--dev` creates an unencrypted dev keystore; `--force` re-establishes an existing one (discards its keys) |
+| `keystore status` | - | Show the resolved path, protection mode (`encrypted`/`dev`/`absent`), whether a passphrase is established, and the key count. Never decrypts or prompts |
+| `keystore change-passphrase` | `passwd` | Re-seal every key under a new passphrase (encrypted keystores only). Prompts for the current passphrase, then a new one (with confirmation) |
+
+**Encrypted vs dev keystores.** An encrypted keystore seals each secret with argon2id + XChaCha20-Poly1305 under one passphrase, and records a verifier so a mistyped passphrase fails loudly (with `Incorrect passphrase`) instead of sealing a key under an unknown or divergent passphrase. A **dev keystore** (`--dev`) stores secrets in plaintext and never prompts: it is for disposable testnet/regtest keys only, and the CLI **hard-refuses** to sign or generate a mainnet (`bitcoin`) key with one.
 
 ### config
 
@@ -125,7 +159,7 @@ Read and write CLI configuration.
 | `config list` | `ls` | Print the entire config file. Secret values are redacted; `--show-secrets` reveals them |
 | `config validate` | - | Report unknown keys, invalid enum values, and an unsupported schema version |
 | `config effective` | - | Print the resolved connection config with per-value provenance (`flag`/`env`/`file`/`default`). `-n, --network <n>` selects the network; `--show-secrets` reveals the RPC password |
-| `config path` | - | Print the resolved config-file and keystore paths |
+| `config path` | - | Print the resolved home directory, config-file, and keystore paths |
 | `config doctor` | - | Probe reachability of the resolved endpoints (read-only; touches the network). `-n, --network <n>` selects the network |
 
 ### profile
@@ -223,7 +257,8 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `-o, --output <format>` | Output format: `json` or `text` (default: config `defaults.output`, else `text`) |
 | `--verbose` | Verbose output |
 | `--quiet` | Suppress non-essential output |
-| `-c, --config <path>` | Path to config file (default: `$XDG_CONFIG_HOME/btcr2/config.json`) |
+| `--home <dir>` | btcr2 home directory holding `config.json` + `keystore.json` (default: `~/.btcr2`, `%LOCALAPPDATA%\btcr2` on Windows; overrides `$BTCR2_HOME`) |
+| `-c, --config <path>` | Path to config file (default: `<home>/config.json`) |
 | `--profile <name>` | Config profile name (default: auto-detected from network) |
 | `--btc-rest <url>` | Override Bitcoin REST endpoint (Esplora API) |
 | `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
@@ -236,7 +271,7 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads (read-only) |
 | `--cas-rpc-url <url>` | IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables `--publish-to-cas`) |
 | `--cas-timeout <ms>` | CAS request timeout in milliseconds (default: `30000`; `0` disables) |
-| `--keystore <path>` | Path to the keystore file (default: `$XDG_DATA_HOME/btcr2/keystore.json`) |
+| `--keystore <path>` | Path to the keystore file (default: `<home>/keystore.json`) |
 | `--passphrase-file <path>` | Read the keystore passphrase from a file (unattended use) |
 | `--signing-key <ref>` | Key for create/update/deactivate signing: a URN, fingerprint prefix, or name |
 
@@ -255,10 +290,16 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_CAS_TIMEOUT` | `--cas-timeout` |
 | `BTCR2_FEE_RATE` | `--fee-rate` |
 | `BTCR2_OUTPUT` | `-o, --output` |
+| `BTCR2_HOME` | `--home` |
+| `BTCR2_KEYSTORE_PASSPHRASE` | keystore passphrase (unattended use) |
+
+### Home directory
+
+The CLI keeps its config and keystore side by side in one home directory, resolved as `--home <dir>`, then `$BTCR2_HOME`, then the platform default: `~/.btcr2` on Linux/macOS and `%LOCALAPPDATA%\btcr2` on Windows. Both files live directly under it (`<home>/config.json`, `<home>/keystore.json`); `btcr2 config path` prints the resolved locations. `--config` and `--keystore` still override each file individually, so the historical XDG split can be reproduced explicitly.
 
 ### Config file
 
-Default location: `$XDG_CONFIG_HOME/btcr2/config.json` (falls back to `~/.config/btcr2/config.json`). An empty `$XDG_CONFIG_HOME` is treated as unset. A malformed config file fails loudly (the CLI never silently falls back to public endpoints, and never overwrites an unparseable file).
+Default location: `<home>/config.json`. A malformed config file fails loudly (the CLI never silently falls back to public endpoints, and never overwrites an unparseable file).
 
 Profiles are matched by network name when `--profile` is not specified. For example, resolving a regtest DID automatically selects the `"regtest"` profile. A profile that is not named after a network can declare its network with a `network` field.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,9 @@ import {
   registerConfigCommand,
   registerCreateCommand,
   registerDeactivateCommand,
+  registerInitCommand,
   registerKeyCommand,
+  registerKeystoreCommand,
   registerProfileCommand,
   registerResolveCommand,
   registerUpdateCommand,
@@ -44,7 +46,8 @@ export class DidBtcr2Cli {
       .option('-o, --output <format>', 'Output format <json|text> (default: config defaults.output, else text)')
       .option('--verbose', 'Verbose output', false)
       .option('--quiet', 'Suppress non-essential output', false)
-      .option('-c, --config <path>', 'Path to config file (default: $XDG_CONFIG_HOME/btcr2/config.json)')
+      .option('--home <dir>', 'btcr2 home directory holding config.json + keystore.json (default: ~/.btcr2, %LOCALAPPDATA%\\btcr2 on Windows; overrides $BTCR2_HOME)')
+      .option('-c, --config <path>', 'Path to config file (default: <home>/config.json)')
       .option('--profile <name>', 'Config profile name (default: auto-detected from network)')
       .option('--btc-rest <url>', 'Override Bitcoin REST endpoint (Esplora API)')
       .option('--btc-rpc-url <url>', 'Override Bitcoin Core RPC endpoint')
@@ -57,7 +60,7 @@ export class DidBtcr2Cli {
       .option('--btc-rest-header <header>', 'Extra Bitcoin REST header "Key: Value" (repeatable)', collectHeader, [])
       .option('--btc-rpc-wallet <name>', 'Bitcoin Core wallet name for wallet-scoped RPCs')
       .option('--btc-rpc-header <header>', 'Extra Bitcoin Core RPC header "Key: Value" (repeatable)', collectHeader, [])
-      .option('--keystore <path>', 'Path to the keystore file (default: $XDG_DATA_HOME/btcr2/keystore.json)')
+      .option('--keystore <path>', 'Path to the keystore file (default: <home>/keystore.json)')
       .option('--passphrase-file <path>', 'Read the keystore passphrase from a file (unattended use)')
       .option('--signing-key <ref>', 'Key for create/update/deactivate signing: a URN, fingerprint prefix, or name');
 
@@ -70,14 +73,16 @@ export class DidBtcr2Cli {
     // value is written back so every command reads it through globals().output.
     this.program.hook('preAction', () => {
       const opts = this.program.opts() as GlobalOptions;
-      opts.output = resolveOutputFormat({ output: opts.output, config: opts.config });
+      opts.output = resolveOutputFormat({ output: opts.output, config: opts.config, home: opts.home });
     });
 
+    registerInitCommand(this.program, globals);
     registerCreateCommand(this.program, factory, keystoreFactory, globals);
     registerResolveCommand(this.program, factory, globals);
     registerUpdateCommand(this.program, keystoreFactory, globals);
     registerDeactivateCommand(this.program, keystoreFactory, globals);
     registerKeyCommand(this.program, keystoreFactory, globals);
+    registerKeystoreCommand(this.program, globals);
     registerConfigCommand(this.program, globals);
     registerProfileCommand(this.program, globals);
     registerCompletionCommand(this.program, globals);

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,6 +1,5 @@
 import type { Command } from 'commander';
 import { existsSync } from 'node:fs';
-import { dirname } from 'node:path';
 import {
   CONFIG_SCHEMA_VERSION,
   defaultConfigPath,
@@ -9,23 +8,24 @@ import {
   readConfigFile,
   resolveDefaultNetwork,
   resolveEffectiveConfig,
+  resolveKeystorePath,
   runDoctor,
   setConfigPath,
   unsetConfigPath,
   writeConfigFile,
+  writeDefaultConfigFile,
 } from '../config.js';
 import { findConfigIssues, validateConfigSet } from '../config-schema.js';
 import { CLIError } from '../error.js';
-import { ensureDir, writeFileAtomic } from '../keystore/atomic.js';
-import { defaultKeystorePath } from '../keystore/paths.js';
 import { formatResult, REDACTED, redactSecrets, scrubUrlUserinfo } from '../output.js';
+import { resolveHome } from '../paths.js';
 import type { CommandResult, GlobalOptions, NetworkOption } from '../types.js';
 import { SUPPORTED_NETWORKS } from '../types.js';
 
 /** Registers the `config` command group for reading and writing CLI configuration. */
 export function registerConfigCommand(program: Command, globals: () => GlobalOptions): void {
   const config = program.command('config').description('Read and write CLI configuration.');
-  const path = (): string => globals().config ?? defaultConfigPath();
+  const path = (): string => globals().config ?? defaultConfigPath(globals());
   const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
 
   config
@@ -37,13 +37,7 @@ export function registerConfigCommand(program: Command, globals: () => GlobalOpt
       if (existsSync(p) && !options.force) {
         throw new CLIError(`Config already exists at ${p}. Use --force to overwrite.`, 'INVALID_ARGUMENT_ERROR', { path: p });
       }
-      const scaffold = {
-        schemaVersion : CONFIG_SCHEMA_VERSION,
-        defaults      : { output: 'text' },
-        profiles      : Object.fromEntries(SUPPORTED_NETWORKS.map(n => [ n, {} ])),
-      };
-      ensureDir(dirname(p), 0o700);
-      writeFileAtomic(p, `${JSON.stringify(scaffold, null, 2)}\n`, 0o600);
+      writeDefaultConfigFile(p);
       print({ action: 'config-init', data: { path: p } });
     });
 
@@ -128,11 +122,15 @@ export function registerConfigCommand(program: Command, globals: () => GlobalOpt
 
   config
     .command('path')
-    .description('Print the resolved config-file and keystore paths.')
+    .description('Print the resolved home directory, config-file, and keystore paths.')
     .action(() => {
+      const g = globals();
       const data = {
-        config   : globals().config ?? defaultConfigPath(),
-        keystore : globals().keystore ?? defaultKeystorePath(),
+        home     : resolveHome(g),
+        config   : g.config ?? defaultConfigPath(g),
+        // Diagnostic command: report the path even when the config is malformed
+        // (this is a command you run to find and fix a broken config).
+        keystore : resolveKeystorePath(g, { lenient: true }),
       };
       print({ action: 'config-path', data });
     });

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import type { Command } from 'commander';
 import type { ApiFactory, ConnectionOverrides } from '../config.js';
-import { profileNetworkMismatch, resolveDefaultNetwork } from '../config.js';
+import { assertKeystoreAllowedForNetwork, profileNetworkMismatch, resolveDefaultNetwork } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -132,6 +132,8 @@ export function registerCreateCommand(
       }
 
       // Generate: mint a fresh key, persist it, and set it active (passphrase prompt).
+      // Refuse to seal a fresh mainnet key into an unencrypted dev keystore (ADR 080).
+      assertKeystoreAllowedForNetwork(network, overrides);
       const api = keystoreFactory(undefined, overrides);
       const { did, keyId } = api.generateDid({ network, setActive: true });
       const publicKey = bytesToHex(api.kms.getPublicKey(keyId));
@@ -145,6 +147,7 @@ export function registerCreateCommand(
 /** Builds the keystore- and config-resolution overrides from the global flags. */
 function overridesFromGlobals(g: GlobalOptions): ConnectionOverrides {
   return {
+    home           : g.home,
     config         : g.config,
     profile        : g.profile,
     keystore       : g.keystore,

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -1,7 +1,7 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
-import { deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
+import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -88,6 +88,8 @@ export function registerDeactivateCommand(
       // Deactivation is an update that applies the deactivation patch. The core
       // method has no separate deactivate path, so this routes through update.
       const network = deriveNetwork(did);
+      // Refuse to sign a mainnet deactivation with an unencrypted dev keystore (ADR 080).
+      assertKeystoreAllowedForNetwork(network, globals());
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, resolveSigningKeyRef(globals()));
       const signer = new KeyManagerSigner(api.kms.kms, keyId);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,8 +1,10 @@
+export { registerInitCommand } from './init.js';
 export { registerCreateCommand } from './create.js';
 export { registerResolveCommand } from './resolve.js';
 export { registerUpdateCommand } from './update.js';
 export { registerDeactivateCommand } from './deactivate.js';
 export { registerKeyCommand } from './key.js';
+export { registerKeystoreCommand } from './keystore.js';
 export { registerConfigCommand } from './config.js';
 export { registerProfileCommand } from './profile.js';
 export { registerCompletionCommand } from './completion.js';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,74 @@
+import type { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { defaultConfigPath, resolveKeystorePath, writeDefaultConfigFile } from '../config.js';
+import { ensureDir } from '../keystore/atomic.js';
+import { initKeystore, keystoreSummary } from '../keystore/file-key-store.js';
+import { acquirePassphrase } from '../keystore/passphrase.js';
+import { formatResult } from '../output.js';
+import { resolveHome } from '../paths.js';
+import type { CommandResult, GlobalOptions } from '../types.js';
+
+/**
+ * Registers the top-level `btcr2 init`: the one-command entry point that creates
+ * the btcr2 home (ADR 079), writes a default config if none exists, and
+ * establishes the keystore if none exists (encrypted with a confirmed passphrase
+ * by default, or `--dev` for an unencrypted testnet keystore). Idempotent:
+ * existing files are left untouched unless `--force` is given. Establishing the
+ * passphrase here, up front and confirmed, is what keeps the first `key generate`
+ * off the accidental-first-seal path (ADR 080).
+ */
+export function registerInitCommand(program: Command, globals: () => GlobalOptions): void {
+  const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
+
+  program
+    .command('init')
+    .description('Set up the btcr2 home: create the directory, a default config, and establish the keystore.')
+    .option('--dev', 'Establish an UNENCRYPTED dev keystore: plaintext keys, no passphrase. Testnet only.', false)
+    .option('--force', 'Re-create the config and keystore even if they already exist.', false)
+    .action((options: { dev?: boolean; force?: boolean }) => {
+      const g = globals();
+      const home = resolveHome(g);
+      const configPath = g.config ?? defaultConfigPath(g);
+      const keystorePath = resolveKeystorePath(g);
+      ensureDir(home, 0o700);
+
+      const created: string[] = [];
+
+      // The config is regenerable, so --force may re-scaffold it.
+      if (!existsSync(configPath) || options.force) {
+        writeDefaultConfigFile(configPath);
+        created.push('config');
+      }
+
+      // The keystore holds unrecoverable secret keys, so `init` never overwrites
+      // an existing one, even with --force: re-establishing a keystore is the
+      // explicit, deliberate `keystore init --force`. `init` only establishes a
+      // keystore when none exists.
+      const keystoreExists = existsSync(keystorePath);
+      if (keystoreExists && options.force && !g.quiet) {
+        process.stderr.write(
+          `note: a keystore already exists at ${keystorePath} and was left intact. `
+          + 'To re-establish it (discarding its keys), run "btcr2 keystore init --force".\n',
+        );
+      }
+      if (!keystoreExists) {
+        if (options.dev && !g.quiet) {
+          process.stderr.write(
+            'warning: establishing an UNENCRYPTED dev keystore. Keys are stored in plaintext. '
+            + 'Use it only for disposable testnet material; mainnet operations will be refused.\n',
+          );
+        }
+        initKeystore(keystorePath, {
+          protection    : options.dev ? 'none' : 'passphrase',
+          getPassphrase : (opts) => acquirePassphrase({ passphraseFile: g.passphraseFile, confirm: opts?.confirm, prompt: 'New keystore passphrase: ' }),
+        });
+        created.push('keystore');
+      }
+
+      const protection = keystoreSummary(keystorePath).protection;
+      print({ action: 'init', data: { home, config: configPath, keystore: keystorePath, created, protection } });
+      if (!g.quiet && g.output !== 'json') {
+        process.stderr.write(`btcr2 home ready at ${home}. Next: btcr2 key generate --set-active\n`);
+      }
+    });
+}

--- a/packages/cli/src/commands/keystore.ts
+++ b/packages/cli/src/commands/keystore.ts
@@ -1,0 +1,98 @@
+import type { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { resolveKeystorePath } from '../config.js';
+import { CLIError } from '../error.js';
+import { changeKeystorePassphrase, initKeystore, keystoreSummary } from '../keystore/file-key-store.js';
+import { acquirePassphrase } from '../keystore/passphrase.js';
+import { formatResult } from '../output.js';
+import type { CommandResult, GlobalOptions } from '../types.js';
+
+/**
+ * Registers the `keystore` command group: establish, inspect, and re-key the
+ * encrypted keystore (ADR 080). These operate on the keystore file directly (no
+ * Bitcoin connection or KeyManager) and never decrypt a key except when
+ * re-sealing during `change-passphrase`.
+ */
+export function registerKeystoreCommand(program: Command, globals: () => GlobalOptions): void {
+  const keystore = program.command('keystore').description('Establish, inspect, and re-key the keystore.');
+  const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
+
+  keystore
+    .command('init')
+    .description('Establish the keystore (encrypted by default). Prompts for a passphrase and confirms it.')
+    .option('--dev', 'Create an UNENCRYPTED dev keystore: plaintext keys, no passphrase. Testnet only; mainnet operations are refused.', false)
+    .option('--force', 'Re-establish even if a keystore already exists (discards its keys).', false)
+    .action((options: { dev?: boolean; force?: boolean }) => {
+      const g = globals();
+      const path = resolveKeystorePath(g);
+      if (existsSync(path) && !options.force) {
+        throw new CLIError(
+          `A keystore already exists at ${path}. Use --force to re-establish it (this discards its keys).`,
+          'INVALID_ARGUMENT_ERROR',
+          { path },
+        );
+      }
+      // --force re-establishes over an existing keystore; make the key loss loud.
+      if (existsSync(path) && options.force && !g.quiet) {
+        const { keyCount } = keystoreSummary(path);
+        if (keyCount > 0) {
+          process.stderr.write(
+            `warning: re-establishing the keystore at ${path} permanently discards its ${keyCount} existing key(s).\n`,
+          );
+        }
+      }
+      if (options.dev && !g.quiet) {
+        process.stderr.write(
+          'warning: creating an UNENCRYPTED dev keystore. Keys are stored in plaintext. '
+          + 'Use it only for disposable testnet material; mainnet operations will be refused.\n',
+        );
+      }
+      initKeystore(path, {
+        protection    : options.dev ? 'none' : 'passphrase',
+        getPassphrase : (opts) => acquirePassphrase({ passphraseFile: g.passphraseFile, confirm: opts?.confirm, prompt: 'New keystore passphrase: ' }),
+      });
+      print({ action: 'keystore-init', data: { path, protection: options.dev ? 'dev' : 'encrypted' } });
+    });
+
+  keystore
+    .command('status')
+    .description('Show the keystore path, protection mode, and key count. Never decrypts or prompts.')
+    .action(() => {
+      const g = globals();
+      // Diagnostic command: report status even when the config is malformed,
+      // rather than crashing on the config you ran this to inspect.
+      const path = resolveKeystorePath(g, { lenient: true });
+      const summary = keystoreSummary(path);
+      if (summary.protection === 'dev' && !g.quiet && g.output !== 'json') {
+        process.stderr.write('warning: this is an UNENCRYPTED dev keystore; keys are stored in plaintext.\n');
+      }
+      print({ action: 'keystore-status', data: { path, ...summary } });
+    });
+
+  keystore
+    .command('change-passphrase')
+    .alias('passwd')
+    .description('Change the keystore passphrase, re-sealing every key under the new one. Encrypted keystores only.')
+    .action(() => {
+      const g = globals();
+      const path = resolveKeystorePath(g);
+      const summary = keystoreSummary(path);
+      if (summary.protection === 'absent') {
+        throw new CLIError(`No keystore at ${path}. Run "btcr2 keystore init" first.`, 'INVALID_ARGUMENT_ERROR', { path });
+      }
+      if (summary.protection === 'dev') {
+        throw new CLIError(
+          `The keystore at ${path} is an unencrypted dev keystore; there is no passphrase to change.`,
+          'INVALID_ARGUMENT_ERROR',
+          { path },
+        );
+      }
+      // Current passphrase may come from the env var / file (unattended); the new
+      // one must be entered fresh (forcePrompt) so it cannot be silently satisfied
+      // by the same source and make the change a no-op.
+      const oldPassphrase = acquirePassphrase({ passphraseFile: g.passphraseFile, prompt: 'Current keystore passphrase: ' });
+      const newPassphrase = acquirePassphrase({ forcePrompt: true, confirm: true, prompt: 'New keystore passphrase: ' });
+      const rekeyed = changeKeystorePassphrase(path, oldPassphrase, newPassphrase);
+      print({ action: 'keystore-change-passphrase', data: { path, rekeyed } });
+    });
+}

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -7,7 +7,7 @@ import type { CommandResult, GlobalOptions } from '../types.js';
 /** Registers the `profile` command group for managing configuration profiles. */
 export function registerProfileCommand(program: Command, globals: () => GlobalOptions): void {
   const profile = program.command('profile').description('Manage configuration profiles.');
-  const path = (): string => globals().config ?? defaultConfigPath();
+  const path = (): string => globals().config ?? defaultConfigPath(globals());
   const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
 
   profile

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,7 +1,7 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
-import { deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
+import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
@@ -88,6 +88,8 @@ export function registerUpdateCommand(
         );
       }
       const network = deriveNetwork(did);
+      // Refuse to sign a mainnet update with an unencrypted dev keystore (ADR 080).
+      assertKeystoreAllowedForNetwork(network, globals());
       const api = factory(network, globals());
       const keyId = resolveKeyRef(api.kms.kms, resolveSigningKeyRef(globals()));
       const signer = new KeyManagerSigner(api.kms.kms, keyId);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,14 +3,17 @@ import type { KeyManager } from '@did-btcr2/key-manager';
 import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { BroadcastOptions } from '@did-btcr2/method';
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 import { CLIError } from './error.js';
 import { ensureDir, writeFileAtomic } from './keystore/atomic.js';
 import { FileBackedKeyManager } from './keystore/file-backed-key-manager.js';
+import { keystoreProtection } from './keystore/file-key-store.js';
 import { defaultKeystorePath } from './keystore/paths.js';
 import { acquirePassphrase } from './keystore/passphrase.js';
-import { blankToUndef, SUPPORTED_NETWORKS, type NetworkOption, type OutputFormat } from './types.js';
+import { defaultConfigPath } from './paths.js';
+import { blankToUndef, SUPPORTED_NETWORKS, type KeystoreProtectionLabel, type NetworkOption, type OutputFormat } from './types.js';
+
+export { defaultConfigPath };
 
 /**
  * Endpoint overrides provided via CLI flags, env vars, or config file.
@@ -39,9 +42,11 @@ export type ConnectionOverrides = {
   btcRpcWallet?   : string;
   /** Extra Bitcoin Core RPC headers as raw `Key: Value` flag values (repeatable). */
   btcRpcHeader?   : string[];
+  /** CLI home root from `--home`. Colocates config.json + keystore.json (ADR 079). */
+  home?           : string;
   config?         : string;
   profile?        : string;
-  /** Keystore file path. Overrides the default `$XDG_DATA_HOME/btcr2/keystore.json`. */
+  /** Keystore file path. Overrides the home default `<home>/keystore.json`. */
   keystore?       : string;
   /** Path to a file holding the keystore passphrase (for unattended use). */
   passphraseFile? : string;
@@ -144,6 +149,22 @@ export function writeConfigFile(path: string, mutate: (raw: Record<string, unkno
   writeFileAtomic(path, `${JSON.stringify(raw, null, 2)}\n`, 0o600);
 }
 
+/**
+ * Writes a default config scaffold to `path`: schema version, a `text` output
+ * default, and one empty profile per supported network. Shared by `config init`
+ * and `btcr2 init` so the seeded config is identical. Writes atomically (file
+ * 0600, dir 0700); the caller decides whether to overwrite an existing file.
+ */
+export function writeDefaultConfigFile(path: string): void {
+  const scaffold = {
+    schemaVersion : CONFIG_SCHEMA_VERSION,
+    defaults      : { output: 'text' },
+    profiles      : Object.fromEntries(SUPPORTED_NETWORKS.map(n => [ n, {} ])),
+  };
+  ensureDir(dirname(path), 0o700);
+  writeFileAtomic(path, `${JSON.stringify(scaffold, null, 2)}\n`, 0o600);
+}
+
 /** Reads the value at a dotted path (e.g. `profiles.regtest.btc.rest`). */
 export function getConfigPath(config: Record<string, unknown>, path: string): unknown {
   return path.split('.').reduce<unknown>(
@@ -242,21 +263,6 @@ export function readEnvOverrides(): ConnectionOverrides {
     casGateway : env(ENV_VARS.CAS_GATEWAY),
     casRpcUrl  : env(ENV_VARS.CAS_RPC_URL),
   };
-}
-
-/**
- * Default config file path following the XDG Base Directory Specification.
- *
- * Resolution order:
- * 1. `$XDG_CONFIG_HOME/btcr2/config.json`
- * 2. `%APPDATA%/btcr2/config.json` (Windows)
- * 3. `~/.config/btcr2/config.json` (fallback)
- */
-export function defaultConfigPath(): string {
-  const base = blankToUndef(process.env.XDG_CONFIG_HOME)
-    ?? blankToUndef(process.env.APPDATA)
-    ?? join(homedir(), '.config');
-  return join(base, 'btcr2', 'config.json');
 }
 
 /**
@@ -379,7 +385,7 @@ export function resolveActiveProfile(
  * identifier encodes.
  */
 export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkOption {
-  const configPath = overrides?.config ?? defaultConfigPath();
+  const configPath = overrides?.config ?? defaultConfigPath(overrides);
   const file = readConfigFile(configPath);
 
   const explicit = file?.defaults?.network;
@@ -407,7 +413,7 @@ export function profileNetworkMismatch(
   // command that actually resolves a connection.
   let file: ConfigFile | undefined;
   try {
-    file = readConfigFile(overrides?.config ?? defaultConfigPath());
+    file = readConfigFile(overrides?.config ?? defaultConfigPath(overrides));
   } catch {
     return undefined;
   }
@@ -422,13 +428,13 @@ export function profileNetworkMismatch(
  * then `'text'`. A malformed config never blocks output resolution (the command's
  * own read path surfaces it); output format falls back to `'text'` instead.
  */
-export function resolveOutputFormat(options: { output?: string; config?: string }): OutputFormat {
+export function resolveOutputFormat(options: { output?: string; config?: string; home?: string }): OutputFormat {
   const candidates: Array<string | undefined> = [
     blankToUndef(options.output),
     process.env.BTCR2_OUTPUT || undefined,
   ];
   try {
-    candidates.push(readConfigFile(options.config ?? defaultConfigPath())?.defaults?.output);
+    candidates.push(readConfigFile(options.config ?? defaultConfigPath(options))?.defaults?.output);
   } catch {
     // Output format is cosmetic; a broken config is reported by the command
     // itself rather than aborting here (which would block a recovery command).
@@ -501,7 +507,7 @@ export function resolveConnectionConfig(
   // Layer 1: Config file profile (lowest precedence of the three override layers).
   // The active-profile name is resolved through the same shared helper as
   // resolveDefaultNetwork so the two cannot disagree about which profile is live.
-  const configPath = overrides?.config ?? defaultConfigPath();
+  const configPath = overrides?.config ?? defaultConfigPath(overrides);
   const file = readConfigFile(configPath);
   const { name: activeProfile } = resolveActiveProfile(file, overrides);
   const profileName = activeProfile ?? network;
@@ -708,7 +714,7 @@ export function resolveBroadcastOptions(
   overrides: ConnectionOverrides | undefined,
   flags    : { feeRate?: string; changeAddress?: string },
 ): BroadcastOptions | undefined {
-  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath(overrides));
   const { name: activeProfile } = resolveActiveProfile(file, overrides);
   const profileBtc = file?.profiles?.[activeProfile ?? network]?.btc;
 
@@ -778,7 +784,7 @@ export interface EffectiveConfig {
  * and each `source` is derived by the same precedence order the merge uses.
  */
 export function resolveEffectiveConfig(network: NetworkOption, overrides?: ConnectionOverrides): EffectiveConfig {
-  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath(overrides));
   const { name: activeProfile } = resolveActiveProfile(file, overrides);
   const profileName = activeProfile ?? network;
   const fileOv = file ? profileToOverrides(file, profileName) : {};
@@ -944,17 +950,65 @@ export function defaultApiFactory(network?: NetworkOption, overrides?: Connectio
 function buildKeystoreKms(overrides?: ConnectionOverrides): KeyManager {
   return new FileBackedKeyManager({
     path          : resolveKeystorePath(overrides),
-    getPassphrase : () => acquirePassphrase({ passphraseFile: overrides?.passphraseFile }),
+    // The store decides when to confirm: it passes `confirm: true` only while
+    // establishing a fresh keystore's passphrase, so a first-key typo is caught
+    // by a second entry (ADR 080). confirm is a no-op for env/file sources.
+    getPassphrase : (opts) => acquirePassphrase({ passphraseFile: overrides?.passphraseFile, confirm: opts?.confirm }),
   });
 }
 
 /**
- * Resolves the keystore file path: the `--keystore` flag, else the active
- * profile's `identity.keystore`, else the default XDG keystore path. The flag
- * always wins over the profile default.
+ * The protection mode of the resolved keystore, read without decrypting or
+ * prompting: `encrypted`, `dev` (plaintext), or `absent`. Used by `keystore
+ * status`, `config path`, and the mainnet guard.
  */
-export function resolveKeystorePath(overrides?: ConnectionOverrides): string {
-  return overrides?.keystore ?? activeProfileIdentity(overrides)?.keystore ?? defaultKeystorePath();
+export function resolveKeystoreProtection(overrides?: ConnectionOverrides): KeystoreProtectionLabel {
+  return keystoreProtection(resolveKeystorePath(overrides));
+}
+
+/**
+ * Hard-refuses using an unencrypted dev keystore for a mainnet operation (ADR
+ * 080). A plaintext key must never sign or seal a `bitcoin` did:btcr2; the check
+ * reads only the keystore's protection header, so it never decrypts or prompts.
+ * A no-op for every other network and for encrypted/absent keystores.
+ */
+export function assertKeystoreAllowedForNetwork(network: NetworkOption, overrides?: ConnectionOverrides): void {
+  if (network !== 'bitcoin') return;
+  if (resolveKeystoreProtection(overrides) !== 'dev') return;
+  const path = resolveKeystorePath(overrides);
+  throw new CLIError(
+    `Refusing a mainnet (bitcoin) operation with the unencrypted dev keystore at ${path}. `
+    + 'Dev keystores hold plaintext keys and are for testnet/regtest throwaway material only. '
+    + 'Establish an encrypted keystore (btcr2 keystore init) for mainnet keys.',
+    'DEV_KEYSTORE_MAINNET_ERROR',
+    { path, network },
+  );
+}
+
+/**
+ * Resolves the keystore file path: the `--keystore` flag, else the active
+ * profile's `identity.keystore`, else the default `<home>/keystore.json` (ADR
+ * 079). The flag always wins over the profile default and never reads the config.
+ *
+ * A malformed config aborts loudly by default so a keystore-mutating command
+ * never silently reads or writes the wrong store. Pass `lenient: true` only for
+ * diagnostic/recovery commands (`config path`, `keystore status`) that must still
+ * report a path instead of crashing on the very config you ran them to fix; those
+ * fall back to the home default when the profile identity cannot be read.
+ */
+export function resolveKeystorePath(overrides?: ConnectionOverrides, options?: { lenient?: boolean }): string {
+  // The flag wins outright and short-circuits before any config read. A blank
+  // flag defers to the profile, and a blank profile `identity.keystore` defers to
+  // the default, so neither resolves the keystore to an empty path.
+  const fromFlag = blankToUndef(overrides?.keystore);
+  if (fromFlag) return fromFlag;
+  let identity: { keystore?: string; default?: string } | undefined;
+  try {
+    identity = activeProfileIdentity(overrides);
+  } catch (error) {
+    if (!options?.lenient) throw error;
+  }
+  return blankToUndef(identity?.keystore) ?? defaultKeystorePath(overrides);
 }
 
 /**
@@ -963,7 +1017,14 @@ export function resolveKeystorePath(overrides?: ConnectionOverrides): string {
  * selected by `--profile` or the config's `defaults.profile`.
  */
 function activeProfileIdentity(overrides?: ConnectionOverrides): { keystore?: string; default?: string } | undefined {
-  const file = readConfigFile(overrides?.config ?? defaultConfigPath());
+  // Intentionally propagates a malformed-config error rather than swallowing it.
+  // This feeds resolveKeystorePath for keystore-mutating commands (key generate/
+  // import, keystore init/change-passphrase) and the mainnet dev-keystore guard,
+  // so a broken config must abort loudly instead of silently resolving to the
+  // default keystore and stranding key material there. Diagnostic-only commands
+  // opt into a graceful fallback via resolveKeystorePath's `lenient` option; do
+  // not add a try/catch here (it would re-hide the keystore misdirection).
+  const file = readConfigFile(overrides?.config ?? defaultConfigPath(overrides));
   const { name } = resolveActiveProfile(file, overrides);
   return name ? file?.profiles?.[name]?.identity : undefined;
 }

--- a/packages/cli/src/keystore/file-key-store.ts
+++ b/packages/cli/src/keystore/file-key-store.ts
@@ -1,7 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { KeyEntry, KeyIdentifier, KeyValueStore } from '@did-btcr2/key-manager';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { base64urlnopad } from '@scure/base';
+import type { KeystoreProtectionLabel } from '../types.js';
 import { assertSecurePerms, ensureDir, writeFileAtomic } from './atomic.js';
 import { DEFAULT_ARGON_PARAMS, decryptSecret, encryptSecret } from './envelope.js';
 import type { ArgonParams, SecretEnvelope } from './envelope.js';
@@ -12,18 +14,56 @@ import { defaultKeystorePath } from './paths.js';
 /** Current on-disk keystore file format version. */
 export const KEYSTORE_VERSION = 1 as const;
 
-/** One key as stored on disk: public material in clear, secret sealed (or absent for watch-only). */
+/**
+ * How a keystore protects its secrets on disk:
+ * - `passphrase`: each secret is sealed in its own argon2id + XChaCha20-Poly1305
+ *   envelope, all opened by one shared, verifier-checked passphrase.
+ * - `none`: a dev keystore; secrets are stored as plaintext bytes. Never prompts;
+ *   refused for mainnet (ADR 080). For disposable testnet material only.
+ */
+export type KeystoreProtection = 'passphrase' | 'none';
+
+/**
+ * Fixed sentinel sealed under the keystore passphrase and stored as the file's
+ * `verifier`. Decrypting it checks a candidate passphrase before any real secret
+ * is sealed or opened, so a typo fails loudly instead of corrupting the store.
+ */
+const VERIFIER_PLAINTEXT = utf8ToBytes('did-btcr2-keystore-verifier-v1');
+
+/** Constant-length-independent byte compare for the verifier sentinel. */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/** Whether two secret envelopes are byte-identical (structural JSON compare). */
+function sameEnvelope(a: SecretEnvelope | undefined, b: SecretEnvelope | undefined): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * One key as stored on disk: public material in clear, and the secret either
+ * sealed (`secret`, encrypted keystore), stored in the clear (`plainSecret`, dev
+ * keystore), or absent (watch-only).
+ */
 type StoredKey = {
-  publicKey : string;
-  tags?     : Record<string, string>;
-  secret?   : SecretEnvelope;
+  publicKey    : string;
+  tags?        : Record<string, string>;
+  secret?      : SecretEnvelope;
+  plainSecret? : string;
 };
 
 /** The whole keystore file. */
 type KeystoreFile = {
-  v       : typeof KEYSTORE_VERSION;
-  active? : string;
-  keys    : Record<string, StoredKey>;
+  v           : typeof KEYSTORE_VERSION;
+  /** Protection mode, present on every keystore this CLI writes: `passphrase` (encrypted) or `none` (dev). */
+  protection? : KeystoreProtection;
+  /** Passphrase verifier, present once an encrypted keystore's passphrase is established. */
+  verifier?   : SecretEnvelope;
+  active?     : string;
+  keys        : Record<string, StoredKey>;
 };
 
 /** One key in the in-memory cache; the materialized secret is retained per session once decrypted. */
@@ -31,6 +71,8 @@ type CacheEntry = {
   publicKey  : Uint8Array;
   tags?      : Record<string, string>;
   secret?    : SecretEnvelope;
+  /** True for a dev-keystore entry whose `decrypted` bytes are stored plaintext, not sealed. */
+  plaintext? : boolean;
   decrypted? : Uint8Array;
 };
 
@@ -38,28 +80,45 @@ type CacheEntry = {
 export type FileKeyStoreOptions = {
   /** Keystore file path. Defaults to {@link defaultKeystorePath}. */
   path?: string;
-  /** Supplies the passphrase lazily, called only when a secret must be sealed or opened. */
-  getPassphrase: () => string;
+  /**
+   * Supplies the passphrase lazily, called only when a secret must be sealed or
+   * opened. `confirm` is passed as `true` only while establishing a fresh
+   * encrypted keystore's passphrase, so the provider prompts twice and requires
+   * a match; it is a no-op for non-interactive sources.
+   */
+  getPassphrase: (opts?: { confirm?: boolean }) => string;
   /** argon2id cost parameters used when sealing new secrets. Defaults to {@link DEFAULT_ARGON_PARAMS}. */
   argonParams?: ArgonParams;
   /** Tuning for the cross-process write lock. Defaults documented on {@link LockOptions}. */
   lock?: LockOptions;
+  /**
+   * Protection mode to use when *establishing* a fresh keystore. Defaults to
+   * `passphrase` (encrypted). Ignored for an existing keystore, whose on-disk
+   * `protection` always wins.
+   */
+  protection?: KeystoreProtection;
 };
 
 /**
- * A Node-only, file-backed {@link KeyValueStore} that encrypts secret keys at
+ * A Node-only, file-backed {@link KeyValueStore} that protects secret keys at
  * rest. It satisfies the synchronous store contract by caching the parsed file
  * in memory at construction and flushing the whole file atomically on every
  * mutation.
  *
+ * Encrypted keystores seal each secret in its own argon2id + XChaCha20-Poly1305
+ * envelope under one shared passphrase, and store a `verifier` sentinel so a
+ * candidate passphrase is checked before it is used (ADR 080): the first
+ * passphrase is established with a confirm prompt, and every later use is
+ * verified, so a typo is a loud failure rather than a key sealed under an
+ * unknown or divergent passphrase. Dev keystores (`protection: 'none'`) store
+ * secrets as plaintext and never prompt; they are refused for mainnet by the
+ * command layer.
+ *
  * Every mutation runs under an exclusive cross-process lock and, inside that
- * lock, reloads the file from disk before applying its change and flushing.
- * Caching at construction and flushing the whole file is otherwise a lost-update
- * race: two `btcr2` processes that each load, then each write, would have the
- * second overwrite the first. The lock serializes the writers and the reload
- * merges any change the other made, so concurrent invocations compose instead of
- * clobbering. Reads stay lock-free: an atomic rename means a concurrent reader
- * always sees a complete file, old or new.
+ * lock, reloads the file from disk before applying its change and flushing, so
+ * concurrent `btcr2` invocations compose instead of clobbering. Reads stay
+ * lock-free: an atomic rename means a concurrent reader always sees a complete
+ * file, old or new.
  *
  * Secrets are materialized only through {@link FileKeyStore.get}. The
  * {@link FileKeyStore.list} and {@link FileKeyStore.entries} projections omit
@@ -70,10 +129,12 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
   readonly #path: string;
   readonly #lockPath: string;
   readonly #lockOptions: LockOptions;
-  readonly #getPassphrase: () => string;
+  readonly #getPassphrase: (opts?: { confirm?: boolean }) => string;
   readonly #argonParams: ArgonParams;
   readonly #cache: Map<KeyIdentifier, CacheEntry> = new Map();
   #active: string | undefined;
+  #protection: KeystoreProtection;
+  #verifier: SecretEnvelope | undefined;
 
   constructor(options: FileKeyStoreOptions) {
     this.#path = options.path ?? defaultKeystorePath();
@@ -81,6 +142,9 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
     this.#lockOptions = options.lock ?? {};
     this.#getPassphrase = options.getPassphrase;
     this.#argonParams = options.argonParams ?? DEFAULT_ARGON_PARAMS;
+    // The requested mode applies only when establishing a fresh keystore; an
+    // existing file's on-disk protection overrides it in #loadFromDisk.
+    this.#protection = options.protection ?? 'passphrase';
     ensureDir(dirname(this.#path), 0o700);
     this.#loadFromDisk();
   }
@@ -105,7 +169,34 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
         { version: parsed.v },
       );
     }
+    // Every keystore this CLI writes carries a recognized protection header. A
+    // file without one was not written by this CLI (there is no pre-header
+    // format to accommodate); refuse it rather than guess how its secrets are
+    // protected.
+    if (parsed.protection !== 'none' && parsed.protection !== 'passphrase') {
+      throw new KeyStoreError(
+        `Keystore at ${this.#path} has no recognized protection header; it was not written by this CLI.`,
+        'KEYSTORE_CORRUPT_ERROR',
+        { path: this.#path },
+      );
+    }
+    this.#protection = parsed.protection;
+    this.#verifier = parsed.verifier;
     this.#active = parsed.active;
+    // An encrypted keystore that holds sealed keys must carry the verifier that
+    // established its passphrase. Without it, the verify-or-establish decision in
+    // #sealPassphrase could take the establish path over existing sealed keys and
+    // seal a new key under a divergent passphrase; refuse the file instead.
+    const sealedPresent = Object.values(parsed.keys ?? {}).some(
+      k => k && typeof k === 'object' && (k as StoredKey).secret !== undefined,
+    );
+    if (this.#protection === 'passphrase' && sealedPresent && this.#verifier === undefined) {
+      throw new KeyStoreError(
+        `Keystore at ${this.#path} holds sealed keys but no passphrase verifier; it is corrupt or was tampered with.`,
+        'KEYSTORE_CORRUPT_ERROR',
+        { path: this.#path },
+      );
+    }
     for (const [ id, stored ] of Object.entries(parsed.keys ?? {})) {
       let publicKey: Uint8Array;
       try {
@@ -125,25 +216,75 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
           { path: this.#path, keyId: id },
         );
       }
-      this.#cache.set(id, {
-        publicKey,
-        ...(stored.tags && { tags: stored.tags }),
-        ...(stored.secret && { secret: stored.secret }),
-      });
+      const entry: CacheEntry = { publicKey, ...(stored.tags && { tags: stored.tags }) };
+      // A secret's storage form must match the keystore's protection mode: a dev
+      // keystore holds plaintext, an encrypted keystore holds sealed envelopes. A
+      // mismatch is a tampered or foreign file, not something to open blindly.
+      if (stored.plainSecret !== undefined) {
+        if (this.#protection !== 'none') {
+          throw new KeyStoreError(
+            `Keystore entry ${id} holds a plaintext secret in an encrypted keystore at ${this.#path}.`,
+            'KEYSTORE_CORRUPT_ERROR',
+            { path: this.#path, keyId: id },
+          );
+        }
+        entry.plaintext = true;
+        entry.decrypted = this.#decodePlainSecret(stored.plainSecret, id);
+      } else if (stored.secret) {
+        if (this.#protection !== 'passphrase') {
+          throw new KeyStoreError(
+            `Keystore entry ${id} holds a sealed secret in a dev keystore at ${this.#path}.`,
+            'KEYSTORE_CORRUPT_ERROR',
+            { path: this.#path, keyId: id },
+          );
+        }
+        entry.secret = stored.secret;
+      }
+      this.#cache.set(id, entry);
     }
+  }
+
+  /** Decodes and length-checks a dev-keystore plaintext secret. */
+  #decodePlainSecret(encoded: string, id: KeyIdentifier): Uint8Array {
+    let secret: Uint8Array;
+    try {
+      secret = base64urlnopad.decode(encoded);
+    } catch {
+      throw new KeyStoreError(
+        `Keystore entry ${id} has a malformed plaintext secret.`,
+        'KEYSTORE_CORRUPT_ERROR',
+        { path: this.#path, keyId: id },
+      );
+    }
+    if (secret.length !== 32) {
+      throw new KeyStoreError(
+        `Keystore entry ${id} has a ${secret.length}-byte secret; expected 32.`,
+        'KEYSTORE_CORRUPT_ERROR',
+        { path: this.#path, keyId: id },
+      );
+    }
+    return secret;
   }
 
   #flush(): void {
     const keys: Record<string, StoredKey> = {};
     for (const [ id, entry ] of this.#cache) {
-      keys[id] = {
-        publicKey : base64urlnopad.encode(entry.publicKey),
-        ...(entry.tags && { tags: entry.tags }),
-        ...(entry.secret && { secret: entry.secret }),
-      };
+      const stored: StoredKey = { publicKey: base64urlnopad.encode(entry.publicKey) };
+      if (entry.tags) stored.tags = entry.tags;
+      if (entry.plaintext && entry.decrypted) {
+        stored.plainSecret = base64urlnopad.encode(entry.decrypted);
+      } else if (entry.secret) {
+        stored.secret = entry.secret;
+      }
+      keys[id] = stored;
     }
+    // Every keystore this CLI writes self-describes: the protection header is
+    // always present (`passphrase` for encrypted, `none` for dev), so a file is
+    // never ambiguous about how its secrets are protected.
     const file: KeystoreFile = {
-      v : KEYSTORE_VERSION,
+      v          : KEYSTORE_VERSION,
+      protection : this.#protection,
+      ...(this.#verifier && { verifier: this.#verifier }),
       ...(this.#active && { active: this.#active }),
       keys,
     };
@@ -155,7 +296,8 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
    * mutation applies on top of whatever other processes have written. Secrets
    * already decrypted this session are carried over for entries whose sealed
    * envelope is byte-identical on disk, so a mid-session write does not force a
-   * re-prompt for keys it did not touch.
+   * re-prompt for keys it did not touch. (Dev-keystore plaintext secrets are
+   * reloaded from disk, so they need no carry.)
    */
   #reload(): void {
     const carried = new Map<KeyIdentifier, { secret: SecretEnvelope; decrypted: Uint8Array }>();
@@ -188,6 +330,56 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
     }, this.#lockOptions);
   }
 
+  /**
+   * Verifies a candidate passphrase against the keystore verifier, throwing when
+   * it does not open the sentinel. A no-op only on a fresh keystore whose
+   * passphrase has not been established yet (no verifier to check against).
+   */
+  #assertPassphrase(passphrase: string): void {
+    if (!this.#verifier) return;
+    let plain: Uint8Array;
+    try {
+      plain = decryptSecret(this.#verifier, passphrase);
+    } catch {
+      throw new KeyStoreError(
+        `Incorrect passphrase for the keystore at ${this.#path}.`,
+        'DECRYPT_ERROR',
+        { path: this.#path },
+      );
+    }
+    if (!bytesEqual(plain, VERIFIER_PLAINTEXT)) {
+      throw new KeyStoreError(
+        `Keystore verifier at ${this.#path} did not match; the file may be corrupt.`,
+        'KEYSTORE_CORRUPT_ERROR',
+        { path: this.#path },
+      );
+    }
+  }
+
+  /** Passphrase for opening an existing secret: verified when a verifier exists. */
+  #openPassphrase(): string {
+    const passphrase = this.#getPassphrase();
+    this.#assertPassphrase(passphrase);
+    return passphrase;
+  }
+
+  /**
+   * Passphrase for sealing a secret. When the keystore's passphrase is already
+   * established (a verifier exists), prompt once and verify it. Otherwise this is
+   * establishment on a fresh keystore: prompt with confirm and mint a verifier for
+   * the caller to persist alongside the first sealed key.
+   */
+  #sealPassphrase(): { passphrase: string; newVerifier?: SecretEnvelope } {
+    if (this.#verifier) {
+      const passphrase = this.#getPassphrase();
+      this.#assertPassphrase(passphrase);
+      return { passphrase };
+    }
+    const passphrase = this.#getPassphrase({ confirm: true });
+    const newVerifier = encryptSecret(VERIFIER_PLAINTEXT, passphrase, this.#argonParams);
+    return { passphrase, newVerifier };
+  }
+
   get(id: KeyIdentifier): KeyEntry | undefined {
     const entry = this.#cache.get(id);
     if (!entry) return undefined;
@@ -195,18 +387,25 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
       publicKey : entry.publicKey,
       ...(entry.tags && { tags: entry.tags }),
     };
-    if (entry.secret) {
-      // Materialize the secret lazily, only when it is actually accessed, so
-      // reads that need just public material (an active-key existence check,
-      // getPublicKey, getEntry) never trigger a passphrase prompt. The property
-      // is non-enumerable so spreading or serializing the entry cannot silently
-      // decrypt the secret.
+    if (entry.plaintext && entry.decrypted) {
+      // Dev keystore: plaintext already materialized; expose without a prompt.
+      const secret = entry.decrypted;
+      Object.defineProperty(result, 'secretKey', {
+        configurable : true,
+        enumerable   : false,
+        get          : (): Uint8Array => secret,
+      });
+    } else if (entry.secret) {
+      // Materialize the sealed secret lazily, only when it is actually accessed,
+      // so reads that need just public material never trigger a passphrase
+      // prompt. The property is non-enumerable so spreading or serializing the
+      // entry cannot silently decrypt the secret.
       const sealed = entry.secret;
       Object.defineProperty(result, 'secretKey', {
         configurable : true,
         enumerable   : false,
         get          : (): Uint8Array => {
-          entry.decrypted ??= decryptSecret(sealed, this.#getPassphrase());
+          entry.decrypted ??= decryptSecret(sealed, this.#openPassphrase());
           return entry.decrypted;
         },
       });
@@ -219,16 +418,59 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
   }
 
   set(id: KeyIdentifier, value: KeyEntry): void {
-    // Seal the secret before taking the lock: argon2id is deliberately slow and
-    // must not extend the critical section that blocks other processes.
-    const secret = value.secretKey
-      ? encryptSecret(value.secretKey, this.#getPassphrase(), this.#argonParams)
-      : undefined;
+    if (this.#protection === 'none') {
+      // Dev keystore: store the secret in the clear, never prompt.
+      this.#mutate(() => {
+        this.#cache.set(id, {
+          publicKey : value.publicKey,
+          ...(value.tags && { tags: value.tags }),
+          ...(value.secretKey && { plaintext: true, decrypted: value.secretKey }),
+        });
+      });
+      return;
+    }
+
+    // Encrypted keystore. Resolve (and, if establishing, confirm) the passphrase
+    // and seal the secret before taking the lock: argon2id is deliberately slow
+    // and must not extend the critical section that blocks other processes.
+    const verifierAtSeal = this.#verifier;
+    let sealed: SecretEnvelope | undefined;
+    let newVerifier: SecretEnvelope | undefined;
+    let passphrase: string | undefined;
+    if (value.secretKey) {
+      const resolved = this.#sealPassphrase();
+      passphrase = resolved.passphrase;
+      newVerifier = resolved.newVerifier;
+      sealed = encryptSecret(value.secretKey, passphrase, this.#argonParams);
+    }
     this.#mutate(() => {
+      // A secret sealed outside the lock must never be persisted under a
+      // passphrase that diverges from the keystore verifier (the key-loss class
+      // ADR 080 exists to prevent). Reconcile our seal-time view with whatever the
+      // reload sees before committing.
+      if (value.secretKey) {
+        if (this.#verifier === undefined && newVerifier !== undefined) {
+          // Establishing, and no concurrent writer beat us to it: record our verifier.
+          this.#verifier = newVerifier;
+        } else if (this.#verifier !== undefined && passphrase !== undefined) {
+          // A verifier exists: it pre-existed, was established concurrently while we
+          // sealed, or was rotated by a concurrent change-passphrase. If it was
+          // rotated out from under our seal, abort with a clear message; otherwise
+          // assert our passphrase still opens it before persisting the key.
+          if (verifierAtSeal !== undefined && !sameEnvelope(this.#verifier, verifierAtSeal)) {
+            throw new KeyStoreError(
+              `The keystore passphrase at ${this.#path} changed concurrently; re-run the command.`,
+              'KEYSTORE_CONCURRENT_CHANGE_ERROR',
+              { path: this.#path },
+            );
+          }
+          this.#assertPassphrase(passphrase);
+        }
+      }
       this.#cache.set(id, {
         publicKey : value.publicKey,
         ...(value.tags && { tags: value.tags }),
-        ...(secret && { secret }),
+        ...(sealed && { secret: sealed }),
         ...(value.secretKey && { decrypted: value.secretKey }),
       });
     });
@@ -302,4 +544,174 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
       this.#active = id;
     });
   }
+
+  /** The keystore's protection mode. */
+  get protection(): KeystoreProtection {
+    return this.#protection;
+  }
+
+  /**
+   * Re-seals every sealed secret and the verifier under a new passphrase (ADR
+   * 080), returning the number of secrets re-sealed. Verifies the current
+   * passphrase against the verifier first. Refused on a dev keystore, which has
+   * no passphrase.
+   */
+  changePassphrase(oldPassphrase: string, newPassphrase: string): number {
+    if (this.#protection === 'none') {
+      throw new KeyStoreError(
+        `The keystore at ${this.#path} is an unencrypted dev keystore; it has no passphrase to change.`,
+        'KEYSTORE_PROTECTION_ERROR',
+        { path: this.#path },
+      );
+    }
+    // Fail a wrong current passphrase up front (when a verifier exists) so a typo
+    // does not pay for a full re-seal before failing.
+    if (this.#verifier) this.#assertPassphrase(oldPassphrase);
+    // Precompute every re-seal and the new verifier BEFORE taking the lock:
+    // argon2id is deliberately slow, and holding the exclusive lock across many
+    // derivations could exceed the lock's stale threshold and let a concurrent
+    // process break a still-live lock. Each re-seal records the source envelope
+    // it derived from, so the locked section can abort on any concurrent change
+    // instead of corrupting. This follows the same do-expensive-work-before-the-
+    // lock contract as set().
+    const resealed = new Map<KeyIdentifier, { from: SecretEnvelope; to: SecretEnvelope; plain: Uint8Array }>();
+    for (const [ id, entry ] of this.#cache) {
+      if (!entry.secret) continue;
+      let plain: Uint8Array;
+      try {
+        plain = decryptSecret(entry.secret, oldPassphrase);
+      } catch {
+        throw new KeyStoreError(
+          `Incorrect current passphrase for the keystore at ${this.#path}.`,
+          'DECRYPT_ERROR',
+          { path: this.#path },
+        );
+      }
+      resealed.set(id, { from: entry.secret, to: encryptSecret(plain, newPassphrase, this.#argonParams), plain });
+    }
+    const newVerifier = encryptSecret(VERIFIER_PLAINTEXT, newPassphrase, this.#argonParams);
+    let rekeyed = 0;
+    this.#mutate(() => {
+      // The reload reflects any concurrent writer. Apply a precomputed re-seal
+      // only where the on-disk envelope still matches what it was derived from;
+      // abort if any sealed key changed or a new sealed key appeared that was not
+      // re-sealed, rather than leave a key under the old passphrase.
+      for (const [ id, entry ] of this.#cache) {
+        if (!entry.secret) continue;
+        const pre = resealed.get(id);
+        if (!pre || !sameEnvelope(pre.from, entry.secret)) {
+          throw new KeyStoreError(
+            `The keystore at ${this.#path} changed while its passphrase was being changed; re-run the command.`,
+            'KEYSTORE_CONCURRENT_CHANGE_ERROR',
+            { path: this.#path },
+          );
+        }
+        entry.secret = pre.to;
+        entry.decrypted = pre.plain;
+        rekeyed++;
+      }
+      this.#verifier = newVerifier;
+    });
+    return rekeyed;
+  }
+}
+
+/** A no-decrypt, no-prompt summary of a keystore file for `keystore status`. */
+export interface KeystoreSummary {
+  protection  : KeystoreProtectionLabel;
+  established : boolean;
+  keyCount    : number;
+  active      : string | undefined;
+}
+
+/**
+ * Summarizes a keystore file by structure alone: protection mode, whether a
+ * passphrase is established, key count, and active key. Never decrypts, never
+ * prompts, and never throws (a missing or unreadable file reports `absent`), so
+ * it is safe for `keystore status`, `config path`, and the mainnet dev-keystore
+ * guard.
+ */
+export function keystoreSummary(path: string): KeystoreSummary {
+  const absent: KeystoreSummary = { protection: 'absent', established: false, keyCount: 0, active: undefined };
+  if (!existsSync(path)) return absent;
+  let parsed: KeystoreFile;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as KeystoreFile;
+  } catch {
+    return absent;
+  }
+  const keys = (parsed.keys && typeof parsed.keys === 'object') ? parsed.keys : {};
+  const keyCount = Object.keys(keys).length;
+  const active = typeof parsed.active === 'string' ? parsed.active : undefined;
+
+  if (parsed.protection === 'none') {
+    return { protection: 'dev', established: true, keyCount, active };
+  }
+  if (parsed.protection === 'passphrase') {
+    // An encrypted keystore is "established" once its passphrase verifier exists
+    // (written by `init` or the first key-seal). Without it the passphrase has not
+    // been set yet: a freshly-created, still-empty encrypted keystore.
+    return { protection: 'encrypted', established: parsed.verifier !== undefined, keyCount, active };
+  }
+  // No recognized protection header: not a keystore this CLI wrote. Report absent
+  // (never throw) so `keystore status` stays a safe, no-decrypt introspection; an
+  // actual open of such a file is refused by FileKeyStore.
+  return absent;
+}
+
+/** The protection label of a keystore file, without decrypting or prompting. */
+export function keystoreProtection(path: string): KeystoreProtectionLabel {
+  return keystoreSummary(path).protection;
+}
+
+/** Options for {@link initKeystore}. */
+export interface InitKeystoreOptions {
+  protection    : KeystoreProtection;
+  getPassphrase : (opts?: { confirm?: boolean }) => string;
+  argonParams?  : ArgonParams;
+}
+
+/**
+ * Establishes a fresh keystore file (ADR 080). An encrypted keystore prompts
+ * (with confirm) for the passphrase and writes the verifier; a dev keystore
+ * writes a plaintext-mode header with no passphrase. The caller is responsible
+ * for refusing to overwrite an existing keystore; this always writes the file.
+ */
+export function initKeystore(path: string, options: InitKeystoreOptions): void {
+  ensureDir(dirname(path), 0o700);
+  let file: KeystoreFile;
+  if (options.protection === 'none') {
+    file = { v: KEYSTORE_VERSION, protection: 'none', keys: {} };
+  } else {
+    const passphrase = options.getPassphrase({ confirm: true });
+    const verifier = encryptSecret(VERIFIER_PLAINTEXT, passphrase, options.argonParams ?? DEFAULT_ARGON_PARAMS);
+    file = { v: KEYSTORE_VERSION, protection: 'passphrase', verifier, keys: {} };
+  }
+  writeFileAtomic(path, `${JSON.stringify(file, null, 2)}\n`, 0o600);
+}
+
+/**
+ * Re-seals every secret in an encrypted keystore under a new passphrase (ADR
+ * 080), returning the count re-sealed. The old and new passphrases are supplied
+ * explicitly, so the store's own passphrase provider is never invoked (a wrong
+ * current passphrase is caught by the verifier). Refused on a dev keystore.
+ */
+export function changeKeystorePassphrase(
+  path          : string,
+  oldPassphrase : string,
+  newPassphrase : string,
+  argonParams?  : ArgonParams,
+): number {
+  const store = new FileKeyStore({
+    path,
+    ...(argonParams && { argonParams }),
+    getPassphrase : () => {
+      throw new KeyStoreError(
+        `Unexpected passphrase prompt while changing the passphrase for ${path}.`,
+        'KEYSTORE_INTERNAL_ERROR',
+        { path },
+      );
+    },
+  });
+  return store.changePassphrase(oldPassphrase, newPassphrase);
 }

--- a/packages/cli/src/keystore/passphrase.ts
+++ b/packages/cli/src/keystore/passphrase.ts
@@ -12,6 +12,13 @@ export type PassphraseOptions = {
   prompt?: string;
   /** When true, prompt twice and require the entries to match (for a new keystore). */
   confirm?: boolean;
+  /**
+   * When true, skip the environment variable and passphrase file and require a
+   * fresh terminal entry. Used for the *new* passphrase in `change-passphrase`,
+   * where the env var / file holds the *current* passphrase and must not silently
+   * satisfy the new one (which would make the change a no-op).
+   */
+  forcePrompt?: boolean;
 };
 
 /**
@@ -19,16 +26,19 @@ export type PassphraseOptions = {
  * (which would leak into process listings and shell history). Resolution order:
  * the {@link ENV_KEYSTORE_PASSPHRASE} environment variable, a passphrase file,
  * then a non-echoing terminal prompt. Throws if none is available and standard
- * input is not a terminal.
+ * input is not a terminal. When `forcePrompt` is set, the env var and file are
+ * skipped and a terminal entry is required.
  */
 export function acquirePassphrase(options: PassphraseOptions = {}): string {
   // All sources are normalized identically (at most one trailing newline
   // removed) so the KDF input is source-independent.
-  const fromEnv = process.env[ENV_KEYSTORE_PASSPHRASE];
-  if (fromEnv) return assertNonEmpty(fromEnv.replace(/\r?\n$/, ''));
+  if (!options.forcePrompt) {
+    const fromEnv = process.env[ENV_KEYSTORE_PASSPHRASE];
+    if (fromEnv) return assertNonEmpty(fromEnv.replace(/\r?\n$/, ''));
 
-  if (options.passphraseFile) {
-    return assertNonEmpty(readFileSync(options.passphraseFile, 'utf-8').replace(/\r?\n$/, ''));
+    if (options.passphraseFile) {
+      return assertNonEmpty(readFileSync(options.passphraseFile, 'utf-8').replace(/\r?\n$/, ''));
+    }
   }
 
   if (!process.stdin.isTTY) {
@@ -57,8 +67,33 @@ function assertNonEmpty(passphrase: string): string {
 }
 
 /**
+ * A 4-byte shared buffer used only as an {@link Atomics.wait} target. It lets
+ * {@link promptHidden} block briefly on an empty non-blocking TTY instead of
+ * busy-spinning. It is never written to, so the wait always times out.
+ */
+const IDLE_WAIT = new Int32Array(new SharedArrayBuffer(4));
+
+/**
+ * Milliseconds to block on each empty read. Imperceptible to a typist yet long
+ * enough that an open prompt sits idle rather than pegging a CPU core.
+ */
+const IDLE_POLL_MS = 20;
+
+/**
+ * Removes the last whole UTF-8 character from an accumulating byte array in
+ * place: pops any trailing continuation bytes (0b10xxxxxx) then the leading
+ * byte. Exported for testing; a backspace mid-entry must not strand a fragment
+ * that later decodes to U+FFFD.
+ */
+export function dropLastUtf8Char(bytes: number[]): void {
+  while (bytes.length > 0 && (bytes[bytes.length - 1] & 0xc0) === 0x80) bytes.pop();
+  bytes.pop();
+}
+
+/**
  * Reads a line from the terminal synchronously without echoing keystrokes.
- * Bytes are accumulated and decoded as UTF-8 so multibyte passphrases survive.
+ * Bytes are accumulated and decoded as UTF-8 so multibyte passphrases survive,
+ * including a backspace that spans a whole multibyte character.
  * This path runs only when standard input is a terminal.
  */
 function promptHidden(label: string): string {
@@ -75,7 +110,12 @@ function promptHidden(label: string): string {
         read = readSync(stdin.fd, byte, 0, 1, null);
       } catch (error) {
         const code = (error as { code?: string }).code;
-        if (code === 'EAGAIN') continue; // no byte ready yet on a non-blocking TTY
+        if (code === 'EAGAIN') {
+          // No byte ready yet on a non-blocking TTY. Block briefly instead of
+          // spinning so an open prompt does not peg a CPU core while it waits.
+          Atomics.wait(IDLE_WAIT, 0, 0, IDLE_POLL_MS);
+          continue;
+        }
         if (code === 'EOF') break;
         throw error;
       }
@@ -86,7 +126,7 @@ function promptHidden(label: string): string {
         throw new KeyStoreError('Passphrase entry aborted.', 'PASSPHRASE_REQUIRED_ERROR');
       }
       if (ch === 0x7f || ch === 0x08) { // DEL or backspace
-        bytes.pop();
+        dropLastUtf8Char(bytes);
         continue;
       }
       bytes.push(ch);

--- a/packages/cli/src/keystore/paths.ts
+++ b/packages/cli/src/keystore/paths.ts
@@ -1,21 +1,8 @@
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { blankToUndef } from '../types.js';
-
 /**
- * Default keystore file path, following the XDG Base Directory Specification's
- * data directory. Secret key material is data a user accumulates, so it lives
- * under the data directory, kept separate from the configuration directory used
- * for portable settings.
- *
- * Resolution order:
- * 1. `$XDG_DATA_HOME/btcr2/keystore.json`
- * 2. `%LOCALAPPDATA%/btcr2/keystore.json` (Windows)
- * 3. `~/.local/share/btcr2/keystore.json` (fallback)
+ * The default keystore path now lives alongside the config file under a single
+ * CLI home root (`<home>/keystore.json`, ADR 079). The implementation lives in
+ * `../paths.ts` (the single source of truth for on-disk state locations); it is
+ * re-exported here so existing `./paths.js` importers in the keystore layer keep
+ * their import surface.
  */
-export function defaultKeystorePath(): string {
-  const base = blankToUndef(process.env.XDG_DATA_HOME)
-    ?? blankToUndef(process.env.LOCALAPPDATA)
-    ?? join(homedir(), '.local', 'share');
-  return join(base, 'btcr2', 'keystore.json');
-}
+export { defaultKeystorePath } from '../paths.js';

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,0 +1,79 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { blankToUndef } from './types.js';
+
+/**
+ * State-location overrides that influence where the CLI keeps its home
+ * directory and its two state files. A subset of the broader
+ * `ConnectionOverrides`, restated here so this module (the single source of
+ * truth for on-disk locations) has no runtime dependency on `config.ts`.
+ */
+export interface PathOverrides {
+  /** Explicit home root from the `--home` flag. Wins over `$BTCR2_HOME`. */
+  home?     : string;
+  /** Explicit config-file path from the `--config` flag. Overrides the home default. */
+  config?   : string;
+  /** Explicit keystore path from the `--keystore` flag. Overrides the home default. */
+  keystore? : string;
+}
+
+/** Environment variable naming the CLI home directory (all state colocated). */
+export const ENV_HOME = 'BTCR2_HOME';
+
+/** The config and keystore file names, kept side by side under the home root. */
+export const CONFIG_FILENAME = 'config.json';
+export const KEYSTORE_FILENAME = 'keystore.json';
+
+/**
+ * Resolves the CLI home directory: the single root that holds `config.json` and
+ * `keystore.json` side by side (ADR 079). Resolution order, highest wins:
+ *
+ * 1. `--home <dir>` (the {@link PathOverrides.home} flag)
+ * 2. `$BTCR2_HOME`
+ * 3. the platform default (see {@link platformDefaultHome})
+ *
+ * A blank value at any layer defers to the next, mirroring the `blankToUndef`
+ * treatment every other precedence layer uses, so an exported-but-empty
+ * `BTCR2_HOME` does not resolve the home to a bare relative path.
+ */
+export function resolveHome(overrides?: PathOverrides): string {
+  return blankToUndef(overrides?.home)
+    ?? blankToUndef(process.env[ENV_HOME])
+    ?? platformDefaultHome();
+}
+
+/**
+ * The default home when no `--home` / `$BTCR2_HOME` override is present, chosen
+ * per OS so the location is idiomatic while staying a single colocated dir:
+ *
+ * - Windows: `%LOCALAPPDATA%\btcr2` (fallback `%APPDATA%\btcr2`, then the user
+ *   profile), the native place for per-user application state.
+ * - Linux / macOS: `~/.btcr2`, the short, teachable dot-directory in the same
+ *   family as `~/.ssh`, `~/.aws`, and `~/.gnupg`.
+ */
+export function platformDefaultHome(): string {
+  if (process.platform === 'win32') {
+    const base = blankToUndef(process.env.LOCALAPPDATA)
+      ?? blankToUndef(process.env.APPDATA)
+      ?? homedir();
+    return join(base, 'btcr2');
+  }
+  return join(homedir(), '.btcr2');
+}
+
+/**
+ * Default config-file path: `<home>/config.json`. The `--config` flag, when
+ * present, overrides it wholesale (it names a specific file, not a home).
+ */
+export function defaultConfigPath(overrides?: PathOverrides): string {
+  return join(resolveHome(overrides), CONFIG_FILENAME);
+}
+
+/**
+ * Default keystore path: `<home>/keystore.json`. The `--keystore` flag and a
+ * profile's `identity.keystore` (resolved in `config.ts`) override it; this
+ * function is the final fallback in that chain.
+ */
+export function defaultKeystorePath(overrides?: PathOverrides): string {
+  return join(resolveHome(overrides), KEYSTORE_FILENAME);
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -8,6 +8,13 @@ import type { ConfigIssue } from './config-schema.js';
 export type NetworkOption = 'bitcoin' | 'testnet3' | 'testnet4' | 'signet' | 'mutinynet' | 'regtest';
 export type OutputFormat = 'json' | 'text';
 
+/**
+ * How a keystore protects its secrets, as reported by `keystore status` and
+ * `btcr2 init`: `encrypted` (passphrase-sealed), `dev` (plaintext, testnet-only),
+ * or `absent` (no keystore file yet).
+ */
+export type KeystoreProtectionLabel = 'encrypted' | 'dev' | 'absent';
+
 export const SUPPORTED_NETWORKS: NetworkOption[] = [
   'bitcoin', 'testnet3', 'testnet4', 'signet', 'mutinynet', 'regtest'
 ];
@@ -48,6 +55,7 @@ export type CommandResult =
   | { action: 'key-export'; data: { keyId: string; publicKey?: string; secretWrittenTo?: string } }
   | { action: 'key-delete'; data: { keyId: string; deleted: true } }
   | { action: 'key-use'; data: { keyId: string; active: true } }
+  | { action: 'init'; data: { home: string; config: string; keystore: string; created: string[]; protection: KeystoreProtectionLabel } }
   | { action: 'config-init'; data: { path: string } }
   | { action: 'config-get'; data: unknown }
   | { action: 'config-set'; data: { path: string } }
@@ -55,8 +63,11 @@ export type CommandResult =
   | { action: 'config-list'; data: unknown }
   | { action: 'config-validate'; data: { ok: boolean; issues: ConfigIssue[] } }
   | { action: 'config-effective'; data: EffectiveConfig }
-  | { action: 'config-path'; data: { config: string; keystore: string } }
+  | { action: 'config-path'; data: { home: string; config: string; keystore: string } }
   | { action: 'config-doctor'; data: DoctorReport }
+  | { action: 'keystore-init'; data: { path: string; protection: 'encrypted' | 'dev' } }
+  | { action: 'keystore-status'; data: { path: string; protection: KeystoreProtectionLabel; established: boolean; keyCount: number; active: string | undefined } }
+  | { action: 'keystore-change-passphrase'; data: { path: string; rekeyed: number } }
   | { action: 'profile-add'; data: { profile: string } }
   | { action: 'profile-use'; data: { profile: string } }
   | { action: 'profile-show'; data: unknown }
@@ -66,6 +77,7 @@ export interface GlobalOptions {
   output         : OutputFormat;
   verbose        : boolean;
   quiet          : boolean;
+  home?          : string;
   config?        : string;
   profile?       : string;
   btcRest?       : string;

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -371,8 +371,8 @@ describe('blankToUndef', () => {
   });
 });
 
-describe('defaultConfigPath / defaultKeystorePath (empty XDG is unset)', () => {
-  const keys = [ 'XDG_CONFIG_HOME', 'APPDATA', 'XDG_DATA_HOME', 'LOCALAPPDATA' ];
+describe('defaultConfigPath / defaultKeystorePath (single home root, ADR 079)', () => {
+  const keys = [ 'BTCR2_HOME', 'XDG_CONFIG_HOME', 'APPDATA', 'XDG_DATA_HOME', 'LOCALAPPDATA' ];
   const saved: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -385,23 +385,44 @@ describe('defaultConfigPath / defaultKeystorePath (empty XDG is unset)', () => {
     }
   });
 
-  it('treats an empty XDG_CONFIG_HOME as unset (absolute home path, never CWD-relative)', () => {
-    process.env.XDG_CONFIG_HOME = '';
+  it('defaults the config to the platform home (~/.btcr2 off Windows) and ignores XDG_CONFIG_HOME', () => {
+    process.env.XDG_CONFIG_HOME = join(tmpdir(), 'xdg-custom');
     const p = defaultConfigPath();
     expect(isAbsolute(p)).to.equal(true);
-    expect(p).to.match(/[/\\]\.config[/\\]btcr2[/\\]config\.json$/);
+    expect(p).to.not.contain('xdg-custom');
+    if (process.platform !== 'win32') expect(p).to.match(/[/\\]\.btcr2[/\\]config\.json$/);
   });
 
-  it('honors a non-blank XDG_CONFIG_HOME', () => {
-    process.env.XDG_CONFIG_HOME = join(tmpdir(), 'xdg-custom');
-    expect(defaultConfigPath()).to.equal(join(tmpdir(), 'xdg-custom', 'btcr2', 'config.json'));
-  });
-
-  it('treats an empty XDG_DATA_HOME as unset for the keystore path', () => {
-    process.env.XDG_DATA_HOME = '';
+  it('colocates the keystore in the same home and ignores XDG_DATA_HOME', () => {
+    process.env.XDG_DATA_HOME = join(tmpdir(), 'xdg-data');
     const p = defaultKeystorePath();
     expect(isAbsolute(p)).to.equal(true);
-    expect(p).to.match(/[/\\]\.local[/\\]share[/\\]btcr2[/\\]keystore\.json$/);
+    expect(p).to.not.contain('xdg-data');
+    if (process.platform !== 'win32') expect(p).to.match(/[/\\]\.btcr2[/\\]keystore\.json$/);
+  });
+
+  it('$BTCR2_HOME relocates both files as a unit', () => {
+    process.env.BTCR2_HOME = join(tmpdir(), 'btcr2home');
+    expect(defaultConfigPath()).to.equal(join(tmpdir(), 'btcr2home', 'config.json'));
+    expect(defaultKeystorePath()).to.equal(join(tmpdir(), 'btcr2home', 'keystore.json'));
+  });
+});
+
+describe('resolveKeystorePath blank handling (ADR 079)', () => {
+  const keys = [ 'BTCR2_HOME', 'XDG_DATA_HOME', 'LOCALAPPDATA' ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => { for (const k of keys) { saved[k] = process.env[k]; delete process.env[k]; } });
+
+  afterEach(() => { for (const k of keys) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; } });
+
+  it('an explicit --keystore wins', () => {
+    expect(resolveKeystorePath({ keystore: '/explicit/ks.json' })).to.equal('/explicit/ks.json');
+  });
+
+  it('a blank --keystore defers to the home default instead of resolving to an empty path', () => {
+    process.env.BTCR2_HOME = join(tmpdir(), 'ks-home');
+    expect(resolveKeystorePath({ keystore: '   ' })).to.equal(join(tmpdir(), 'ks-home', 'keystore.json'));
   });
 });
 
@@ -918,5 +939,40 @@ describe('profile identity wiring (keystore + default signing key)', () => {
   it('resolveSigningKeyRef returns undefined when neither flag nor identity.default is set', () => {
     const cfg = writeCfg('id-default-none.json', { defaults: { profile: 'custom' }, profiles: { custom: {} } });
     expect(resolveSigningKeyRef({ config: cfg })).to.be.undefined;
+  });
+
+  it('resolveKeystorePath aborts loudly on a malformed config by default', () => {
+    // A keystore-mutating command must not silently fall back to the default
+    // store under a broken config; that would strand key material in the wrong
+    // keystore. So the default resolution throws rather than degrading.
+    const bad = join(tempDir, 'id-malformed.json');
+    writeFileSync(bad, '{ not valid json ');
+    expect(() => resolveKeystorePath({ config: bad })).to.throw(CLIError, /not valid JSON/);
+  });
+
+  it('resolveKeystorePath degrades to the home default under a malformed config only when lenient', () => {
+    // Diagnostic/recovery commands (`config path`, `keystore status`) opt in so
+    // they can still report a path instead of crashing on the config you ran
+    // them to fix.
+    const bad = join(tempDir, 'id-malformed-lenient.json');
+    writeFileSync(bad, '{ not valid json ');
+    expect(() => resolveKeystorePath({ config: bad }, { lenient: true })).to.not.throw();
+    expect(resolveKeystorePath({ config: bad }, { lenient: true })).to.match(/btcr2[/\\]keystore\.json$/);
+  });
+
+  it('the --keystore flag wins without reading a malformed config, even when strict', () => {
+    // The flag short-circuits before any config read, so a broken config never
+    // blocks an explicit keystore path.
+    const bad = join(tempDir, 'id-malformed-flag.json');
+    writeFileSync(bad, '{ not valid json ');
+    expect(resolveKeystorePath({ config: bad, keystore: '/explicit/ks.json' })).to.equal('/explicit/ks.json');
+  });
+
+  it('resolveSigningKeyRef aborts loudly on a malformed config', () => {
+    // Never silently sign with the default/active key when the configured
+    // signing identity cannot be read.
+    const bad = join(tempDir, 'id-malformed-sign.json');
+    writeFileSync(bad, '{ not valid json ');
+    expect(() => resolveSigningKeyRef({ config: bad })).to.throw(CLIError, /not valid JSON/);
   });
 });

--- a/packages/cli/tests/file-backed-key-manager.spec.ts
+++ b/packages/cli/tests/file-backed-key-manager.spec.ts
@@ -62,9 +62,10 @@ describe('FileBackedKeyManager', () => {
     const id = 'urn:kms:secp256k1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const pub = base64urlnopad.encode(SchnorrKeyPair.generate().publicKey.compressed);
     writeFileSync(path, JSON.stringify({
-      v      : 1,
-      active : 'urn:kms:secp256k1:ffffffffffffffffffffffffffffffff',
-      keys   : { [id]: { publicKey: pub } },
+      v          : 1,
+      protection : 'passphrase',
+      active     : 'urn:kms:secp256k1:ffffffffffffffffffffffffffffffff',
+      keys       : { [id]: { publicKey: pub } },
     }), { mode: 0o600 });
     chmodSync(path, 0o600);
     const km = open();

--- a/packages/cli/tests/keystore-factory.spec.ts
+++ b/packages/cli/tests/keystore-factory.spec.ts
@@ -33,7 +33,10 @@ describe('keystoreApiFactory', () => {
   });
 
   it('persists a generated key across factory calls', function () {
-    this.timeout(15000); // exercises the real factory path: production argon2id (64 MiB) runs once
+    // Exercises the real factory path with production argon2id (64 MiB). The
+    // establishing generate now runs it twice: once to seal the key and once for
+    // the passphrase verifier written on first establishment (ADR 080).
+    this.timeout(30000);
     process.env[ENV_KEYSTORE_PASSPHRASE] = 'factory-pass';
     const id = keystoreApiFactory(undefined, { keystore }).kms.generateKey();
     expect(keystoreApiFactory(undefined, { keystore }).kms.listKeys()).to.deep.equal([id]);

--- a/packages/cli/tests/keystore-lifecycle.spec.ts
+++ b/packages/cli/tests/keystore-lifecycle.spec.ts
@@ -1,0 +1,204 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  changeKeystorePassphrase,
+  FileKeyStore,
+  initKeystore,
+  keystoreProtection,
+  keystoreSummary,
+} from '../src/keystore/file-key-store.js';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import { KeyStoreError } from '../src/keystore/error.js';
+import { expect } from './helpers.js';
+
+/** Low-cost argon2id so the lifecycle tests do not pay the production key-derivation cost. */
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+
+const SECRET = new Uint8Array(32).fill(7);
+const PUBLIC = new Uint8Array(33).fill(2);
+const ID = 'urn:kms:secp256k1:testkey';
+const ID2 = 'urn:kms:secp256k1:testkey2';
+
+describe('keystore lifecycle (ADR 080)', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-kslife-'));
+    path = join(dir, 'keystore.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function readFile(): Record<string, unknown> {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  }
+
+  describe('dev (unencrypted) keystore', () => {
+    it('round-trips a secret with no passphrase prompt', () => {
+      const never = (): string => { throw new Error('passphrase must never be requested for a dev keystore'); };
+      const store = new FileKeyStore({ path, protection: 'none', getPassphrase: never });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+
+      // Stored in the clear, marked as a dev keystore.
+      const file = readFile();
+      expect(file.protection).to.equal('none');
+      expect((file.keys as Record<string, { plainSecret?: string; secret?: unknown }>)[ID].plainSecret).to.be.a('string');
+      expect((file.keys as Record<string, { secret?: unknown }>)[ID].secret).to.equal(undefined);
+
+      // A fresh store (new process) reads the secret back without a prompt.
+      const reopened = new FileKeyStore({ path, getPassphrase: never });
+      const entry = reopened.get(ID);
+      expect(entry?.secretKey).to.deep.equal(SECRET);
+    });
+
+    it('is reported as dev by keystoreProtection', () => {
+      initKeystore(path, { protection: 'none', getPassphrase: () => 'unused' });
+      expect(keystoreProtection(path)).to.equal('dev');
+    });
+  });
+
+  describe('first passphrase is confirmed', () => {
+    it('requests confirm on the establishing seal only', () => {
+      const confirmSeen: boolean[] = [];
+      const getPassphrase = (opts?: { confirm?: boolean }): string => {
+        confirmSeen.push(Boolean(opts?.confirm));
+        return 'correct-horse';
+      };
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });   // establishing -> confirm
+      store.set(ID2, { publicKey: PUBLIC, secretKey: SECRET });  // established -> no confirm
+      expect(confirmSeen[0]).to.equal(true);
+      expect(confirmSeen[1]).to.equal(false);
+      // A verifier was written when the passphrase was established.
+      expect(readFile().verifier).to.be.an('object');
+    });
+
+    it('does not write a key when the confirmation fails on establishment', () => {
+      const getPassphrase = (opts?: { confirm?: boolean }): string => {
+        if (opts?.confirm) throw new KeyStoreError('Passphrases did not match.', 'PASSPHRASE_MISMATCH_ERROR');
+        return 'x';
+      };
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase });
+      expect(() => store.set(ID, { publicKey: PUBLIC, secretKey: SECRET }))
+        .to.throw(KeyStoreError, /did not match/);
+      // Nothing was persisted: the establishing seal aborted before the flush.
+      const reopened = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'x' });
+      expect(reopened.list()).to.deep.equal([]);
+    });
+  });
+
+  describe('a wrong passphrase fails loudly against an established keystore', () => {
+    it('rejects a wrong passphrase before sealing a second key', () => {
+      new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'correct' })
+        .set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+
+      // A second invocation with the wrong passphrase must throw, and must not
+      // seal the second key under a divergent passphrase.
+      const wrong = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'wrong' });
+      expect(() => wrong.set(ID2, { publicKey: PUBLIC, secretKey: SECRET }))
+        .to.throw(KeyStoreError, /Incorrect passphrase/);
+
+      const reopened = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'correct' });
+      expect(reopened.list()).to.have.length(1);
+      expect(reopened.get(ID)?.secretKey).to.deep.equal(SECRET);
+    });
+
+    it('rejects a wrong passphrase when opening an existing secret', () => {
+      new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'correct' })
+        .set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      const wrong = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'wrong' });
+      expect(() => wrong.get(ID)?.secretKey).to.throw(KeyStoreError, /Incorrect passphrase/);
+    });
+  });
+
+  describe('change-passphrase', () => {
+    it('re-seals every key so the new passphrase opens them and the old does not', () => {
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'old-pass' });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      store.set(ID2, { publicKey: PUBLIC, secretKey: new Uint8Array(32).fill(9) });
+
+      const rekeyed = changeKeystorePassphrase(path, 'old-pass', 'new-pass', FAST);
+      expect(rekeyed).to.equal(2);
+
+      const withNew = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'new-pass' });
+      expect(withNew.get(ID)?.secretKey).to.deep.equal(SECRET);
+
+      const withOld = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'old-pass' });
+      expect(() => withOld.get(ID)?.secretKey).to.throw(KeyStoreError, /Incorrect passphrase/);
+    });
+
+    it('rejects a wrong current passphrase and leaves keys unchanged', () => {
+      new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'old-pass' })
+        .set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      expect(() => changeKeystorePassphrase(path, 'not-the-old-pass', 'new-pass', FAST))
+        .to.throw(KeyStoreError, /Incorrect/);
+      // The original passphrase still opens the key.
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'old-pass' });
+      expect(store.get(ID)?.secretKey).to.deep.equal(SECRET);
+    });
+
+    it('refuses to change the passphrase of a dev keystore', () => {
+      initKeystore(path, { protection: 'none', getPassphrase: () => 'unused' });
+      expect(() => changeKeystorePassphrase(path, 'a', 'b', FAST))
+        .to.throw(KeyStoreError, /dev keystore/);
+    });
+  });
+
+  describe('initKeystore and keystoreSummary', () => {
+    it('establishes an empty encrypted keystore with a verifier', () => {
+      initKeystore(path, { protection: 'passphrase', argonParams: FAST, getPassphrase: () => 'pw' });
+      const summary = keystoreSummary(path);
+      expect(summary.protection).to.equal('encrypted');
+      expect(summary.established).to.equal(true);
+      expect(summary.keyCount).to.equal(0);
+      expect(readFile().verifier).to.be.an('object');
+    });
+
+    it('reports absent for a missing keystore', () => {
+      expect(keystoreSummary(path)).to.deep.equal({ protection: 'absent', established: false, keyCount: 0, active: undefined });
+    });
+
+    it('refuses to load a keystore with no recognized protection header', () => {
+      // A file this CLI never writes (protection header stripped) is not silently
+      // treated as encrypted: opening it is refused rather than guessed at.
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      const file = readFile();
+      delete file.protection;
+      writeFileSync(path, JSON.stringify(file));
+      expect(() => new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' }))
+        .to.throw(KeyStoreError, /protection header/i);
+    });
+
+    it('refuses an encrypted keystore that holds sealed keys but no verifier', () => {
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      const file = readFile();
+      delete file.verifier; // protection stays 'passphrase'
+      writeFileSync(path, JSON.stringify(file));
+      expect(() => new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' }))
+        .to.throw(KeyStoreError, /verifier/i);
+    });
+
+    it('refuses a plaintext secret inside an encrypted keystore (tamper guard)', () => {
+      const store = new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' });
+      store.set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+      const file = readFile();
+      const keys = file.keys as Record<string, { secret?: unknown; plainSecret?: string }>;
+      delete keys[ID].secret;
+      keys[ID].plainSecret = 'AAAA'; // rejected before it is ever decoded
+      writeFileSync(path, JSON.stringify(file));
+      expect(() => new FileKeyStore({ path, argonParams: FAST, getPassphrase: () => 'pw' }))
+        .to.throw(KeyStoreError, /plaintext secret in an encrypted keystore/i);
+    });
+
+    it('reports a header-less file as absent without throwing (keystoreSummary is safe)', () => {
+      writeFileSync(path, JSON.stringify({ v: 1, keys: {} }));
+      expect(keystoreSummary(path).protection).to.equal('absent');
+    });
+  });
+});

--- a/packages/cli/tests/passphrase.spec.ts
+++ b/packages/cli/tests/passphrase.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { acquirePassphrase, ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
+import { acquirePassphrase, dropLastUtf8Char, ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
 import { KeyStoreError } from '../src/keystore/error.js';
 import { expect } from './helpers.js';
 
@@ -59,5 +59,33 @@ describe('acquirePassphrase', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('dropLastUtf8Char (backspace over a hidden entry)', () => {
+  const decode = (bytes: number[]): string => Buffer.from(bytes).toString('utf-8');
+
+  it('removes a whole two-byte character rather than a single byte', () => {
+    const bytes = [ ...Buffer.from('aé', 'utf-8') ]; // é = 0xC3 0xA9
+    dropLastUtf8Char(bytes);
+    expect(decode(bytes)).to.equal('a'); // not a lone 0xC3 that decodes to U+FFFD
+  });
+
+  it('removes a whole four-byte character (emoji)', () => {
+    const bytes = [ ...Buffer.from('x😀', 'utf-8') ]; // 😀 = 0xF0 0x9F 0x98 0x80
+    dropLastUtf8Char(bytes);
+    expect(decode(bytes)).to.equal('x');
+  });
+
+  it('removes a single ASCII byte', () => {
+    const bytes = [ ...Buffer.from('ab', 'utf-8') ];
+    dropLastUtf8Char(bytes);
+    expect(decode(bytes)).to.equal('a');
+  });
+
+  it('is a no-op on an empty buffer', () => {
+    const bytes: number[] = [];
+    dropLastUtf8Char(bytes);
+    expect(bytes).to.deep.equal([]);
   });
 });

--- a/packages/cli/tests/paths.spec.ts
+++ b/packages/cli/tests/paths.spec.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  defaultConfigPath,
+  defaultKeystorePath,
+  platformDefaultHome,
+  resolveHome,
+} from '../src/paths.js';
+import { expect } from './helpers.js';
+
+/** Env keys these tests mutate, restored to their captured values after each case. */
+const ENV_KEYS = [ 'BTCR2_HOME', 'APPDATA', 'LOCALAPPDATA', 'HOME' ];
+
+describe('paths / home resolution (ADR 079)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const originalPlatform = process.platform;
+  let dir: string;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-paths-'));
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('resolveHome precedence', () => {
+    it('--home wins over $BTCR2_HOME and the default', () => {
+      process.env.BTCR2_HOME = join(dir, 'env');
+      expect(resolveHome({ home: join(dir, 'flag') })).to.equal(join(dir, 'flag'));
+    });
+
+    it('$BTCR2_HOME wins over the default', () => {
+      process.env.BTCR2_HOME = join(dir, 'env');
+      expect(resolveHome()).to.equal(join(dir, 'env'));
+    });
+
+    it('a blank --home defers to $BTCR2_HOME', () => {
+      process.env.BTCR2_HOME = join(dir, 'env');
+      expect(resolveHome({ home: '   ' })).to.equal(join(dir, 'env'));
+    });
+
+    it('a blank $BTCR2_HOME defers to the platform default', () => {
+      process.env.BTCR2_HOME = '';
+      process.env.HOME = dir;
+      expect(resolveHome()).to.equal(join(dir, '.btcr2'));
+    });
+  });
+
+  describe('platformDefaultHome', () => {
+    it('is ~/.btcr2 off Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      process.env.HOME = dir;
+      expect(platformDefaultHome()).to.equal(join(dir, '.btcr2'));
+    });
+
+    it('is %LOCALAPPDATA%\\btcr2 on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.LOCALAPPDATA = dir;
+      expect(platformDefaultHome()).to.equal(join(dir, 'btcr2'));
+    });
+
+    it('falls back to %APPDATA%\\btcr2 on Windows without LOCALAPPDATA', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.APPDATA = dir;
+      expect(platformDefaultHome()).to.equal(join(dir, 'btcr2'));
+    });
+  });
+
+  describe('config and keystore both derive from the home', () => {
+    it('colocates config.json and keystore.json under a home override', () => {
+      expect(defaultConfigPath({ home: dir })).to.equal(join(dir, 'config.json'));
+      expect(defaultKeystorePath({ home: dir })).to.equal(join(dir, 'keystore.json'));
+    });
+  });
+});

--- a/packages/cli/tests/state-commands.spec.ts
+++ b/packages/cli/tests/state-commands.spec.ts
@@ -1,0 +1,228 @@
+import { createApi } from '@did-btcr2/api';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DidBtcr2Cli } from '../src/cli.js';
+import { initKeystore, keystoreSummary } from '../src/keystore/file-key-store.js';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import { ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
+import { createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
+
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+const ENV_KEYS = [ 'BTCR2_HOME', ENV_KEYSTORE_PASSPHRASE ];
+
+/** A valid did:btcr2 identifier on the given network, minted offline. */
+function didFor(network: string): string {
+  const pub = SchnorrKeyPair.generate().publicKey.compressed;
+  return createApi().createDid('deterministic', pub, { network: network as never });
+}
+
+describe('state + keystore commands (ADR 079/080)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let dir: string;
+  let home: string;
+  let out: string[];
+  let err: string[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-state-'));
+    home = join(dir, 'home');
+    out = [];
+    err = [];
+    console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };
+    console.error = (m?: unknown) => { if (m !== undefined) err.push(String(m)); };
+    // Capture stderr notes/warnings (init/keystore write these via process.stderr).
+    process.stderr.write = ((chunk: unknown): boolean => { err.push(String(chunk)); return true; }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = 0;
+    for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Fresh CLI invocation with a temp home; the api factory is never network-touched here. */
+  async function run(...args: string[]): Promise<void> {
+    await new DidBtcr2Cli(createTestApiFactory()).run(['node', 'btcr2', '--home', home, ...args]);
+  }
+
+  const keystorePath = (): string => join(home, 'keystore.json');
+  const configPath = (): string => join(home, 'config.json');
+
+  describe('btcr2 init', () => {
+    it('--dev seeds home, config, and an unencrypted keystore', async () => {
+      await run('-o', 'json', 'init', '--dev');
+      const result = JSON.parse(out.join('\n'));
+      expect(result.action).to.equal('init');
+      expect(result.data.home).to.equal(home);
+      expect(result.data.created).to.have.members([ 'config', 'keystore' ]);
+      expect(result.data.protection).to.equal('dev');
+      expect(existsSync(configPath())).to.equal(true);
+      expect(keystoreSummary(keystorePath()).protection).to.equal('dev');
+    });
+
+    it('is idempotent: a second run creates nothing', async () => {
+      await run('init', '--dev');
+      out = [];
+      await run('-o', 'json', 'init', '--dev');
+      expect(JSON.parse(out.join('\n')).data.created).to.deep.equal([]);
+    });
+
+    it('establishes an encrypted keystore from the passphrase env var', async function () {
+      this.timeout(20000); // one production argon2id run for the verifier
+      process.env[ENV_KEYSTORE_PASSPHRASE] = 'demo-pass';
+      await run('-o', 'json', 'init');
+      expect(JSON.parse(out.join('\n')).data.protection).to.equal('encrypted');
+      expect(keystoreSummary(keystorePath()).established).to.equal(true);
+    });
+  });
+
+  describe('keystore group', () => {
+    it('init --dev then status reports dev', async () => {
+      await run('keystore', 'init', '--dev');
+      out = [];
+      await run('-o', 'json', 'keystore', 'status');
+      const status = JSON.parse(out.join('\n')).data;
+      expect(status.protection).to.equal('dev');
+      expect(status.path).to.equal(keystorePath());
+    });
+
+    it('status reports absent when no keystore exists', async () => {
+      await run('-o', 'json', 'keystore', 'status');
+      expect(JSON.parse(out.join('\n')).data.protection).to.equal('absent');
+    });
+
+    it('init refuses to overwrite without --force', async () => {
+      await run('keystore', 'init', '--dev');
+      err = [];
+      await run('keystore', 'init', '--dev');
+      expect(err.join(' ')).to.match(/already exists/i);
+    });
+
+    it('change-passphrase refuses a dev keystore', async () => {
+      await run('keystore', 'init', '--dev');
+      err = [];
+      await run('keystore', 'change-passphrase');
+      expect(err.join(' ')).to.match(/dev keystore/i);
+    });
+
+    it('change-passphrase errors when no keystore exists', async () => {
+      await run('keystore', 'change-passphrase');
+      expect(err.join(' ')).to.match(/No keystore/i);
+    });
+  });
+
+  describe('config path', () => {
+    it('config path reports the home, config, and keystore locations', async () => {
+      await run('-o', 'json', 'config', 'path');
+      const data = JSON.parse(out.join('\n')).data;
+      expect(data.home).to.equal(home);
+      expect(data.config).to.equal(configPath());
+      expect(data.keystore).to.equal(keystorePath());
+    });
+  });
+
+  describe('a malformed config is loud for key material but graceful for diagnostics', () => {
+    const writeMalformedConfig = (): void => {
+      mkdirSync(home, { recursive: true });
+      writeFileSync(configPath(), '{ not valid json ');
+    };
+
+    it('config path still reports locations instead of crashing', async () => {
+      writeMalformedConfig();
+      await run('-o', 'json', 'config', 'path');
+      expect(err.join(' ')).to.equal('');
+      const data = JSON.parse(out.join('\n')).data;
+      expect(data.home).to.equal(home);
+      expect(data.keystore).to.equal(keystorePath());
+    });
+
+    it('keystore status still reports instead of crashing', async () => {
+      writeMalformedConfig();
+      await run('-o', 'json', 'keystore', 'status');
+      expect(err.join(' ')).to.equal('');
+      expect(JSON.parse(out.join('\n')).data.protection).to.equal('absent');
+    });
+
+    it('key generate aborts loudly rather than sealing a key into the wrong store', async () => {
+      writeMalformedConfig();
+      await run('key', 'generate', '--name', 'x');
+      expect(err.join(' ')).to.match(/not valid JSON/i);
+      expect(existsSync(keystorePath())).to.equal(false); // no key material written
+    });
+  });
+
+  describe('init and keystore init never silently destroy keys (review fix)', () => {
+    it('btcr2 init --force re-scaffolds config but leaves an existing keystore (and its keys) intact', async () => {
+      initKeystore(keystorePath(), { protection: 'none', getPassphrase: () => 'x', argonParams: FAST });
+      await run('key', 'generate', '--name', 'keep'); // dev keystore: no prompt
+      out = [];
+      err = [];
+      await run('-o', 'json', 'init', '--force');
+      const result = JSON.parse(out.join('\n'));
+      expect(result.data.created).to.not.include('keystore');
+      expect(err.join(' ')).to.match(/left intact/i);
+      expect(keystoreSummary(keystorePath()).keyCount).to.equal(1);
+    });
+
+    it('keystore init --force warns before discarding existing keys', async () => {
+      initKeystore(keystorePath(), { protection: 'none', getPassphrase: () => 'x', argonParams: FAST });
+      await run('key', 'generate', '--name', 'doomed');
+      err = [];
+      await run('keystore', 'init', '--dev', '--force');
+      expect(err.join(' ')).to.match(/discards its 1 existing key/i);
+      expect(keystoreSummary(keystorePath()).keyCount).to.equal(0);
+    });
+  });
+
+  describe('dev keystore is refused on mainnet (ADR 080)', () => {
+    beforeEach(() => {
+      // A dev keystore at the home default, established directly (fast).
+      initKeystore(keystorePath(), { protection: 'none', getPassphrase: () => 'unused', argonParams: FAST });
+    });
+
+    async function runUpdate(did: string): Promise<void> {
+      await run(
+        'update',
+        '-s', JSON.stringify({ id: did }),
+        '--source-version-id', '1',
+        '-p', '[]',
+        '-m', `${did}#key-0`,
+        '-b', '"bitcoin:addr"',
+      );
+    }
+
+    it('refuses update on a mainnet DID', async () => {
+      await runUpdate(didFor('bitcoin'));
+      expect(err.join(' ')).to.match(/Refusing a mainnet/i);
+    });
+
+    it('does not raise the dev-keystore error on a testnet DID', async () => {
+      await runUpdate(didFor('testnet4'));
+      expect(err.join(' ')).to.not.match(/Refusing a mainnet/i);
+    });
+
+    it('refuses generating a mainnet key into a dev keystore', async () => {
+      await run('create', '-t', 'k', '-n', 'bitcoin');
+      expect(err.join(' ')).to.match(/Refusing a mainnet/i);
+    });
+
+    it('refuses deactivate on a mainnet DID', async () => {
+      const did = didFor('bitcoin');
+      await run(
+        'deactivate',
+        '-s', JSON.stringify({ id: did }),
+        '--source-version-id', '1',
+        '-m', `${did}#key-0`,
+        '-b', '"bitcoin:addr"',
+      );
+      expect(err.join(' ')).to.match(/Refusing a mainnet/i);
+    });
+  });
+});


### PR DESCRIPTION
* chore(release): bump cli 0.16.0
* test(cli): paths, keystore lifecycle, state cmds, mainnet refuse, multibyte backspace, malform-conf
* feat(cli): unify home dir; opt env/flag overrides; keystore command; confirmed+verified keystore passphrase
* docs(adr): 079 state dir + 080 keystore lifecycle
