### PR TITLE
cli keystore session unlock agent

### DIFF
--- a/docs/adr/081-cli-keystore-session-unlock.md
+++ b/docs/adr/081-cli-keystore-session-unlock.md
@@ -1,0 +1,87 @@
+---
+title: "ADR 081: A Session Unlock Agent for the Encrypted Keystore"
+---
+
+# ADR 081: A Session Unlock Agent for the Encrypted Keystore
+
+**Status:** Accepted
+
+**Date:** 2026-07-14
+
+**Branch / PR:** `feat/cli-keystore-unlock-agent`
+
+**References:** [ADR 052](052-cli-keystore-file-locking.md), [ADR 077](077-cli-rpc-secret-handling.md), [ADR 079](079-cli-state-directory-consolidation.md), [ADR 080](080-keystore-lifecycle-and-dev-keystores.md)
+
+## Context
+
+The encrypted keystore (ADR 080) seals each secret in its own argon2id + XChaCha20-Poly1305 envelope under one shared passphrase, acquired lazily by `getPassphrase` (`config.ts`) whenever a secret is sealed or opened. Every `btcr2` invocation is a fresh process, so nothing carries a decrypted secret (or the passphrase) from one command to the next: a returning operator is prompted again on the very next `key generate`, `update`, or `deactivate`. ADR 080 deliberately deferred the convenience of not re-prompting to its own decision, which is this one.
+
+The workshop happy path is `init` then a run of key and DID commands. Retyping the passphrase between each, or exporting `BTCR2_KEYSTORE_PASSPHRASE` (which leaks it into shell history and every child process for the whole shell lifetime), is exactly the friction that pushed four test keys onto the accidental-first-seal path in the first place. A returning operator wants to authenticate once and then run a short series of commands unattended, the way `ssh-agent` lets one `ssh-add` cover a working session.
+
+Two facts constrain the mechanism:
+
+1. **There is no single "unlock key" to cache.** Each secret carries its own random argon2id salt, so opening any secret requires the passphrase to re-derive *that secret's* key (or the already-decrypted bytes). A cached argon2id output opens exactly one envelope, not the store. And sealing a *new* key (the most common workshop operation) needs the passphrase string to run argon2id over a fresh salt. The only thing that covers both open and seal across a fresh process is the passphrase itself.
+2. **The audience is cross-OS and types commands literally.** An `eval $(btcr2 keystore unlock)` handshake (secret in the shell environment, ciphertext on disk) is the strongest on-disk-adjacent design, but it is not portable to Windows PowerShell and it silently does nothing if an attendee forgets the `eval`. The next `btcr2` process must therefore pick up the unlocked session on its own, by reading a file, with no shell integration.
+
+## Decision
+
+Add a **session unlock agent**: `keystore unlock` caches the verified passphrase in a single file under the home directory, and subsequent commands consume it in place of a prompt until it expires or is revoked. This is an explicit **v1, on-disk** design; a future in-memory/socket agent (v2) is the real fix for the residual it carries, and is out of scope here.
+
+### What is cached, and where
+
+A session file at `<home>/session.json` (colocated with `config.json` and `keystore.json` per ADR 079), mode `0600`, written atomically (temp sibling + rename). It holds:
+
+- `v`: session-file format version (`1`).
+- `keystore`: the absolute, normalized path of the keystore this session unlocks. The session is honored only for a command resolving to that exact keystore.
+- `verifierId`: `base64urlnopad(sha256(JSON.stringify(keystore.verifier)))`. A rotation sentinel compared by equality, never decrypted. `change-passphrase` and `keystore init --force` rotate the verifier, so a stale session stops matching automatically (belt to the explicit `clearSession` those commands also run).
+- `passphrase`: `base64urlnopad(utf8(passphrase))`. **base64url is an encoding, not encryption.** The passphrase's only protection at rest is the `0600` file mode. This is the design's honest cost, stated plainly below.
+- `allowMainnet`: whether the operator unlocked with `--allow-mainnet`. A session without it is withheld from a `bitcoin` operation at consumption (below), so mainnet keeps per-use authentication even while the session is live.
+- `createdAt`, `expiresAt` (`createdAt + ttl`), `ttlSeconds` (display only).
+
+The file **never** holds a derived key, any keystore ciphertext, or any signing-key bytes. The passphrase is structurally absent from every command result, from stdout/stderr, and from verbose logs.
+
+We cache the passphrase rather than a random session key wrapping the secrets. With per-secret salts, a random wrap key would have to sit in the same `0600` file as the ciphertext it opens, so it protects nothing a passphrase cache does not against a reader of that file, while forcing edits into the audited `FileKeyStore` secret path and leaving new-key sealing still prompting. Caching the passphrase changes only the `getPassphrase` seam and leaves the audited store untouched. Its one genuine disadvantage, that the reusable human passphrase (not just this keystore's keys) is what leaks if the file is read, is precisely what the deferred in-memory v2 removes.
+
+### How a session is consumed
+
+`acquirePassphrase` gains an optional `beforePrompt` source, consulted **after** the environment variable and `--passphrase-file` and **before** the "no TTY" failure, so a non-interactive follow-on command (piped output, a task runner) consumes a live session instead of hard-failing. `buildKeystoreKms` wires `beforePrompt` to read the session, but **only when it is not establishing** a passphrase: establishment always prompts twice, fresh, so ADR 080's confirmed-first-passphrase guarantee is untouched. The precedence is therefore: `BTCR2_KEYSTORE_PASSPHRASE`, then `--passphrase-file`, then a live session, then an interactive prompt. Unattended and CI paths keep winning over the cache and are never weakened by it.
+
+A cached passphrase is still checked by the store's existing verifier on every use (`#assertPassphrase`), so a forged or stale cache can never seal a key under a divergent passphrase; the ADR 080 key-loss class stays closed by construction.
+
+### The commands
+
+- **`keystore unlock`**: resolve the keystore strictly; refuse an absent keystore (run `init`), a dev keystore (no passphrase to cache), or an encrypted-but-unestablished keystore (no verifier yet). Acquire the passphrase once (env / file / prompt, **no** session consultation and **no** confirm), verify it against the keystore verifier, and only then write the session. A wrong passphrase writes **no** file. `--ttl <dur>` sets the lifetime (bare seconds or an `s`/`m`/`h` suffix), defaulting to **1 hour** and hard-capped at **24 hours**; `BTCR2_KEYSTORE_TTL` supplies a default below the flag. The printed result carries the keystore path and expiry, never the passphrase.
+- **`keystore lock`**: delete the session file (and sweep any crash-orphaned `.session.json.*.tmp` sibling, which would hold a plaintext passphrase). Idempotent, needs no passphrase, works for any protection mode, and resolves the session path from the **home only** so it revokes even under a malformed config.
+- **`keystore status`**: additionally reports whether a live session exists and its remaining lifetime. It never decrypts, never prompts, never throws, and never emits the passphrase; an expired, foreign-keystore, or stale session reports inactive.
+
+### Mainnet is gated at unlock and enforced at consumption
+
+An unlocked encrypted keystore signs prompt-free for the whole TTL, which silently removes per-use passphrase authentication, including for a `bitcoin` DID (ADR 080's dev-keystore refusal does not cover an *encrypted* mainnet key). Keys are not network-tagged, and the network a command signs under is derived per-operation (from the DID for `update`/`deactivate`, from `--network`/config for `create`), not from the configured default. So the gate is keyed to `--allow-mainnet` in **two** places:
+
+- **At unlock (early signal):** `keystore unlock` **refuses when the *configured* default network resolves to `bitcoin`** unless `--allow-mainnet` is passed, mirroring ADR 080's hard-refuse posture, so an operator whose default is mainnet is stopped before any passphrase is cached.
+- **At consumption (authoritative):** the session records `allowMainnet`, and a `bitcoin` operation is **withheld from a session that lacks it**, falling through to a per-use passphrase prompt rather than signing prompt-free. This is what actually protects a mainnet key, because the configured default network is unrelated to the network a given command signs under: unlocking on a testnet default (or dodging the early gate with `--profile`) still cannot silently sign a `bitcoin` DID. The withheld session is left in place, since it remains valid for the non-mainnet operations it was unlocked for.
+
+The workshop is on mutinynet, so the gate costs attendees nothing; a keystore genuinely reused for mainnet is the honest edge the explicit flag exists for. Testnet, signet, mutinynet, and regtest unlock and sign without a flag.
+
+### Hardening the on-disk read
+
+Because the file holds a plaintext passphrase, the read path is defensive and **never throws** (a bad session degrades to a prompt, never a crash):
+
+- On POSIX, open with `O_RDONLY | O_NOFOLLOW` (a symlink is refused here, by `ELOOP`, with nothing to delete since it was never opened), then `fstat` the returned descriptor and refuse a non-regular file, a file not owned by the caller, or one accessible by group or other, reading only from that same descriptor (no TOCTOU re-open). A file rejected by these `fstat` checks (not the symlink case) is best-effort deleted, since it may hold a plaintext passphrase.
+- On Windows, these POSIX checks are skipped (they would throw on `O_NOFOLLOW`/`getuid`), and the file is read normally, relying on the same `LocalAppData` ACL the keystore already trusts. The skip is explicit so the session is *used*, not silently ignored on every command.
+- A session is refused if its `v` is unknown, its shape is wrong (including a missing/non-boolean `allowMainnet`), its `createdAt` is in the future (a copied file or a backward clock jump), its `expiresAt` has passed, its `verifierId` no longer matches the keystore, or its `keystore` path differs from the one the command resolved. On the consume path (`readLiveSessionPassphrase`), an expired, future-dated, verifier-rotated, or malformed file is pruned; a *foreign* session (live, but for a different keystore) is deliberately left in place, and `keystore status` never prunes.
+
+## Consequences
+
+- A returning operator authenticates once and then runs a series of key and DID commands prompt-free until the session expires or `keystore lock` revokes it, without exporting the passphrase into shell history. The workshop's `unlock` line is a single portable command on every OS.
+- The change is confined to the `getPassphrase` seam, a new `keystore/session.ts` module, two no-decrypt keystore helpers, and the command layer. The audited `FileKeyStore` secret path is unchanged, and the verifier remains the sole authority that a passphrase (cached or typed) is correct, so ADR 080's guarantees hold verbatim.
+- **The residual, stated honestly:** the human passphrase sits base64url-encoded in a `0600` file for the TTL, protected only by file permissions. Any same-uid process (another terminal, a malicious `postinstall` in the dependency tree) can read it during the window; `lock`/expiry unlink but do not securely erase, so freed blocks, backups, or a sync client may retain it. The TTL is a convenience bound on reuse by a cooperating reader, not a control against a thief who has the file (the passphrase feeds straight into argon2id). This is a deliberate v1 trade for portability and a minimal diff; the in-memory v2 agent, which never persists the secret, is the fix and is referenced as future work.
+- Tests: `unlock` writes the exact `0600` schema with no passphrase in any output; a follow-on command opens a sealed key prompt-free within the TTL, including a non-TTY follow-on that would otherwise hard-fail; the passphrase round-trips the cache verbatim (trailing newline and multibyte characters preserved); an expired, future-dated, or verifier-rotated session is refused and pruned while a foreign-keystore session is refused but left in place; `change-passphrase` invalidates the session and `btcr2 init` clears one when it establishes a keystore (but not when the keystore already exists); `unlock` refuses dev/absent/unestablished keystores and a wrong passphrase writes no file; the mainnet gate refuses a `bitcoin` *default* at unlock without `--allow-mainnet`, records the allowance in the session, and at consumption withholds a non-allowing session from a `bitcoin` operation while still serving other networks; `lock` is idempotent, needs no passphrase, and works under a malformed config; POSIX symlink/loose-perm sessions are refused (and the Windows path is not silently disabled); `--ttl` parsing, the 24h cap, env/file precedence over a session, and a malformed (missing `allowMainnet`) session all hold.
+
+## Rejected alternatives
+
+- **Cache a random session key wrapping the secrets, not the passphrase.** It never writes the human passphrase, but a v1 on-disk design has to store that wrap key in the same `0600` file as the ciphertext it opens, so it gives a file thief the same keys while adding edits to the audited `FileKeyStore.get` path, failing to cover new-key sealing, and creating an empty-keystore footgun (unlock caches zero keys, the next `key generate` still prompts). The only property it buys over caching the passphrase, not exposing the reusable human secret, is exactly the in-memory v2 agent's job.
+- **An `ssh-agent`-style `eval $(btcr2 keystore unlock)` handshake** (token in the shell environment, ciphertext on disk). This is genuinely stronger, but it is not portable to Windows PowerShell and silently no-ops if an attendee omits the `eval`, both disqualifying for a cross-OS follow-along. The portable equivalent is the deferred in-memory agent reachable over a socket, not an environment handshake.
+- **Encrypt the cached passphrase under a machine-bound key.** Without an OS keychain there is no key not derivable from files the same user can read, so it is obfuscation, not protection, and it invites a false sense of security. Storing the passphrase plainly at `0600` and documenting the exposure is more honest.
+- **Skip the mainnet gate (treat unlock as purely keystore-level).** Keys are not network-tagged, so this is defensible, but it silently suspends per-use authentication for a mainnet key for the whole TTL. Refusing `bitcoin` unless `--allow-mainnet` mirrors the ADR 080 posture at no cost to the testnet workshop.
+- **Ship the in-memory agent now instead of the on-disk cache.** A background process holding decrypted material behind a socket is the right end state, but it is materially more machinery (lifecycle, socket auth, cross-platform daemonization) than the workshop needs. The on-disk cache is the minimal step that removes the re-prompt friction; v2 supersedes it without changing the command surface.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -157,3 +157,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 078 | 2026-07-07 | [Wire the Advertised-but-Dead Bitcoin RPC and Profile-Identity Config Surface](078-wire-dead-config-surface.md) |
 | 079 | 2026-07-08 | [Consolidate CLI State Under a Single ~/.btcr2 Home Directory](079-cli-state-directory-consolidation.md) |
 | 080 | 2026-07-08 | [Keystore Lifecycle, a Confirmed First Passphrase, and Opt-In Dev Keystores](080-keystore-lifecycle-and-dev-keystores.md) |
+| 081 | 2026-07-14 | [A Session Unlock Agent for the Encrypted Keystore](081-cli-keystore-session-unlock.md) |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @did-btcr2/cli
 
+## 0.17.0
+
+### Minor Changes
+
+- Add a session unlock agent so an encrypted keystore is authenticated once per session instead of on every command (ADR 081).
+
+  - **`keystore unlock`** caches the verified passphrase in `<home>/session.json` (`0600`, TTL, bound to the keystore) so later commands do not re-prompt. `--ttl <duration>` sets the lifetime (bare seconds or an `s`/`m`/`h` suffix; default 1h, hard cap 24h; also `$BTCR2_KEYSTORE_TTL`).
+  - **`keystore lock`** revokes the session; **`keystore status`** now reports whether a session is live and its remaining lifetime (a new `session` field on its output).
+  - A cached session sits below `$BTCR2_KEYSTORE_PASSPHRASE` / `--passphrase-file` and above the interactive prompt, so unattended and CI paths still win and are never weakened by it. Establishment (the confirmed first passphrase, ADR 080) never consults the session, and the keystore verifier still checks every use, so a stale or forged cache can never seal a key under a divergent passphrase.
+  - Mainnet keeps per-use authentication: `keystore unlock` refuses a `bitcoin` _default_ network unless `--allow-mainnet` is passed, and the session records that allowance so that at consumption a `bitcoin` operation (whose network is derived from the DID, not the config default) is withheld from a session lacking it and falls through to a per-use prompt, while other networks are still served. `change-passphrase`, `keystore init --force`, and `btcr2 init` (when it establishes a keystore) invalidate any cached session.
+  - The cached passphrase is base64url-encoded, not encrypted: its only protection at rest is the `0600` file mode. This is a deliberate on-disk v1 for portability and a minimal diff; a future in-memory agent removes the on-disk persistence.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/cli/DEMO.md
+++ b/packages/cli/DEMO.md
@@ -1,14 +1,16 @@
 # did:btcr2 CLI - Client Demo
 
-A guided, run-it-yourself walkthrough of the `btcr2` command-line tool: create a
-decentralized identifier offline, resolve it live from Bitcoin, and update it on-chain.
-Runs on **Mutinynet** (a public Bitcoin signet with 30-second blocks and a free faucet),
-so nothing here costs real money.
+A guided, run-it-yourself walkthrough of the `btcr2` command-line tool: set up a local
+keystore, create a decentralized identifier offline, resolve it live from Bitcoin, and
+update it on-chain. Runs on **Mutinynet** (a public Bitcoin signet with 30-second blocks
+and a free faucet), so nothing here costs real money.
 
 **How to use this doc:** run the commands top to bottom in one terminal session. Later
 commands reuse shell variables set by earlier ones, so keep the same session open. Every
 output block is **illustrative** - your keys, DID strings, and Bitcoin addresses will be
 unique to you, but the shape will match.
+
+Targets `@did-btcr2/cli` **v0.17.0**.
 
 ---
 
@@ -28,7 +30,23 @@ Three things make it different, and this demo shows all three:
 
 ## Part 0 - Setup
 
-**Get the CLI.** Either install the published package:
+### Prerequisites
+
+Before the first command, confirm you have:
+
+- **Node.js >= 22** (the CLI runtime).
+- **`jq`** (used to pull values out of JSON in Parts 3 and 4).
+- **A POSIX shell**: bash or zsh on Linux/macOS. On Windows, use **WSL** or **Git Bash**;
+  the copy-paste flow here relies on `alias`, `$(...)`, `2>/dev/null`, and single-quoted
+  JSON, which PowerShell and cmd do not handle the same way.
+
+```bash
+node --version && jq --version      # both should print a version, not "command not found"
+```
+
+### Get the CLI
+
+Either install the published package:
 
 ```bash
 npm install -g @did-btcr2/cli
@@ -48,27 +66,72 @@ btcr2 --version
 ```
 
 ```
-btcr2 0.12.14
+btcr2 0.17.0
 ```
 
-**Set Mutinynet as the default network** so you can drop `-n mutinynet` from every
-command:
+### Set up the btcr2 home and keystore
+
+`btcr2 init` is the one command that gets you ready: it creates the btcr2 home
+directory, writes a default config, and establishes the keystore. Pick one of two paths.
+
+**Path A (recommended) - encrypted keystore, authenticate once per session.** This is the
+real product experience and shows off v0.17.0's session unlock agent. `init` prompts for a
+passphrase (twice, to confirm it) so your keys are encrypted at rest:
 
 ```bash
-btcr2 config init
+btcr2 init
+btcr2 config set defaults.network mutinynet
+btcr2 keystore unlock --ttl 2h
+```
+
+`keystore unlock` caches the passphrase for the session (here, 2 hours) so every later
+command in Parts 1 to 4 runs **without re-prompting**. You authenticate once, not on
+every signing step.
+
+**Path B (fastest) - unencrypted dev keystore, no passphrase at all.** For a smooth
+follow-along with zero passphrase typing, use a dev keystore. Keys are stored in
+plaintext, so this is **testnet/regtest/signet/mutinynet only** (the CLI hard-refuses to
+sign or generate a mainnet key with a dev keystore):
+
+```bash
+btcr2 init --dev
 btcr2 config set defaults.network mutinynet
 ```
 
-**Optional connectivity check.** This DID is already live on Mutinynet, so resolving it
-confirms your network path works before you generate your own:
+Either way, `init` prints where it put everything (text mode shows just the data; on
+Path B the `protection` reads `"dev"`):
 
-```bash
-btcr2 resolve -i did:btcr2:k1q5pel7vf3pjqa526m2up700805yckzsk6qpx6fkeqlaxfggclk43adqzeap82
+```json
+{
+  "home": "/home/you/.btcr2",
+  "config": "/home/you/.btcr2/config.json",
+  "keystore": "/home/you/.btcr2/keystore.json",
+  "created": ["config", "keystore"],
+  "protection": "encrypted"
+}
 ```
 
-If that returns a JSON document, you are ready.
+(Add `-o json` to any command, for example `btcr2 -o json init`, to get the full
+`{"action": ..., "data": ...}` envelope instead.)
 
-**See everything the tool can do:**
+> `init` is idempotent: run it again and it leaves existing files untouched (it never
+> overwrites a keystore, even with `--force`; re-establishing one is the explicit
+> `btcr2 keystore init --force`). Setting `defaults.network mutinynet` lets you drop
+> `-n mutinynet` from every later command.
+
+### Connectivity check
+
+Confirm your machine can reach Mutinynet's public infrastructure before you go further.
+This probes the resolved endpoints without depending on any particular DID's history:
+
+```bash
+btcr2 config doctor -n mutinynet
+```
+
+If it reports the endpoints reachable, you are ready. (You will also see a live resolve
+of your own DID in Part 3.)
+
+### See everything the tool can do
 
 ```bash
 btcr2 --help
@@ -76,11 +139,14 @@ btcr2 --help
 
 ```
 Commands:
+  init          Set up the btcr2 home: create the directory, a default config,
+                and establish the keystore.
   create        Create an identifier and initial DID document
   resolve|read  Resolve the DID document of the identifier.
   update        Update a did:btcr2 document.
-  deactivate    Deactivate the did:btcr2 identifier permanently.
+  deactivate|delete  Deactivate the did:btcr2 identifier permanently. This is irreversible.
   key           Manage keypairs in the encrypted keystore.
+  keystore      Establish, inspect, re-key, and unlock the keystore.
   config        Read and write CLI configuration.
   profile       Manage configuration profiles.
   completion    Print a shell completion script (bash, zsh, or fish).
@@ -90,11 +156,12 @@ Commands:
 
 ## Part 1 - Own your keys
 
-did:btcr2 keys live in a local, encrypted keystore that you control. There is no account
-and no server.
+did:btcr2 keys live in a local keystore that you control. There is no account and no
+server. You already established the keystore in Part 0; now put a key in it.
 
-**Generate a key.** You will be prompted to set a passphrase; it encrypts the keystore
-on disk.
+**Generate a key.** On Path A (encrypted) this seals the key under your passphrase, but
+because you unlocked the session it does **not** re-prompt. On Path B (dev) there is no
+passphrase at all.
 
 ```bash
 btcr2 key generate --name demo --set-active
@@ -104,8 +171,8 @@ Illustrative output (your `keyId` and `publicKey` will differ):
 
 ```json
 {
-  "keyId": "urn:kms:secp256k1:48c2f0ccbbecce41f36b4116272f9842",
-  "publicKey": "039ff98988640ed15adab81f3de77d098b0a16d0026d26d907fa64a118fdab1eb4",
+  "keyId": "urn:kms:secp256k1:e3fa32a91bd958990086bc4c787aa00d",
+  "publicKey": "03b59c8cf3e9be573b1543a52717f17a046164cca95ab781ccdf2e75f71344a158",
   "active": true
 }
 ```
@@ -119,17 +186,37 @@ btcr2 key list
 ```json
 [
   {
-    "keyId": "urn:kms:secp256k1:48c2f0ccbbecce41f36b4116272f9842",
-    "fingerprint": "48c2f0ccbbecce41f36b4116272f9842",
+    "keyId": "urn:kms:secp256k1:e3fa32a91bd958990086bc4c787aa00d",
+    "fingerprint": "e3fa32a91bd958990086bc4c787aa00d",
     "name": "demo",
     "active": true
   }
 ]
 ```
 
-Talking point: the secret never leaves this machine, and the keystore is encrypted at
-rest. `key show`, `key use`, `key import`, and `key export` round out the lifecycle.
-Public material is always safe to print; the secret is never displayed.
+**Inspect the keystore and session state at any time** (never decrypts, never prompts):
+
+```bash
+btcr2 keystore status
+```
+
+```json
+{
+  "path": "/home/you/.btcr2/keystore.json",
+  "protection": "encrypted",
+  "established": true,
+  "keyCount": 1,
+  "active": "urn:kms:secp256k1:e3fa32a91bd958990086bc4c787aa00d",
+  "session": { "active": true, "expiresAt": 1784058588203, "secondsRemaining": 7200, "allowMainnet": false }
+}
+```
+
+(That is the Path A shape. On Path B, `protection` reads `"dev"` and `session` stays
+`{ "active": false }`: a dev keystore has no passphrase, so it never needs a session.)
+
+Talking point: the secret never leaves this machine, and (on Path A) the keystore is
+encrypted at rest. `key show`, `key use`, `key import`, and `key export` round out the
+lifecycle. Public material is always safe to print; the secret is never displayed.
 
 ---
 
@@ -146,12 +233,13 @@ echo "$DID"
 Illustrative output (yours will differ):
 
 ```
-did:btcr2:k1q5pel7vf3pjqa526m2up700805yckzsk6qpx6fkeqlaxfggclk43adqzeap82
+did:btcr2:k1q5plyvwt6qw6523ndym6dg8hqdnvk0kxqke37ejl0hc6taffmqdz36qnssf9t
 ```
 
 That string **is** the identifier. It was produced in milliseconds, with no fee. (Note:
-`create --signing-key` only reads the public key, so it does not prompt for your
-passphrase.)
+`create --signing-key` only reads the **public** key, so it never needs your passphrase,
+session or not. In text mode it prints the DID to stdout and a `Using stored key ...`
+note to stderr, which is why we redirect `2>/dev/null` when capturing `$DID`.)
 
 A few things to show off:
 
@@ -164,7 +252,8 @@ btcr2 create --signing-key demo -n signet      # did:btcr2:k1qyp... (signet)
 btcr2 create --signing-key demo -n mutinynet   # did:btcr2:k1q5p... (mutinynet)
 ```
 
-**Machine-readable output** for scripting and integration:
+**Machine-readable output** for scripting and integration. Because this uses a stored
+key, the envelope also echoes the `keyId` and `publicKey` it resolved:
 
 ```bash
 btcr2 -o json create --signing-key demo
@@ -173,9 +262,15 @@ btcr2 -o json create --signing-key demo
 ```json
 {
   "action": "create",
-  "data": "did:btcr2:k1q5pel7vf3pjqa526m2up700805yckzsk6qpx6fkeqlaxfggclk43adqzeap82"
+  "data": "did:btcr2:k1q5plyvwt6qw6523ndym6dg8hqdnvk0kxqke37ejl0hc6taffmqdz36qnssf9t",
+  "keyId": "urn:kms:secp256k1:2d821c62dfdfaca4a91745a086fd4a9c",
+  "publicKey": "03f231cbd01daa2a336937a6a0f70366cb3ec605b31f665f7df1a5f529d81a28e8"
 }
 ```
+
+(For a bare `{action, data}` envelope, use the keystore-free raw-bytes path:
+`btcr2 -o json create -b <33-byte-pubkey-hex>`. Because `k` identifiers are deterministic,
+that raw path and the `--signing-key` path above yield the **same** DID for the same key.)
 
 **Two identifier flavors.** The one above is a *deterministic* (`k`) identifier: it is
 derived straight from a public key, so it resolves with zero external data. There is
@@ -204,7 +299,7 @@ Illustrative output (your `id`, `publicKeyMultibase`, and beacon addresses will 
 {
   "didResolutionMetadata": {},
   "didDocument": {
-    "id": "did:btcr2:k1q5pel7vf3pjqa526m2up700805yckzsk6qpx6fkeqlaxfggclk43adqzeap82",
+    "id": "did:btcr2:k1q5plyvwt6qw6523ndym6dg8hqdnvk0kxqke37ejl0hc6taffmqdz36qnssf9t",
     "@context": [
       "https://www.w3.org/ns/did/v1.1",
       "https://btcr2.dev/context/v1"
@@ -242,7 +337,7 @@ What to point at:
   address the controller watches: publishing an update means broadcasting a tiny signal
   from one of these addresses. They are derived from the same key, so they exist the
   moment the DID does.
-- `versionId: 1`. No updates yet.
+- `versionId: "1"`. No updates yet.
 
 ---
 
@@ -272,6 +367,13 @@ Then:
 2. Wait for **1 confirmation** (about 30-60 seconds). Watch it at
    `https://mutinynet.com/address/<the-address>`.
 
+> **Running this for a room?** The public Mutinynet faucet is rate-limited and usually
+> gated by a captcha, and a conference-room full of attendees behind one venue IP can get
+> throttled as if they were a single abusive client. Pre-arrange a mitigation: pre-fund
+> each attendee's beacon address from a facilitator wallet ahead of time, stagger the
+> requests, or keep one already-funded DID warm as a fallback so the reveal still runs if
+> the faucet is slow or down.
+
 > **Why wait for a confirmation?** The CLI deliberately refuses to spend an unconfirmed
 > beacon UTXO (an unconfirmed input can be reorged or replaced, which would un-anchor
 > your update). If you run `update` too early you will see
@@ -281,8 +383,8 @@ Then:
 ### Step B - broadcast the update
 
 Save the current document, then describe the change as a JSON Patch. This example adds
-an `alsoKnownAs` link. You will be prompted for your keystore passphrase here, because
-signing needs the secret key.
+an `alsoKnownAs` link. Signing needs your secret key: on Path A the live `keystore unlock`
+session supplies the passphrase (no prompt); on Path B the dev keystore needs none.
 
 ```bash
 # Save the current (v1) document.
@@ -295,12 +397,14 @@ btcr2 -o json --signing-key demo update \
   -p '[{"op":"add","path":"/alsoKnownAs","value":["https://example.com/demo"]}]' \
   -m "${DID}#initialKey" \
   -b "\"${DID}#initialP2WPKH\"" \
-  | jq '.data' > signed-update.json
+  | jq '.data.signedUpdate' > signed-update.json
 ```
 
 `update` signs the change, spends the funded beacon UTXO, and broadcasts a Bitcoin
-transaction whose `OP_RETURN` carries the update hash. `signed-update.json` is the
-off-chain half you keep.
+transaction whose `OP_RETURN` carries the update hash. The command's `.data` is an
+enriched result (`.data.txid` is the broadcast transaction id, handy for watching the
+signal confirm); `.data.signedUpdate` is the off-chain half you keep, so we extract just
+that into `signed-update.json`.
 
 > If the beacon is not funded (or the payment has not confirmed), `update` stops before
 > broadcasting with a clear message, for example:
@@ -309,7 +413,8 @@ off-chain half you keep.
 
 ### Step C - wait for the signal to confirm
 
-Give the update transaction about 1 block (30-60 seconds) to confirm on Mutinynet.
+Give the update transaction about 1 block (30-60 seconds) to confirm on Mutinynet. You
+can watch it with the `txid` from Step B at `https://mutinynet.com/tx/<txid>`.
 
 ### Step D - resolve v2 (the reveal)
 
@@ -335,16 +440,20 @@ Expected: the same document, now with your patch applied and `versionId: "2"`:
 }
 ```
 
-**The privacy punchline.** Resolve the **same** DID **without** the sidecar, and it
-reports that an update exists but cannot be reconstructed:
+**The privacy punchline.** Resolve the **same** DID **without** the sidecar. Bitcoin still
+holds the commitment (a 32-byte hash), but the document change is not on-chain, so
+resolution cannot reconstruct v2:
 
 ```bash
-btcr2 resolve -i "$DID"
-# Signed update required but not in sidecar (hash: ...). Provide options.sidecar.updates ...
+btcr2 resolve -i "$DID" --cas-timeout 1000
+# Signed update not found in CAS (hash: ...).
 ```
 
-Only the parties you share the sidecar with can see what changed. Bitcoin holds the
-commitment; you hold the contents.
+The resolver, finding an on-chain update hash but no sidecar, checks the default public
+IPFS gateway (where your never-published update was never put) and then fails. The
+`--cas-timeout 1000` just makes that miss return quickly on stage instead of waiting on a
+slow gateway. The takeaway: only the parties you share the sidecar with can see what
+changed. Bitcoin holds the commitment; you hold the contents.
 
 ---
 
@@ -356,6 +465,8 @@ commitment; you hold the contents.
   the most secure ledger there is.
 - **Private by construction.** On-chain you commit a hash; the document and any PII stay
   off-chain and are shared selectively.
+- **Authenticate once.** `keystore unlock` caches the passphrase for a session, so a run
+  of key and DID commands is prompt-free without ever exporting the secret into the shell.
 - **Standards-based.** The output is a W3C DID Core document; it drops into existing DID
   tooling.
 
@@ -365,20 +476,71 @@ commitment; you hold the contents.
 
 ### Output formats
 
-`-o text` (default) is terse and human-friendly; `-o json` is clean and scriptable.
-Every command supports both.
+`-o text` (default) is terse and human-friendly (it prints just the `data`); `-o json` is
+clean and scriptable (it prints the full `{action, data}` envelope). Every command
+supports both, and `BTCR2_OUTPUT` or `defaults.output` sets the default.
+
+### Keystore and sessions
+
+The `keystore` command group manages the encrypted store and the session unlock agent
+(these never touch Bitcoin):
+
+```bash
+btcr2 keystore init                    # establish the keystore (encrypted; prompts + confirms). --dev for an unencrypted dev keystore
+btcr2 keystore status                  # path, protection, key count, and session state (never decrypts or prompts)
+btcr2 keystore unlock --ttl 2h         # cache the passphrase for a session (default 1h, max 24h; also $BTCR2_KEYSTORE_TTL)
+btcr2 keystore lock                    # revoke the cached session (idempotent, needs no passphrase)
+btcr2 keystore change-passphrase       # re-seal every key under a new passphrase
+```
+
+How the session works (ADR 081):
+
+- `unlock` verifies the passphrase, then caches it in `<home>/session.json` (mode `0600`),
+  bound to that keystore. Later signing/sealing commands consume it instead of prompting,
+  until it expires or you `lock`. Passphrase precedence is: `BTCR2_KEYSTORE_PASSPHRASE`,
+  then `--passphrase-file`, then a live session, then an interactive prompt, so unattended
+  and CI paths always win over the cache.
+- The cached passphrase is base64url-encoded, **not encrypted**: its only protection at
+  rest is the `0600` file mode, so treat an unlocked machine accordingly. `lock` clears
+  it, as do `change-passphrase` and any `init` that establishes a fresh keystore
+  (`keystore init --force` is the way to re-establish over an existing one).
+- **Mainnet is gated.** `unlock` refuses a `bitcoin` default network unless you pass
+  `--allow-mainnet`, and even a session unlocked for testnet is withheld from a mainnet
+  operation (it falls back to a per-use prompt). Mutinynet needs no flag.
+
+**Encrypted vs dev keystores.** An encrypted keystore seals each secret with argon2id +
+XChaCha20-Poly1305 under one passphrase and records a verifier, so a mistyped passphrase
+fails loudly (`Incorrect passphrase`) instead of sealing a key under the wrong one. A
+**dev keystore** (`--dev`) stores secrets in plaintext and never prompts: it is for
+disposable testnet/regtest/signet/mutinynet keys only, and the CLI **hard-refuses** to
+sign or generate a mainnet (`bitcoin`) key with one.
+
+### Environment variables
+
+Handy for pre-seeding attendee machines or unattended runs:
+
+- `BTCR2_HOME` - relocate all state (same as `--home`).
+- `BTCR2_KEYSTORE_PASSPHRASE` - supply the passphrase non-interactively (highest
+  precedence, above `--passphrase-file` and any session).
+- `BTCR2_KEYSTORE_TTL` - default `keystore unlock` lifetime (same as `--ttl`).
+- Connection: `BTCR2_BTC_REST`, `BTCR2_CAS_GATEWAY`, `BTCR2_FEE_RATE`, and more.
+
+See the README's environment-variable table for the complete set.
 
 ### Config and profiles
 
+`btcr2 init` already created the config, so you rarely call `config init` directly.
+
 ```bash
-btcr2 config init                         # one profile per network
 btcr2 config set defaults.network mutinynet
 btcr2 config list
+btcr2 config path                         # show the resolved home, config, and keystore paths
 btcr2 profile add client-demo
 btcr2 profile use client-demo
 ```
 
-`config list` illustrative output:
+`config list` illustrative output (a fresh config has one empty profile per network;
+`defaults` starts with just `output` until you set more):
 
 ```json
 {
@@ -391,6 +553,10 @@ btcr2 profile use client-demo
 }
 ```
 
+`config validate` checks a file, `config effective` shows resolved connection values with
+their provenance (`flag`/`env`/`file`/`default`), and `config doctor` probes endpoint
+reachability.
+
 ### Shell completion
 
 ```bash
@@ -399,18 +565,28 @@ eval "$(btcr2 completion bash)"           # or: zsh, fish
 
 ### Deactivate
 
-`btcr2 deactivate` permanently and irreversibly retires a DID via the same on-chain
-write path as `update` (same funding prerequisite). Do not run it against a DID you want
-to keep.
+`btcr2 deactivate` (alias `delete`) permanently and irreversibly retires a DID via the
+same on-chain write path as `update` (same funding prerequisite, same signing: a live
+session or a prompt). Do not run it against a DID you want to keep.
 
 ### Where your data lives
 
-- Keystore: `$XDG_DATA_HOME/btcr2/keystore.json` (typically `~/.local/share/btcr2/`).
-- Config: `$XDG_CONFIG_HOME/btcr2/config.json` (typically `~/.config/btcr2/`).
+All CLI state lives in **one home directory**, holding `config.json`, `keystore.json`, and
+(after `keystore unlock`) `session.json` side by side:
 
-To run against throwaway locations instead (handy for a clean rehearsal), pass
-`--keystore <path>` and `--config <path>`, or point `XDG_DATA_HOME` / `XDG_CONFIG_HOME`
-at a scratch directory. Delete those files to reset.
+- Default: `~/.btcr2` on Linux/macOS, `%LOCALAPPDATA%\btcr2` on Windows.
+- Override the whole home with `--home <dir>` (highest priority) or `$BTCR2_HOME`.
+- `--config <path>` and `--keystore <path>` still override each file individually.
+- `btcr2 config path` prints the resolved locations.
+
+For a throwaway rehearsal that cannot touch your real state, point the home at a scratch
+directory and delete it to reset:
+
+```bash
+btcr2 --home /tmp/btcr2-demo init --dev
+# ...run the demo against /tmp/btcr2-demo...
+rm -rf /tmp/btcr2-demo
+```
 
 ### Troubleshooting
 
@@ -418,23 +594,34 @@ at a scratch directory. Delete those files to reset.
 |---|---|
 | `... is unfunded. Send BTC ...` | Fund the beacon address from the faucet, then retry. |
 | `No spendable UTXO ... unconfirmed` | The faucet payment has not confirmed yet. Wait one block. |
-| `Signed update required but not in sidecar` | The DID has an on-chain update; pass it back with `-r '{"sidecar":{"updates":[...]}}'`. |
-| `resolve` hangs | Check reachability to `https://mutinynet.com/api`; override with `--btc-rest <url>` if needed. |
-| `update` never prompts for a passphrase | You are in an old shell; the prompt appears on the signing step. Use `--passphrase-file <path>` for unattended runs. |
+| Faucet returns a rate-limit or captcha error | A shared room IP is being throttled. Stagger requests, or use a pre-funded beacon (see Step A). |
+| `Signed update not found in CAS` | You resolved a DID that has an on-chain update without providing the sidecar. Pass it back with `-r '{"sidecar":{"updates":[...]}}'` (that is the privacy feature, not a bug). |
+| `resolve` hangs | Check reachability to `https://mutinynet.com/api` (`btcr2 config doctor -n mutinynet`); override with `--btc-rest <url>` if needed. |
+| `update`/`deactivate` does not prompt for a passphrase | Expected when a `keystore unlock` session is live, when `BTCR2_KEYSTORE_PASSPHRASE`/`--passphrase-file` is set, or with a dev keystore. Run `btcr2 keystore status` to inspect the session; `btcr2 keystore lock` forces the prompt back. |
+| `Incorrect passphrase ...; no session was created` | The passphrase did not match the keystore verifier. Re-enter it, or rotate with `btcr2 keystore change-passphrase`. |
+| `Refusing to unlock for a mainnet (bitcoin) context` | Unlocking a mainnet default suspends per-use auth. Pass `--allow-mainnet` to override, or keep the per-use prompt. |
 
 ### Command reference (quick)
 
 ```
+btcr2 init [--dev] [--force]
+btcr2 keystore init [--dev] [--force] | status | change-passphrase | unlock [--ttl <dur>] [--allow-mainnet] | lock
 btcr2 key generate --name <n> --set-active
-btcr2 key list | show <ref> | use <ref> | import ... | export <ref> | delete <ref>
+btcr2 key list|ls | show <ref> | use <ref> | import ... | export [--secret --out <path>] <ref> | delete|rm [--force] <ref>
 btcr2 create [-t k|x] [-n <network>] [-b <hex>] [--signing-key <ref>]
-btcr2 resolve -i <did> [-r <json>] [-p <path>]
-btcr2 update -s <doc-json> --source-version-id <n> -p <patches-json> -m <vm-id> -b <beacon-id-json>
-btcr2 deactivate -s <doc-json> --source-version-id <n> -m <vm-id> -b <beacon-id-json>
-btcr2 config init | get [path] | set <path> <value> | unset <path> | list
-btcr2 profile add <name> | use <name> | show [name] | remove <name>
+btcr2 resolve|read -i <did> [-r <json>] [-p <path>]
+btcr2 update -s <doc-json> --source-version-id <n> -p <patches-json> -m <vm-id> -b <beacon-id-json> [--publish-to-cas <mode>] [--fee-rate <n>] [--change-address <addr>]
+btcr2 deactivate|delete -s <doc-json> --source-version-id <n> -m <vm-id> -b <beacon-id-json>
+btcr2 config init | get [path] | set <path> <value> | unset <path> | list|ls | validate | effective | path | doctor
+btcr2 profile add <name> | use <name> | show [name] | remove|rm <name>
+btcr2 completion [bash|zsh|fish]
 ```
 ```
-Global flags: -o json|text  --verbose  --quiet  -c <config>  --profile <name>
-              --btc-rest <url>  --keystore <path>  --passphrase-file <path>  --signing-key <ref>
+Global flags: -o json|text  --verbose  --quiet  --home <dir>  -c <config>  --profile <name>
+              --keystore <path>  --passphrase-file <path>  --signing-key <ref>
+              --btc-rest <url>  --btc-rpc-url <url>  --btc-rpc-user <u>  --btc-rpc-pass <p>
+              --cas-gateway <url>  --cas-rpc-url <url>  --btc-timeout <ms>  --cas-timeout <ms>
 ```
+
+See `btcr2 --help` (or the README's Global flags and Environment variables tables) for the
+complete surface, including the RPC wallet/header and CAS publication flags.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,8 +4,9 @@ import { defaultConfigPath, resolveKeystorePath, writeDefaultConfigFile } from '
 import { ensureDir } from '../keystore/atomic.js';
 import { initKeystore, keystoreSummary } from '../keystore/file-key-store.js';
 import { acquirePassphrase } from '../keystore/passphrase.js';
+import { clearSession } from '../keystore/session.js';
 import { formatResult } from '../output.js';
-import { resolveHome } from '../paths.js';
+import { defaultSessionPath, resolveHome } from '../paths.js';
 import type { CommandResult, GlobalOptions } from '../types.js';
 
 /**
@@ -62,6 +63,11 @@ export function registerInitCommand(program: Command, globals: () => GlobalOptio
           protection    : options.dev ? 'none' : 'passphrase',
           getPassphrase : (opts) => acquirePassphrase({ passphraseFile: g.passphraseFile, confirm: opts?.confirm, prompt: 'New keystore passphrase: ' }),
         });
+        // A freshly established keystore mints a new verifier (or none, for --dev),
+        // so any cached session holds a passphrase for a keystore that no longer
+        // exists. Drop it, matching `keystore init` / `change-passphrase`, rather
+        // than leave a stale plaintext passphrase behind (ADR 081).
+        clearSession(defaultSessionPath(g));
         created.push('keystore');
       }
 

--- a/packages/cli/src/commands/keystore.ts
+++ b/packages/cli/src/commands/keystore.ts
@@ -1,20 +1,37 @@
 import type { Command } from 'commander';
 import { existsSync } from 'node:fs';
-import { resolveKeystorePath } from '../config.js';
+import { resolveDefaultNetwork, resolveKeystorePath } from '../config.js';
 import { CLIError } from '../error.js';
-import { changeKeystorePassphrase, initKeystore, keystoreSummary } from '../keystore/file-key-store.js';
+import {
+  changeKeystorePassphrase,
+  initKeystore,
+  keystoreSummary,
+  keystoreVerifierId,
+  verifyKeystorePassphrase,
+} from '../keystore/file-key-store.js';
 import { acquirePassphrase } from '../keystore/passphrase.js';
+import {
+  clearSession,
+  DEFAULT_SESSION_TTL_MS,
+  ENV_KEYSTORE_TTL,
+  MAX_SESSION_TTL_MS,
+  parseTtlToMs,
+  readSessionStatus,
+  writeSession,
+} from '../keystore/session.js';
 import { formatResult } from '../output.js';
-import type { CommandResult, GlobalOptions } from '../types.js';
+import { defaultSessionPath } from '../paths.js';
+import { blankToUndef, type CommandResult, type GlobalOptions } from '../types.js';
 
 /**
  * Registers the `keystore` command group: establish, inspect, and re-key the
- * encrypted keystore (ADR 080). These operate on the keystore file directly (no
- * Bitcoin connection or KeyManager) and never decrypt a key except when
- * re-sealing during `change-passphrase`.
+ * encrypted keystore (ADR 080), plus the session unlock agent (ADR 081). These
+ * operate on the keystore and session files directly (no Bitcoin connection or
+ * KeyManager) and never decrypt a key except when re-sealing during
+ * `change-passphrase`.
  */
 export function registerKeystoreCommand(program: Command, globals: () => GlobalOptions): void {
-  const keystore = program.command('keystore').description('Establish, inspect, and re-key the keystore.');
+  const keystore = program.command('keystore').description('Establish, inspect, re-key, and unlock the keystore.');
   const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
 
   keystore
@@ -51,22 +68,27 @@ export function registerKeystoreCommand(program: Command, globals: () => GlobalO
         protection    : options.dev ? 'none' : 'passphrase',
         getPassphrase : (opts) => acquirePassphrase({ passphraseFile: g.passphraseFile, confirm: opts?.confirm, prompt: 'New keystore passphrase: ' }),
       });
+      // A re-established keystore mints a new verifier (or none, for --dev), so any
+      // cached session now holds a passphrase for a keystore that no longer exists.
+      // Drop it rather than leave a stale plaintext passphrase behind (ADR 081).
+      clearSession(defaultSessionPath(g));
       print({ action: 'keystore-init', data: { path, protection: options.dev ? 'dev' : 'encrypted' } });
     });
 
   keystore
     .command('status')
-    .description('Show the keystore path, protection mode, and key count. Never decrypts or prompts.')
+    .description('Show the keystore path, protection mode, key count, and session state. Never decrypts or prompts.')
     .action(() => {
       const g = globals();
       // Diagnostic command: report status even when the config is malformed,
       // rather than crashing on the config you ran this to inspect.
       const path = resolveKeystorePath(g, { lenient: true });
       const summary = keystoreSummary(path);
+      const session = readSessionStatus(defaultSessionPath(g), path, keystoreVerifierId(path));
       if (summary.protection === 'dev' && !g.quiet && g.output !== 'json') {
         process.stderr.write('warning: this is an UNENCRYPTED dev keystore; keys are stored in plaintext.\n');
       }
-      print({ action: 'keystore-status', data: { path, ...summary } });
+      print({ action: 'keystore-status', data: { path, ...summary, session } });
     });
 
   keystore
@@ -93,6 +115,118 @@ export function registerKeystoreCommand(program: Command, globals: () => GlobalO
       const oldPassphrase = acquirePassphrase({ passphraseFile: g.passphraseFile, prompt: 'Current keystore passphrase: ' });
       const newPassphrase = acquirePassphrase({ forcePrompt: true, confirm: true, prompt: 'New keystore passphrase: ' });
       const rekeyed = changeKeystorePassphrase(path, oldPassphrase, newPassphrase);
+      // The rotated verifier already invalidates a cached session by fingerprint,
+      // but the session file still holds the OLD passphrase in plaintext; delete it.
+      clearSession(defaultSessionPath(g));
       print({ action: 'keystore-change-passphrase', data: { path, rekeyed } });
     });
+
+  keystore
+    .command('unlock')
+    .description('Cache the keystore passphrase for a session so later commands do not re-prompt (ADR 081).')
+    .option('--ttl <duration>', `Session lifetime: bare seconds or an s/m/h suffix (default 1h, max 24h). Also $${ENV_KEYSTORE_TTL}.`)
+    .option('--allow-mainnet', 'Permit unlocking when the active network is mainnet (bitcoin); this suspends per-use passphrase auth for the session.', false)
+    .action((options: { ttl?: string; allowMainnet?: boolean }) => {
+      const g = globals();
+      const path = resolveKeystorePath(g);
+      const summary = keystoreSummary(path);
+      if (summary.protection === 'absent') {
+        throw new CLIError(`No keystore at ${path}. Run "btcr2 init" or "btcr2 keystore init" first.`, 'INVALID_ARGUMENT_ERROR', { path });
+      }
+      if (summary.protection === 'dev') {
+        throw new CLIError(
+          `The keystore at ${path} is an unencrypted dev keystore; it has no passphrase to cache, so no unlock is needed.`,
+          'INVALID_ARGUMENT_ERROR',
+          { path },
+        );
+      }
+      if (!summary.established) {
+        throw new CLIError(
+          `The keystore at ${path} has no passphrase established yet. `
+          + 'Establish one with "btcr2 keystore init" or the first "btcr2 key generate".',
+          'INVALID_ARGUMENT_ERROR',
+          { path },
+        );
+      }
+      // An unlocked encrypted keystore signs prompt-free for the whole TTL,
+      // silently removing per-use passphrase auth. Two guards, both keyed to
+      // --allow-mainnet (ADR 081): this early refusal when the *configured* default
+      // network is mainnet (a clear signal before caching anything), plus the
+      // authoritative one at consumption, where the session records `allowMainnet`
+      // (below) and a `bitcoin` operation, whose network is derived from the DID
+      // rather than the config, is withheld from a session that lacks it. The
+      // active network defaults to a testnet, so this early refusal never fires
+      // for the demo.
+      if (!options.allowMainnet && resolveDefaultNetwork(g) === 'bitcoin') {
+        throw new CLIError(
+          `Refusing to unlock for a mainnet (bitcoin) context: caching the passphrase suspends per-use `
+          + 'authentication for the session. Pass --allow-mainnet to override, or keep signing mainnet '
+          + 'updates with a per-use passphrase prompt.',
+          'MAINNET_UNLOCK_REFUSED_ERROR',
+          { path },
+        );
+      }
+      const ttlMs = resolveSessionTtl(options.ttl);
+      // Acquire the passphrase directly (env / file / prompt) with NO session
+      // consultation and NO confirm, verify it against the keystore verifier, and
+      // only then cache it. A wrong passphrase writes no session file.
+      const passphrase = acquirePassphrase({ passphraseFile: g.passphraseFile, prompt: 'Keystore passphrase: ' });
+      if (!verifyKeystorePassphrase(path, passphrase)) {
+        throw new CLIError(`Incorrect passphrase for the keystore at ${path}; no session was created.`, 'DECRYPT_ERROR', { path });
+      }
+      const verifierId = keystoreVerifierId(path);
+      if (!verifierId) {
+        // An established keystore always carries a verifier; defensive guard.
+        throw new CLIError(`The keystore at ${path} has no verifier to bind a session to.`, 'INVALID_ARGUMENT_ERROR', { path });
+      }
+      const session = writeSession(defaultSessionPath(g), {
+        keystorePath : path,
+        verifierId,
+        passphrase,
+        ttlMs,
+        allowMainnet : !!options.allowMainnet,
+      });
+      print({ action: 'keystore-unlock', data: { keystore: path, expiresAt: session.expiresAt, ttlSeconds: session.ttlSeconds } });
+    });
+
+  keystore
+    .command('lock')
+    .description('Revoke the cached session so later commands prompt for the passphrase again (ADR 081).')
+    .action(() => {
+      const g = globals();
+      // Resolve the session from the home only (defaultSessionPath never reads the
+      // config), so lock revokes even under a malformed config.
+      const sessionPath = defaultSessionPath(g);
+      const cleared = clearSession(sessionPath);
+      print({ action: 'keystore-lock', data: { path: sessionPath, cleared } });
+    });
+}
+
+/**
+ * Resolves the session TTL in milliseconds from the `--ttl` flag, then
+ * `$BTCR2_KEYSTORE_TTL`, then the one-hour default. Rejects a non-positive,
+ * malformed, or over-24h value with a {@link CLIError} that names the actual
+ * source (the flag or the env var) so the operator fixes the right input.
+ */
+function resolveSessionTtl(flag?: string): number {
+  const fromFlag = blankToUndef(flag);
+  const raw = fromFlag ?? blankToUndef(process.env[ENV_KEYSTORE_TTL]);
+  if (raw === undefined) return DEFAULT_SESSION_TTL_MS;
+  const source = fromFlag !== undefined ? '--ttl' : `$${ENV_KEYSTORE_TTL}`;
+  const ms = parseTtlToMs(raw);
+  if (ms === undefined || ms <= 0) {
+    throw new CLIError(
+      `Invalid ${source} "${raw}": expected seconds or a value with an s/m/h suffix, e.g. 3600, 45m, or 2h.`,
+      'INVALID_ARGUMENT_ERROR',
+      { value: raw, source },
+    );
+  }
+  if (ms > MAX_SESSION_TTL_MS) {
+    throw new CLIError(
+      `${source} "${raw}" exceeds the 24h maximum for a cached passphrase.`,
+      'INVALID_ARGUMENT_ERROR',
+      { value: raw, source },
+    );
+  }
+  return ms;
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,10 +7,11 @@ import { dirname } from 'node:path';
 import { CLIError } from './error.js';
 import { ensureDir, writeFileAtomic } from './keystore/atomic.js';
 import { FileBackedKeyManager } from './keystore/file-backed-key-manager.js';
-import { keystoreProtection } from './keystore/file-key-store.js';
+import { keystoreProtection, keystoreVerifierId } from './keystore/file-key-store.js';
 import { defaultKeystorePath } from './keystore/paths.js';
 import { acquirePassphrase } from './keystore/passphrase.js';
-import { defaultConfigPath } from './paths.js';
+import { readLiveSessionPassphrase } from './keystore/session.js';
+import { defaultConfigPath, defaultSessionPath } from './paths.js';
 import { blankToUndef, SUPPORTED_NETWORKS, type KeystoreProtectionLabel, type NetworkOption, type OutputFormat } from './types.js';
 
 export { defaultConfigPath };
@@ -947,13 +948,34 @@ export function defaultApiFactory(network?: NetworkOption, overrides?: Connectio
  * or opened. The persisted active-key pointer is re-applied (a non-decrypting
  * existence check) so "the active key" survives across invocations.
  */
-function buildKeystoreKms(overrides?: ConnectionOverrides): KeyManager {
+function buildKeystoreKms(overrides?: ConnectionOverrides, network?: NetworkOption): KeyManager {
+  const keystorePath = resolveKeystorePath(overrides);
+  const sessionPath = defaultSessionPath(overrides);
+  // The network the operation will sign under, known here because the factory
+  // receives it. A `bitcoin` operation must not consume a session that was not
+  // unlocked with `--allow-mainnet`, so mainnet keeps per-use authentication even
+  // while a session is live (ADR 081). Key commands pass no network, so the
+  // session serves them as before.
+  const isMainnetOperation = network === 'bitcoin';
   return new FileBackedKeyManager({
-    path          : resolveKeystorePath(overrides),
+    path          : keystorePath,
     // The store decides when to confirm: it passes `confirm: true` only while
     // establishing a fresh keystore's passphrase, so a first-key typo is caught
     // by a second entry (ADR 080). confirm is a no-op for env/file sources.
-    getPassphrase : (opts) => acquirePassphrase({ passphraseFile: overrides?.passphraseFile, confirm: opts?.confirm }),
+    //
+    // On the non-establishing path, a cached session (ADR 081) is consulted below
+    // the env var / --passphrase-file and above the interactive prompt. It is
+    // wired ONLY when not confirming, so establishment never consults the session
+    // and a first passphrase is always entered fresh and twice. The session is
+    // bound to this keystore's verifier, so a rotated passphrase invalidates it.
+    getPassphrase : (opts) => acquirePassphrase({
+      passphraseFile : overrides?.passphraseFile,
+      confirm        : opts?.confirm,
+      ...(opts?.confirm ? {} : {
+        beforePrompt : (): string | undefined =>
+          readLiveSessionPassphrase(sessionPath, keystorePath, keystoreVerifierId(keystorePath), isMainnetOperation),
+      }),
+    }),
   });
 }
 
@@ -1048,7 +1070,7 @@ export function resolveSigningKeyRef(overrides?: ConnectionOverrides): string | 
 export function keystoreApiFactory(network?: NetworkOption, overrides?: ConnectionOverrides): DidBtcr2Api {
   return createApi({
     ...resolveConnectionConfig(network, overrides),
-    kms : buildKeystoreKms(overrides),
+    kms : buildKeystoreKms(overrides, network),
   });
 }
 

--- a/packages/cli/src/keystore/file-key-store.ts
+++ b/packages/cli/src/keystore/file-key-store.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { KeyEntry, KeyIdentifier, KeyValueStore } from '@did-btcr2/key-manager';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { base64urlnopad } from '@scure/base';
 import type { KeystoreProtectionLabel } from '../types.js';
@@ -662,6 +663,48 @@ export function keystoreSummary(path: string): KeystoreSummary {
 /** The protection label of a keystore file, without decrypting or prompting. */
 export function keystoreProtection(path: string): KeystoreProtectionLabel {
   return keystoreSummary(path).protection;
+}
+
+/**
+ * A stable fingerprint of a keystore's passphrase verifier, or `undefined` when
+ * the file is absent, unparsable, or carries no verifier. Compared by equality
+ * to detect a rotated passphrase (`change-passphrase`, `init --force`) or a
+ * re-established keystore, so a cached session (ADR 081) stops matching a
+ * keystore whose passphrase has changed. Never decrypts, never throws.
+ */
+export function keystoreVerifierId(path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  let parsed: KeystoreFile;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as KeystoreFile;
+  } catch {
+    return undefined;
+  }
+  if (!parsed.verifier) return undefined;
+  return base64urlnopad.encode(sha256(utf8ToBytes(JSON.stringify(parsed.verifier))));
+}
+
+/**
+ * Checks a candidate passphrase against the keystore's verifier without
+ * constructing a store or opening any key. Returns `false` for an absent,
+ * unparsable, dev, or verifier-less keystore and for a wrong passphrase; `true`
+ * only when the passphrase opens the verifier sentinel. Never throws. Used by
+ * `keystore unlock` (ADR 081) to refuse caching a wrong passphrase.
+ */
+export function verifyKeystorePassphrase(path: string, passphrase: string): boolean {
+  if (!existsSync(path)) return false;
+  let parsed: KeystoreFile;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as KeystoreFile;
+  } catch {
+    return false;
+  }
+  if (parsed.protection !== 'passphrase' || !parsed.verifier) return false;
+  try {
+    return bytesEqual(decryptSecret(parsed.verifier, passphrase), VERIFIER_PLAINTEXT);
+  } catch {
+    return false;
+  }
 }
 
 /** Options for {@link initKeystore}. */

--- a/packages/cli/src/keystore/passphrase.ts
+++ b/packages/cli/src/keystore/passphrase.ts
@@ -19,6 +19,16 @@ export type PassphraseOptions = {
    * satisfy the new one (which would make the change a no-op).
    */
   forcePrompt?: boolean;
+  /**
+   * An optional non-interactive source consulted *after* the env var and
+   * passphrase file and *before* the terminal prompt (and before the "no TTY"
+   * failure). The session unlock agent (ADR 081) wires this to a cached
+   * passphrase, so a returning command consumes the session instead of
+   * prompting, and a non-interactive follow-on command does not hard-fail. It
+   * returns `undefined` when no session is available. Skipped when `forcePrompt`
+   * is set, and never wired during passphrase establishment (`confirm`).
+   */
+  beforePrompt?: () => string | undefined;
 };
 
 /**
@@ -39,6 +49,19 @@ export function acquirePassphrase(options: PassphraseOptions = {}): string {
     if (options.passphraseFile) {
       return assertNonEmpty(readFileSync(options.passphraseFile, 'utf-8').replace(/\r?\n$/, ''));
     }
+
+    // A cached session (ADR 081) sits below the env var and file but above the
+    // interactive prompt, so it is consulted before the "no TTY" failure: a
+    // scripted or piped follow-on command consumes the session instead of
+    // hard-failing. Establishment never reaches here (its caller omits it).
+    //
+    // The session already holds the exact, keystore-verified passphrase (encoded
+    // and decoded byte-for-byte), not a raw source needing newline normalization.
+    // Return it verbatim: re-stripping a trailing newline here would corrupt the
+    // KDF input for a passphrase that legitimately ends in one, even though unlock
+    // itself succeeded. assertNonEmpty is a defensive guard only.
+    const fromSession = options.beforePrompt?.();
+    if (fromSession) return assertNonEmpty(fromSession);
   }
 
   if (!process.stdin.isTTY) {

--- a/packages/cli/src/keystore/session.ts
+++ b/packages/cli/src/keystore/session.ts
@@ -1,0 +1,303 @@
+import { closeSync, constants, existsSync, fstatSync, openSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
+import { base64urlnopad } from '@scure/base';
+import { ensureDir, writeFileAtomic } from './atomic.js';
+
+/**
+ * The session unlock agent (ADR 081). `keystore unlock` caches the verified
+ * keystore passphrase in a single `<home>/session.json`, and subsequent commands
+ * read it in place of a prompt until it expires or `keystore lock` revokes it.
+ *
+ * This is an on-disk v1 design. The cached passphrase is base64url-*encoded*, not
+ * encrypted: its only protection at rest is the file's `0600` mode. That is the
+ * deliberate, documented cost of a portable, minimal-diff convenience; a future
+ * in-memory agent (v2) that never persists the secret is the real fix. Every read
+ * here is defensive and never throws, so a bad or hostile session degrades to a
+ * passphrase prompt rather than a crash.
+ */
+
+/** Current session-file format version. */
+export const SESSION_VERSION = 1 as const;
+
+/** Default session lifetime: one hour. */
+export const DEFAULT_SESSION_TTL_MS = 60 * 60 * 1000;
+/** Hard cap on a cached-passphrase lifetime: 24 hours. A longer TTL is refused. */
+export const MAX_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+/** Environment variable supplying a default TTL below the `--ttl` flag. */
+export const ENV_KEYSTORE_TTL = 'BTCR2_KEYSTORE_TTL';
+
+/**
+ * The on-disk session file. `passphrase` is base64url(utf8(passphrase)): an
+ * encoding, not encryption. `keystore` binds the session to one keystore, and
+ * `verifierId` (a hash of that keystore's verifier) invalidates the session when
+ * the passphrase is rotated. `allowMainnet` records whether the operator unlocked
+ * with `--allow-mainnet`; a session without it is withheld from a `bitcoin`
+ * operation so mainnet keeps per-use authentication (ADR 081). No derived key,
+ * keystore ciphertext, or signing-key bytes ever appear here.
+ */
+export interface SessionFile {
+  v            : typeof SESSION_VERSION;
+  keystore     : string;
+  verifierId   : string;
+  passphrase   : string;
+  allowMainnet : boolean;
+  createdAt    : number;
+  expiresAt    : number;
+  ttlSeconds   : number;
+}
+
+/** Inputs for {@link writeSession}. */
+export interface WriteSessionInput {
+  /** The keystore this session unlocks (stored resolved/normalized). */
+  keystorePath  : string;
+  /** Fingerprint of the keystore verifier, from `keystoreVerifierId`. */
+  verifierId    : string;
+  /** The verified passphrase to cache. */
+  passphrase    : string;
+  /** Lifetime in milliseconds. */
+  ttlMs         : number;
+  /**
+   * Whether this session may be consumed for a mainnet (`bitcoin`) operation,
+   * from the `unlock --allow-mainnet` flag. Defaults to `false` (deny), so
+   * mainnet operations fall through to a per-use passphrase prompt (ADR 081).
+   */
+  allowMainnet? : boolean;
+}
+
+/**
+ * Writes the session file atomically at `0600` (temp sibling + rename), returning
+ * the written record so the caller can report expiry without re-reading. The
+ * caller is responsible for verifying the passphrase first; this only persists it.
+ */
+export function writeSession(sessionPath: string, input: WriteSessionInput): SessionFile {
+  const createdAt = Date.now();
+  const session: SessionFile = {
+    v            : SESSION_VERSION,
+    keystore     : resolve(input.keystorePath),
+    verifierId   : input.verifierId,
+    passphrase   : base64urlnopad.encode(utf8ToBytes(input.passphrase)),
+    allowMainnet : input.allowMainnet ?? false,
+    createdAt,
+    expiresAt    : createdAt + input.ttlMs,
+    ttlSeconds   : Math.round(input.ttlMs / 1000),
+  };
+  ensureDir(dirname(sessionPath), 0o700);
+  writeFileAtomic(sessionPath, `${JSON.stringify(session, null, 2)}\n`, 0o600);
+  return session;
+}
+
+/**
+ * Deletes the session file and any crash-orphaned `writeFileAtomic` temp sibling
+ * (each of which would hold a plaintext passphrase). Idempotent; needs no
+ * passphrase. Returns whether a session file was present. Unlink is best-effort:
+ * it removes the name, it does not securely erase the bytes (see ADR 081).
+ */
+export function clearSession(sessionPath: string): boolean {
+  let existed = false;
+  try {
+    existed = existsSync(sessionPath);
+    if (existed) rmSync(sessionPath, { force: true });
+  } catch {
+    // Best effort: a session we cannot remove is reported as not-cleared below.
+    existed = false;
+  }
+  sweepSessionTemps(sessionPath);
+  return existed;
+}
+
+/** Removes `.session.json.<pid>.<n>.tmp` leftovers from an interrupted atomic write. */
+function sweepSessionTemps(sessionPath: string): void {
+  const dir = dirname(sessionPath);
+  const prefix = `.${basename(sessionPath)}.`;
+  try {
+    for (const name of readdirSync(dir)) {
+      if (name.startsWith(prefix) && name.endsWith('.tmp')) {
+        try {
+          rmSync(join(dir, name), { force: true });
+        } catch {
+          // A temp file we cannot remove is left for the next sweep.
+        }
+      }
+    }
+  } catch {
+    // Directory unreadable or absent: nothing to sweep.
+  }
+}
+
+/**
+ * Returns the cached passphrase for `keystorePath` when a live, matching session
+ * exists, else `undefined`. Never throws. A session that is expired, stale (the
+ * keystore passphrase rotated), future-dated, or malformed is pruned on read; a
+ * live session bound to a *different* keystore is left in place (it prompts for
+ * the current keystore instead).
+ *
+ * `isMainnetOperation` gates the one case the network is known at consumption: a
+ * live session that was not unlocked with `--allow-mainnet` is withheld from a
+ * `bitcoin` operation (returning `undefined` so the caller falls through to a
+ * per-use prompt) but *not* pruned, since it remains valid for the non-mainnet
+ * operations the operator unlocked for (ADR 081).
+ */
+export function readLiveSessionPassphrase(
+  sessionPath        : string,
+  keystorePath       : string,
+  currentVerifierId  : string | undefined,
+  isMainnetOperation = false,
+): string | undefined {
+  const verdict = evaluateSession(sessionPath, keystorePath, currentVerifierId, Date.now());
+  if (verdict.status === 'live') {
+    // Withhold a session lacking mainnet allowance from a mainnet operation, so
+    // signing a `bitcoin` DID still authenticates per use. Leave it in place: it
+    // is a valid session, just not for this operation (like a foreign keystore).
+    if (isMainnetOperation && !verdict.session.allowMainnet) return undefined;
+    try {
+      return Buffer.from(base64urlnopad.decode(verdict.session.passphrase)).toString('utf-8');
+    } catch {
+      clearSession(sessionPath);
+      return undefined;
+    }
+  }
+  // Prune a session that is dead for everyone or dead for this keystore. A
+  // 'foreign' (live, different keystore) or 'none' session is left untouched.
+  if (verdict.status === 'expired' || verdict.status === 'stale'
+    || verdict.status === 'future' || verdict.status === 'malformed') {
+    clearSession(sessionPath);
+  }
+  return undefined;
+}
+
+/** Public, redacted view of the session state for `keystore status`. Never emits the passphrase. */
+export interface SessionStatus {
+  active            : boolean;
+  expiresAt?        : number;
+  secondsRemaining? : number;
+  /** Whether the session may sign a mainnet operation prompt-free (unlocked with `--allow-mainnet`). */
+  allowMainnet?     : boolean;
+}
+
+/**
+ * Reports whether a live session exists for `keystorePath` and its remaining
+ * lifetime, without decrypting, prompting, throwing, or emitting the passphrase.
+ * An expired, foreign, stale, or malformed session reports inactive. Read-only:
+ * unlike {@link readLiveSessionPassphrase}, it does not prune.
+ */
+export function readSessionStatus(
+  sessionPath       : string,
+  keystorePath      : string,
+  currentVerifierId : string | undefined,
+): SessionStatus {
+  const now = Date.now();
+  const verdict = evaluateSession(sessionPath, keystorePath, currentVerifierId, now);
+  if (verdict.status !== 'live') return { active: false };
+  return {
+    active           : true,
+    expiresAt        : verdict.session.expiresAt,
+    secondsRemaining : Math.max(0, Math.round((verdict.session.expiresAt - now) / 1000)),
+    allowMainnet     : verdict.session.allowMainnet,
+  };
+}
+
+/**
+ * Parses a TTL string into milliseconds: a bare integer is seconds; an `s`, `m`,
+ * or `h` suffix scales it. Returns `undefined` for any malformed input. The
+ * caller applies the default, the 24h cap, and the `<= 0` rejection.
+ */
+export function parseTtlToMs(raw: string): number | undefined {
+  const match = /^(\d+)([smh]?)$/.exec(raw.trim());
+  if (!match) return undefined;
+  const n = Number(match[1]);
+  if (!Number.isFinite(n)) return undefined;
+  const unitMs = match[2] === 'h' ? 3_600_000 : match[2] === 'm' ? 60_000 : 1_000;
+  return n * unitMs;
+}
+
+/** The outcome of inspecting a session file against the current keystore and clock. */
+type SessionVerdict =
+  | { status: 'live'; session: SessionFile }
+  | { status: 'none' | 'foreign' | 'expired' | 'stale' | 'future' | 'malformed' };
+
+/**
+ * Classifies the session file: read it securely, then check version, shape,
+ * clock, keystore binding, and verifier fingerprint in that order. Ordering
+ * `expired` before `foreign` means an expired session is pruned regardless of
+ * which keystore it was for. Never throws.
+ */
+function evaluateSession(
+  sessionPath       : string,
+  keystorePath      : string,
+  currentVerifierId : string | undefined,
+  now               : number,
+): SessionVerdict {
+  const session = secureReadSession(sessionPath);
+  if (!session) return { status: 'none' };
+  if (session.v !== SESSION_VERSION) return { status: 'malformed' };
+  if (typeof session.passphrase !== 'string' || typeof session.keystore !== 'string'
+    || typeof session.verifierId !== 'string' || typeof session.allowMainnet !== 'boolean'
+    || typeof session.createdAt !== 'number' || typeof session.expiresAt !== 'number') {
+    return { status: 'malformed' };
+  }
+  if (session.createdAt > now) return { status: 'future' };
+  if (now >= session.expiresAt) return { status: 'expired' };
+  if (resolve(session.keystore) !== resolve(keystorePath)) return { status: 'foreign' };
+  if (currentVerifierId === undefined || session.verifierId !== currentVerifierId) return { status: 'stale' };
+  return { status: 'live', session };
+}
+
+/**
+ * Reads and parses the session file with a plaintext secret in mind. On POSIX,
+ * opens with `O_NOFOLLOW` (refusing a symlink) and refuses a non-regular file, a
+ * file not owned by this user, or one accessible by group or other, best-effort
+ * deleting a rejected file and reading only from the opened descriptor (no TOCTOU
+ * re-open). On Windows those POSIX guards are skipped (they would throw), so the
+ * file is read normally under the same directory ACL the keystore trusts, keeping
+ * the session usable rather than silently ignored. Returns `undefined` on any
+ * failure; never throws.
+ */
+function secureReadSession(sessionPath: string): SessionFile | undefined {
+  let raw: string;
+  if (process.platform === 'win32') {
+    try {
+      raw = readFileSync(sessionPath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+  } else {
+    let fd: number;
+    try {
+      fd = openSync(sessionPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    } catch {
+      // ENOENT (no session), ELOOP (symlink refused by O_NOFOLLOW), or any other
+      // open failure: no usable session.
+      return undefined;
+    }
+    try {
+      const st = fstatSync(fd);
+      const myUid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+      if (!st.isFile() || (myUid !== undefined && st.uid !== myUid) || (st.mode & 0o077) !== 0) {
+        // Not a regular file we own with 0600 perms: it was not written by this
+        // process. Best-effort remove it (it may hold a plaintext passphrase) and
+        // fall back to a prompt.
+        try {
+          rmSync(sessionPath, { force: true });
+        } catch {
+          // Cannot remove a file we do not own; ignoring it is enough.
+        }
+        return undefined;
+      }
+      raw = readFileSync(fd, 'utf-8');
+    } catch {
+      return undefined;
+    } finally {
+      try {
+        closeSync(fd);
+      } catch {
+        // Descriptor already gone; nothing to close.
+      }
+    }
+  }
+  try {
+    return JSON.parse(raw) as SessionFile;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -23,6 +23,8 @@ export const ENV_HOME = 'BTCR2_HOME';
 /** The config and keystore file names, kept side by side under the home root. */
 export const CONFIG_FILENAME = 'config.json';
 export const KEYSTORE_FILENAME = 'keystore.json';
+/** The session file name, holding the unlock agent's cached passphrase (ADR 081). */
+export const SESSION_FILENAME = 'session.json';
 
 /**
  * Resolves the CLI home directory: the single root that holds `config.json` and
@@ -76,4 +78,15 @@ export function defaultConfigPath(overrides?: PathOverrides): string {
  */
 export function defaultKeystorePath(overrides?: PathOverrides): string {
   return join(resolveHome(overrides), KEYSTORE_FILENAME);
+}
+
+/**
+ * Session file path: `<home>/session.json`, where the unlock agent caches the
+ * keystore passphrase (ADR 081). Deliberately derived from the home root alone,
+ * never from `--config` / `--keystore` or the config file, so `keystore lock`
+ * can revoke a session even under a malformed config, and so the read and write
+ * paths always agree on one location per home.
+ */
+export function defaultSessionPath(overrides?: PathOverrides): string {
+  return join(resolveHome(overrides), SESSION_FILENAME);
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,6 +4,7 @@ import type { Btcr2DidDocument, ResolutionOptions } from '@did-btcr2/method';
 import type { DidResolutionResult } from '@web5/dids';
 import type { DoctorReport, EffectiveConfig } from './config.js';
 import type { ConfigIssue } from './config-schema.js';
+import type { SessionStatus } from './keystore/session.js';
 
 export type NetworkOption = 'bitcoin' | 'testnet3' | 'testnet4' | 'signet' | 'mutinynet' | 'regtest';
 export type OutputFormat = 'json' | 'text';
@@ -66,8 +67,10 @@ export type CommandResult =
   | { action: 'config-path'; data: { home: string; config: string; keystore: string } }
   | { action: 'config-doctor'; data: DoctorReport }
   | { action: 'keystore-init'; data: { path: string; protection: 'encrypted' | 'dev' } }
-  | { action: 'keystore-status'; data: { path: string; protection: KeystoreProtectionLabel; established: boolean; keyCount: number; active: string | undefined } }
+  | { action: 'keystore-status'; data: { path: string; protection: KeystoreProtectionLabel; established: boolean; keyCount: number; active: string | undefined; session: SessionStatus } }
   | { action: 'keystore-change-passphrase'; data: { path: string; rekeyed: number } }
+  | { action: 'keystore-unlock'; data: { keystore: string; expiresAt: number; ttlSeconds: number } }
+  | { action: 'keystore-lock'; data: { path: string; cleared: boolean } }
   | { action: 'profile-add'; data: { profile: string } }
   | { action: 'profile-use'; data: { profile: string } }
   | { action: 'profile-show'; data: unknown }

--- a/packages/cli/tests/passphrase.spec.ts
+++ b/packages/cli/tests/passphrase.spec.ts
@@ -60,6 +60,60 @@ describe('acquirePassphrase', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  describe('beforePrompt session source (ADR 081)', () => {
+    it('consults beforePrompt after env/file and before the no-TTY failure', () => {
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      // Even on a non-TTY runner, a beforePrompt value is used instead of throwing.
+      expect(acquirePassphrase({ beforePrompt: () => 'from-session' })).to.equal('from-session');
+    });
+
+    it('returns the session value verbatim (no re-normalization) and rejects an empty one', () => {
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      // The session holds the exact, already-verified passphrase; a trailing
+      // newline is part of it, not formatting to strip. Re-stripping here would
+      // corrupt the KDF input for a passphrase that legitimately ends in one, so
+      // the value must come back byte-for-byte.
+      expect(acquirePassphrase({ beforePrompt: () => 'sess\n' })).to.equal('sess\n');
+      expect(acquirePassphrase({ beforePrompt: () => 'sess' })).to.equal('sess');
+      expect(() => acquirePassphrase({ beforePrompt: () => '   ' }))
+        .to.throw(KeyStoreError).with.property('type', 'PASSPHRASE_REQUIRED_ERROR');
+    });
+
+    it('lets the env var win over beforePrompt (never consults it)', () => {
+      process.env[ENV_KEYSTORE_PASSPHRASE] = 'env-wins';
+      const beforePrompt = (): string => { throw new Error('beforePrompt must not be consulted when the env var is set'); };
+      expect(acquirePassphrase({ beforePrompt })).to.equal('env-wins');
+    });
+
+    it('lets --passphrase-file win over beforePrompt (never consults it)', () => {
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      const dir = mkdtempSync(join(tmpdir(), 'btcr2-pass-'));
+      const file = join(dir, 'pass.txt');
+      writeFileSync(file, 'file-wins\n');
+      const beforePrompt = (): string => { throw new Error('beforePrompt must not be consulted when a passphrase file is set'); };
+      try {
+        expect(acquirePassphrase({ passphraseFile: file, beforePrompt })).to.equal('file-wins');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not consult beforePrompt under forcePrompt', function () {
+      if (process.stdin.isTTY) return this.skip(); // forcePrompt would otherwise prompt
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      const beforePrompt = (): string => { throw new Error('beforePrompt must not be consulted under forcePrompt'); };
+      expect(() => acquirePassphrase({ forcePrompt: true, beforePrompt }))
+        .to.throw(KeyStoreError).with.property('type', 'PASSPHRASE_REQUIRED_ERROR');
+    });
+
+    it('falls through to the no-TTY failure when beforePrompt yields nothing', function () {
+      if (process.stdin.isTTY) return this.skip();
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      expect(() => acquirePassphrase({ beforePrompt: () => undefined }))
+        .to.throw(KeyStoreError).with.property('type', 'PASSPHRASE_REQUIRED_ERROR');
+    });
+  });
 });
 
 describe('dropLastUtf8Char (backspace over a hidden entry)', () => {

--- a/packages/cli/tests/session.spec.ts
+++ b/packages/cli/tests/session.spec.ts
@@ -1,0 +1,346 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { keystoreApiFactory, type ConnectionOverrides } from '../src/config.js';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import {
+  changeKeystorePassphrase,
+  FileKeyStore,
+  initKeystore,
+  keystoreVerifierId,
+  verifyKeystorePassphrase,
+} from '../src/keystore/file-key-store.js';
+import { ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
+import {
+  clearSession,
+  DEFAULT_SESSION_TTL_MS,
+  MAX_SESSION_TTL_MS,
+  parseTtlToMs,
+  readLiveSessionPassphrase,
+  readSessionStatus,
+  SESSION_VERSION,
+  writeSession,
+  type SessionFile,
+} from '../src/keystore/session.js';
+import { expect } from './helpers.js';
+
+/** Low-cost argon2id so keystore-backed tests do not pay the production cost. */
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+const SECRET = new Uint8Array(32).fill(7);
+const PUBLIC = new Uint8Array(33).fill(2);
+const ID = 'urn:kms:secp256k1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+describe('session unlock agent (ADR 081)', () => {
+  let dir: string;
+  let home: string;
+  let keystorePath: string;
+  let sessionPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-session-'));
+    home = dir;
+    keystorePath = join(home, 'keystore.json');
+    sessionPath = join(home, 'session.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Establishes a FAST encrypted keystore holding one sealed key under `pw`. */
+  function establishKeystore(pw = 'pw'): void {
+    new FileKeyStore({ path: keystorePath, argonParams: FAST, getPassphrase: () => pw })
+      .set(ID, { publicKey: PUBLIC, secretKey: SECRET });
+  }
+
+  /** Writes a raw session object at 0600 (bypassing writeSession) for edge cases. */
+  function writeRawSession(obj: Partial<SessionFile>): void {
+    writeFileSync(sessionPath, JSON.stringify(obj));
+    chmodSync(sessionPath, 0o600);
+  }
+
+  describe('parseTtlToMs', () => {
+    it('parses bare seconds and s/m/h suffixes', () => {
+      expect(parseTtlToMs('3600')).to.equal(3_600_000);
+      expect(parseTtlToMs('10s')).to.equal(10_000);
+      expect(parseTtlToMs('45m')).to.equal(2_700_000);
+      expect(parseTtlToMs('2h')).to.equal(7_200_000);
+      expect(parseTtlToMs('0')).to.equal(0);
+    });
+
+    it('returns undefined for malformed input', () => {
+      for (const bad of [ 'abc', '', '-5', '1.5', '10x', '10 m', 'm10' ]) {
+        expect(parseTtlToMs(bad), bad).to.equal(undefined);
+      }
+    });
+
+    it('exposes sane default and cap constants', () => {
+      expect(DEFAULT_SESSION_TTL_MS).to.equal(60 * 60 * 1000);
+      expect(MAX_SESSION_TTL_MS).to.equal(24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('write / read round trip', () => {
+    it('caches and returns the passphrase for the bound keystore', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      const written = writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      expect(written.v).to.equal(SESSION_VERSION);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal('pw');
+    });
+
+    it('writes the file 0600 and never stores the passphrase in the clear', () => {
+      if (process.platform === 'win32') return; // POSIX perms only
+      establishKeystore();
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'hunter2', ttlMs: 60_000 });
+      const raw = readFileSync(sessionPath, 'utf-8');
+      expect(raw).to.not.include('hunter2'); // base64url-encoded, not plaintext-searchable
+      expect(chmodMode(sessionPath)).to.equal(0o600);
+    });
+
+    it('round-trips a passphrase verbatim, including a trailing newline and multibyte characters', () => {
+      // The cache must reproduce the passphrase byte-for-byte: it is the KDF input.
+      // A trailing newline is significant (not formatting to strip) and non-ASCII
+      // characters must survive the utf8/base64url encode-decode.
+      for (const pw of [ 'pw\n', 'päss-🔑', 'trailing ' ]) {
+        establishKeystore(pw);
+        const vid = keystoreVerifierId(keystorePath);
+        writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: pw, ttlMs: 60_000 });
+        expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(pw);
+        expect(verifyKeystorePassphrase(keystorePath, pw)).to.equal(true);
+        clearSession(sessionPath);
+        rmSync(keystorePath, { force: true }); // re-establish under the next passphrase
+      }
+    });
+  });
+
+  describe('binding and staleness', () => {
+    it('ignores (but does not prune) a session bound to a different keystore', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      const otherKeystore = join(home, 'other-keystore.json');
+      expect(readLiveSessionPassphrase(sessionPath, otherKeystore, keystoreVerifierId(otherKeystore))).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(true); // a live foreign session is left in place
+    });
+
+    it('prunes a session whose keystore verifier rotated (change-passphrase)', () => {
+      establishKeystore();
+      const vidBefore = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vidBefore!, passphrase: 'pw', ttlMs: 60_000 });
+      changeKeystorePassphrase(keystorePath, 'pw', 'new-pw', FAST);
+      const vidAfter = keystoreVerifierId(keystorePath);
+      expect(vidAfter).to.not.equal(vidBefore);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vidAfter)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(false); // stale-for-this-keystore is pruned
+    });
+
+    it('prunes an expired session and reports it inactive', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      const now = Date.now();
+      writeRawSession({ v: SESSION_VERSION, keystore: keystorePath, verifierId: vid!, passphrase: 'cGE', allowMainnet: false, createdAt: now - 10_000, expiresAt: now - 1, ttlSeconds: 10 });
+      expect(readSessionStatus(sessionPath, keystorePath, vid).active).to.equal(false);
+      expect(existsSync(sessionPath)).to.equal(true); // status does not prune
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(false); // consume prunes
+    });
+
+    it('refuses a future-dated session (copied file / backward clock)', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      const now = Date.now();
+      writeRawSession({ v: SESSION_VERSION, keystore: keystorePath, verifierId: vid!, passphrase: 'cGE', allowMainnet: false, createdAt: now + 60_000, expiresAt: now + 120_000, ttlSeconds: 60 });
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(false);
+    });
+
+    it('refuses an unknown session version and a malformed shape', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeRawSession({ v: 2 as never, keystore: keystorePath, verifierId: vid!, passphrase: 'cGE', allowMainnet: false, createdAt: 1, expiresAt: Date.now() + 60_000, ttlSeconds: 60 });
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+      writeFileSync(sessionPath, 'not json {');
+      chmodSync(sessionPath, 0o600);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+    });
+
+    it('treats a session with a missing or non-boolean allowMainnet as malformed', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      const base = { v: SESSION_VERSION, keystore: keystorePath, verifierId: vid!, passphrase: 'cGE', createdAt: 1, expiresAt: Date.now() + 60_000, ttlSeconds: 60 };
+      writeRawSession(base); // allowMainnet omitted
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(false); // malformed is pruned
+      writeRawSession({ ...base, allowMainnet: 'yes' as never });
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+    });
+  });
+
+  describe('mainnet consumption gate', () => {
+    it('withholds a non-mainnet-allowed session from a mainnet operation without pruning it', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 }); // allowMainnet defaults false
+      // A mainnet operation must not consume it, but it stays valid for others.
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid, true)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(true);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid, false)).to.equal('pw');
+    });
+
+    it('serves a mainnet-allowed session to a mainnet operation', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000, allowMainnet: true });
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid, true)).to.equal('pw');
+    });
+  });
+
+  describe('status', () => {
+    it('reports a live session with a remaining lifetime', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      const status = readSessionStatus(sessionPath, keystorePath, vid);
+      expect(status.active).to.equal(true);
+      expect(status.secondsRemaining).to.be.within(1, 60);
+      expect(JSON.stringify(status)).to.not.include('pw'); // never emits the passphrase
+    });
+
+    it('reports inactive when there is no session', () => {
+      establishKeystore();
+      expect(readSessionStatus(sessionPath, keystorePath, keystoreVerifierId(keystorePath)).active).to.equal(false);
+    });
+
+    it('reflects the mainnet allowance of a live session', () => {
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      expect(readSessionStatus(sessionPath, keystorePath, vid).allowMainnet).to.equal(false);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000, allowMainnet: true });
+      expect(readSessionStatus(sessionPath, keystorePath, vid).allowMainnet).to.equal(true);
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes the session and reports whether one existed', () => {
+      establishKeystore();
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'pw', ttlMs: 60_000 });
+      expect(clearSession(sessionPath)).to.equal(true);
+      expect(existsSync(sessionPath)).to.equal(false);
+      expect(clearSession(sessionPath)).to.equal(false); // idempotent
+    });
+
+    it('sweeps crash-orphaned temp files that would hold a plaintext passphrase', () => {
+      const orphan = join(home, '.session.json.999.0.tmp');
+      writeFileSync(orphan, '{"passphrase":"leak"}');
+      clearSession(sessionPath);
+      expect(existsSync(orphan)).to.equal(false);
+    });
+  });
+
+  describe('POSIX hardening of the plaintext file', () => {
+    it('refuses a symlinked session path (O_NOFOLLOW)', function () {
+      if (process.platform === 'win32') return this.skip();
+      establishKeystore();
+      const real = join(home, 'real-session.json');
+      writeSession(real, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'pw', ttlMs: 60_000 });
+      symlinkSync(real, sessionPath);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, keystoreVerifierId(keystorePath))).to.equal(undefined);
+    });
+
+    it('ignores and deletes a group/other-readable session file', function () {
+      if (process.platform === 'win32') return this.skip();
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      chmodSync(sessionPath, 0o644);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
+      expect(existsSync(sessionPath)).to.equal(false); // a loose-perm plaintext file is removed
+    });
+  });
+
+  describe('keystore helpers', () => {
+    it('keystoreVerifierId is stable and changes on rotation; undefined for dev/absent', () => {
+      expect(keystoreVerifierId(keystorePath)).to.equal(undefined); // absent
+      establishKeystore();
+      const a = keystoreVerifierId(keystorePath);
+      expect(a).to.be.a('string');
+      expect(keystoreVerifierId(keystorePath)).to.equal(a); // stable across reads
+      const devPath = join(home, 'dev.json');
+      initKeystore(devPath, { protection: 'none', getPassphrase: () => 'x' });
+      expect(keystoreVerifierId(devPath)).to.equal(undefined); // dev has no verifier
+    });
+
+    it('verifyKeystorePassphrase accepts the right passphrase and rejects others', () => {
+      establishKeystore();
+      expect(verifyKeystorePassphrase(keystorePath, 'pw')).to.equal(true);
+      expect(verifyKeystorePassphrase(keystorePath, 'wrong')).to.equal(false);
+      expect(verifyKeystorePassphrase(join(home, 'missing.json'), 'pw')).to.equal(false);
+    });
+
+    it('the verifier id (and a live session) survives a key-adding re-flush', () => {
+      // A second key re-flushes the keystore file. The verifier is preserved, so its
+      // fingerprint must not change and a session bound to it must stay live: this is
+      // what keeps `unlock` -> `key generate` -> ... prompt-free across commands.
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      new FileKeyStore({ path: keystorePath, argonParams: FAST, getPassphrase: () => 'pw' })
+        .set('urn:kms:secp256k1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', { publicKey: PUBLIC, secretKey: SECRET });
+      expect(keystoreVerifierId(keystorePath)).to.equal(vid);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, keystoreVerifierId(keystorePath))).to.equal('pw');
+    });
+  });
+
+  describe('getPassphrase wiring (keystoreApiFactory)', () => {
+    const saved: Record<string, string | undefined> = {};
+    const keys = [ 'BTCR2_HOME', ENV_KEYSTORE_PASSPHRASE ];
+
+    beforeEach(() => { for (const k of keys) { saved[k] = process.env[k]; delete process.env[k]; } });
+
+    afterEach(() => { for (const k of keys) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+    const overrides = (): ConnectionOverrides => ({ home });
+
+    it('a live session opens a sealed key with no env var, file, or prompt', function () {
+      if (process.stdin.isTTY) return this.skip(); // relies on a non-interactive test runner
+      establishKeystore();
+      // Without a session, opening must fail (no env/file, non-TTY).
+      expect(() => keystoreApiFactory(undefined, overrides()).kms.export(ID)).to.throw(/passphrase/i);
+      // With a session, the same open succeeds and yields the secret.
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'pw', ttlMs: 60_000 });
+      expect(keystoreApiFactory(undefined, overrides()).kms.export(ID).secretKey.bytes).to.deep.equal(SECRET);
+    });
+
+    it('the env var wins over a session cached with a wrong passphrase', () => {
+      establishKeystore();
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'wrong', ttlMs: 60_000 });
+      process.env[ENV_KEYSTORE_PASSPHRASE] = 'pw';
+      expect(keystoreApiFactory(undefined, overrides()).kms.export(ID).secretKey.bytes).to.deep.equal(SECRET);
+    });
+
+    it('a non-mainnet session is withheld from a bitcoin operation but still serves other networks', function () {
+      if (process.stdin.isTTY) return this.skip(); // relies on a non-interactive test runner
+      establishKeystore();
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'pw', ttlMs: 60_000 }); // allowMainnet false
+      // A bitcoin-network factory derives isMainnetOperation and must not consume it.
+      expect(() => keystoreApiFactory('bitcoin', overrides()).kms.export(ID)).to.throw(/passphrase/i);
+      // The refused session is left in place and still opens a signet operation.
+      expect(existsSync(sessionPath)).to.equal(true);
+      expect(keystoreApiFactory('signet', overrides()).kms.export(ID).secretKey.bytes).to.deep.equal(SECRET);
+    });
+
+    it('a mainnet-allowed session opens a bitcoin operation prompt-free', function () {
+      if (process.stdin.isTTY) return this.skip();
+      establishKeystore();
+      writeSession(sessionPath, { keystorePath, verifierId: keystoreVerifierId(keystorePath)!, passphrase: 'pw', ttlMs: 60_000, allowMainnet: true });
+      expect(keystoreApiFactory('bitcoin', overrides()).kms.export(ID).secretKey.bytes).to.deep.equal(SECRET);
+    });
+  });
+});
+
+/** POSIX file mode bits, for asserting 0600. */
+function chmodMode(path: string): number {
+  return statSync(path).mode & 0o777;
+}

--- a/packages/cli/tests/unlock-commands.spec.ts
+++ b/packages/cli/tests/unlock-commands.spec.ts
@@ -1,0 +1,269 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DidBtcr2Cli } from '../src/cli.js';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import { FileKeyStore, initKeystore } from '../src/keystore/file-key-store.js';
+import { ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
+import { ENV_KEYSTORE_TTL } from '../src/keystore/session.js';
+import { createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
+
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+const SECRET = new Uint8Array(32).fill(7);
+const SECRET_HEX = '07'.repeat(32);
+const PUBLIC = new Uint8Array(33).fill(2);
+const KEY_ID = 'urn:kms:secp256k1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const ENV_KEYS = [ 'BTCR2_HOME', ENV_KEYSTORE_PASSPHRASE, ENV_KEYSTORE_TTL ];
+
+describe('keystore unlock / lock / status (ADR 081)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let dir: string;
+  let home: string;
+  let passFile: string;
+  let out: string[];
+  let err: string[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-unlock-'));
+    home = join(dir, 'home');
+    passFile = join(dir, 'pass.txt');
+    writeFileSync(passFile, 'pw\n');
+    out = [];
+    err = [];
+    console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };
+    console.error = (m?: unknown) => { if (m !== undefined) err.push(String(m)); };
+    process.stderr.write = ((chunk: unknown): boolean => { err.push(String(chunk)); return true; }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = 0;
+    for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function run(...args: string[]): Promise<void> {
+    await new DidBtcr2Cli(createTestApiFactory()).run(['node', 'btcr2', '--home', home, ...args]);
+  }
+
+  const keystorePath = (): string => join(home, 'keystore.json');
+  const sessionPath = (): string => join(home, 'session.json');
+
+  /** Establishes a FAST encrypted keystore (empty, established) at the home default. */
+  function establishEncrypted(): void {
+    initKeystore(keystorePath(), { protection: 'passphrase', argonParams: FAST, getPassphrase: () => 'pw' });
+  }
+
+  /** Establishes a FAST encrypted keystore holding one named, sealed key. */
+  function establishWithKey(): void {
+    new FileKeyStore({ path: keystorePath(), argonParams: FAST, getPassphrase: () => 'pw' })
+      .set(KEY_ID, { publicKey: PUBLIC, secretKey: SECRET, tags: { name: 'demo' } });
+  }
+
+  function writeConfig(obj: Record<string, unknown>): void {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'config.json'), JSON.stringify(obj));
+  }
+
+  describe('unlock refusals', () => {
+    it('refuses when no keystore exists', async () => {
+      await run('keystore', 'unlock');
+      expect(err.join(' ')).to.match(/No keystore/i);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('refuses a dev keystore (nothing to cache)', async () => {
+      initKeystore(keystorePath(), { protection: 'none', getPassphrase: () => 'x' });
+      await run('keystore', 'unlock');
+      expect(err.join(' ')).to.match(/dev keystore/i);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('refuses an encrypted keystore with no passphrase established yet', async () => {
+      mkdirSync(home, { recursive: true });
+      writeFileSync(keystorePath(), JSON.stringify({ v: 1, protection: 'passphrase', keys: {} }));
+      await run('keystore', 'unlock');
+      expect(err.join(' ')).to.match(/no passphrase established/i);
+    });
+
+    it('rejects a wrong passphrase and writes no session', async () => {
+      establishEncrypted();
+      const wrongFile = join(dir, 'wrong.txt');
+      writeFileSync(wrongFile, 'not-the-pass');
+      await run('--passphrase-file', wrongFile, 'keystore', 'unlock');
+      expect(err.join(' ')).to.match(/Incorrect passphrase/i);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+  });
+
+  describe('mainnet gate', () => {
+    it('refuses to unlock when the active network is bitcoin, before acquiring the passphrase', async () => {
+      establishEncrypted();
+      writeConfig({ schemaVersion: 1, defaults: { network: 'bitcoin' } });
+      // No --passphrase-file: the gate must fire before any passphrase is acquired,
+      // so the error is the mainnet refusal, not "no passphrase available".
+      await run('keystore', 'unlock');
+      expect(err.join(' ')).to.match(/mainnet/i);
+      expect(err.join(' ')).to.not.match(/no passphrase available/i);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('allows a mainnet unlock with --allow-mainnet and records the allowance', async () => {
+      establishEncrypted();
+      writeConfig({ schemaVersion: 1, defaults: { network: 'bitcoin' } });
+      await run('--passphrase-file', passFile, 'keystore', 'unlock', '--allow-mainnet');
+      expect(err.join(' ')).to.not.match(/mainnet/i);
+      expect(existsSync(sessionPath())).to.equal(true);
+      out = [];
+      await run('-o', 'json', 'keystore', 'status');
+      expect(JSON.parse(out.join('\n')).data.session.allowMainnet).to.equal(true);
+    });
+
+    it('allows unlock on a non-mainnet default without a flag and records no allowance', async () => {
+      establishEncrypted();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      expect(existsSync(sessionPath())).to.equal(true);
+      out = [];
+      await run('-o', 'json', 'keystore', 'status');
+      expect(JSON.parse(out.join('\n')).data.session.allowMainnet).to.equal(false);
+    });
+  });
+
+  describe('--ttl validation', () => {
+    beforeEach(() => establishEncrypted());
+
+    it('rejects a zero, malformed, or over-cap ttl before touching the passphrase', async () => {
+      // No --passphrase-file: the ttl is validated before any passphrase is
+      // acquired, so a bad ttl errors on the ttl, not on a missing passphrase. A
+      // reordering that acquired the passphrase first would surface "no passphrase
+      // available" here and fail the /Invalid --ttl/ match.
+      await run('keystore', 'unlock', '--ttl', '0');
+      expect(err.join(' ')).to.match(/Invalid --ttl/i);
+      expect(err.join(' ')).to.not.match(/no passphrase available/i);
+      err = [];
+      await run('keystore', 'unlock', '--ttl', 'abc');
+      expect(err.join(' ')).to.match(/Invalid --ttl/i);
+      err = [];
+      await run('keystore', 'unlock', '--ttl', '25h');
+      expect(err.join(' ')).to.match(/exceeds the 24h maximum/i);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('reads the ttl from BTCR2_KEYSTORE_TTL and blames the env var, not --ttl, on a bad value', async () => {
+      process.env[ENV_KEYSTORE_TTL] = '25h';
+      await run('keystore', 'unlock');
+      expect(err.join(' ')).to.match(/\$BTCR2_KEYSTORE_TTL "25h" exceeds/);
+      expect(err.join(' ')).to.not.match(/--ttl/);
+    });
+
+    it('honors a valid --ttl and the default of one hour', async () => {
+      await run('-o', 'json', '--passphrase-file', passFile, 'keystore', 'unlock', '--ttl', '30m');
+      expect(JSON.parse(out.join('\n')).data.ttlSeconds).to.equal(1800);
+      await run('keystore', 'lock');
+      out = [];
+      await run('-o', 'json', '--passphrase-file', passFile, 'keystore', 'unlock');
+      expect(JSON.parse(out.join('\n')).data.ttlSeconds).to.equal(3600);
+    });
+  });
+
+  describe('unlock success, status, and output redaction', () => {
+    beforeEach(() => establishEncrypted());
+
+    it('writes a session and status reports it active, never printing the passphrase', async () => {
+      await run('-o', 'json', '--passphrase-file', passFile, 'keystore', 'unlock');
+      const unlock = JSON.parse(out.join('\n'));
+      expect(unlock.action).to.equal('keystore-unlock');
+      expect(unlock.data.keystore).to.equal(keystorePath());
+      expect(unlock.data).to.not.have.property('passphrase');
+      expect(existsSync(sessionPath())).to.equal(true);
+
+      out = [];
+      await run('-o', 'json', 'keystore', 'status');
+      const status = JSON.parse(out.join('\n')).data;
+      expect(status.session.active).to.equal(true);
+      expect(status.session.secondsRemaining).to.be.a('number');
+
+      // The passphrase must not appear anywhere in either command's output.
+      expect(`${out.join(' ')} ${err.join(' ')}`).to.not.match(/\bpw\b/);
+    });
+
+    it('status reports the session inactive after lock', async () => {
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      await run('keystore', 'lock');
+      out = [];
+      await run('-o', 'json', 'keystore', 'status');
+      expect(JSON.parse(out.join('\n')).data.session.active).to.equal(false);
+    });
+  });
+
+  describe('lock', () => {
+    it('clears a session, is idempotent, and reports whether one existed', async () => {
+      establishEncrypted();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      out = [];
+      await run('-o', 'json', 'keystore', 'lock');
+      expect(JSON.parse(out.join('\n')).data.cleared).to.equal(true);
+      expect(existsSync(sessionPath())).to.equal(false);
+      out = [];
+      await run('-o', 'json', 'keystore', 'lock');
+      expect(JSON.parse(out.join('\n')).data.cleared).to.equal(false);
+    });
+
+    it('works under a malformed config (home-only resolution)', async () => {
+      writeConfig({} as never);
+      writeFileSync(join(home, 'config.json'), '{ not valid json ');
+      await run('-o', 'json', 'keystore', 'lock');
+      expect(err.join(' ')).to.equal('');
+      expect(JSON.parse(out.join('\n')).data.cleared).to.equal(false);
+    });
+  });
+
+  describe('establishment invalidates a stale session', () => {
+    it('btcr2 init clears a pre-existing session when it establishes a keystore', async function () {
+      this.timeout(30_000); // real init establishes at production argon2id cost
+      establishEncrypted();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      expect(existsSync(sessionPath())).to.equal(true);
+      // init never overwrites an existing keystore, so remove it first to force a
+      // fresh establishment. The stale session (holding the old passphrase in
+      // plaintext) must be cleared, matching keystore init / change-passphrase.
+      rmSync(keystorePath());
+      await run('--passphrase-file', passFile, 'init');
+      expect(existsSync(keystorePath())).to.equal(true);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('btcr2 init leaves a session intact when the keystore already exists (no re-establishment)', async () => {
+      establishEncrypted();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      // The keystore already exists, so init is a no-op for it; a valid session
+      // for that same keystore must survive.
+      await run('--passphrase-file', passFile, 'init');
+      expect(existsSync(sessionPath())).to.equal(true);
+    });
+  });
+
+  describe('end to end: unlock enables prompt-free key access, lock re-locks', () => {
+    it('exports a sealed key without a prompt while unlocked, then fails once locked', async function () {
+      if (process.stdin.isTTY) return this.skip(); // relies on a non-interactive runner
+      establishWithKey();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+
+      // No passphrase source on this command: the session must supply it.
+      const secretOut = join(dir, 'secret1.hex');
+      await run('key', 'export', 'demo', '--secret', '--out', secretOut);
+      expect(readFileSync(secretOut, 'utf-8').trim()).to.equal(SECRET_HEX);
+
+      await run('keystore', 'lock');
+      err = [];
+      const secretOut2 = join(dir, 'secret2.hex');
+      await run('key', 'export', 'demo', '--secret', '--out', secretOut2);
+      expect(err.join(' ')).to.match(/passphrase/i);
+      expect(existsSync(secretOut2)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
* docs(adr): 081 session unlock agent
* feat(cli): keystore unlock/lock; TTL passphrase cache; mainnet gate
* test(cli): session state machine, unlock/lock, passphrase, mainnet gate
* chore(release): bump cli 0.17.0