### PR TITLE
add quickstart, per-network presets, and faucet/explorer link hints

### DIFF
--- a/docs/adr/082-network-presets.md
+++ b/docs/adr/082-network-presets.md
@@ -1,0 +1,85 @@
+---
+title: "ADR 082: Per-Network Presets for Human-Facing Faucet and Explorer Links"
+---
+
+# ADR 082: Per-Network Presets for Human-Facing Faucet and Explorer Links
+
+**Status:** Accepted
+
+**Date:** 2026-07-14
+
+**Branch / PR:** `feat/cli-mutinynet-quickstart`
+
+**References:** [ADR 053](053-bitcoin-defaults-in-sdk.md), [ADR 073](073-cas-publication-is-opt-in.md), [ADR 075](075-cli-config-validation-and-introspection.md), [ADR 078](078-wire-dead-config-surface.md), [ADR 081](081-cli-keystore-session-unlock.md), [ADR 083](083-cli-quickstart.md)
+
+## Context
+
+A network name already resolves to concrete Bitcoin endpoints. `DEFAULT_BITCOIN_NETWORK_CONFIG` (`packages/api/src/bitcoin.ts`) maps each of the six supported networks to `{ rpc, rest.host }`; mutinynet is `{ rpc: undefined, rest: { host: 'https://mutinynet.com/api' } }`. The CLI layers flags/env/profile on top in `resolveConnectionConfig` (`packages/cli/src/config.ts`). That machinery is settled and is **not** in scope here: this ADR does not touch endpoint resolution, address encoding (`getNetwork`), the CAS opt-in policy (ADR 073), or re-add mutinynet as a network.
+
+The gap is the *human-facing* metadata a demo needs but the tool never emits. Two URLs a testnet operator uses on every run exist as concrete data, but only in a non-runtime dev helper and in prose:
+
+- `explorerUrl()` and `faucetHint()` in `packages/api/lib/_e2e-helpers.ts` (underscore-prefixed, under `lib/`, not exported from `packages/api/src`) already encode, per network, the mutinynet faucet (`https://faucet.mutinynet.com/`), the explorer base (`https://mutinynet.com`, used as `/tx/<txid>` and `/address/<addr>`), and a block-time hint. A grep confirms zero references to `faucet`/`explorer` anywhere in `api/src`, `cli/src`, or `bitcoin/src`.
+- `packages/cli/DEMO.md` hardcodes the same faucet and explorer tx/address links as prose, because the CLI cannot print them.
+
+So `create` prints only the DID; `update`/`deactivate` return `.data.txid` but no link. The workshop instructs the human to hand-copy URLs the tool already knows internally, and to extract the beacon address with a hand-written `jq` filter. The explorer base is genuinely *not* derivable from the REST host (`mutinynet.com` vs `mutinynet.com/api`; `mempool.space/signet` vs `mempool.space/signet/api`), so stripping `/api` is not a reliable shortcut: the explorer base must be its own datum.
+
+## Decision
+
+Add a **per-network preset**: a small, exported, per-network map of ancillary human-facing metadata that sits *beside* the endpoint config, plus pure URL-builder helpers and a handful of text-mode CLI hints that consume it. Presets carry links and hints, never connection behavior.
+
+### Where presets live: the `api` package, as a sibling map
+
+Presets live in `@did-btcr2/api` (new `packages/api/src/presets.ts`, re-exported from the api index) as a **new** exported constant `NETWORK_PRESETS` keyed by `NetworkName`. This mirrors ADR 053's rationale for placing `DEFAULT_BITCOIN_NETWORK_CONFIG` and `DEFAULT_CAS_GATEWAY` in the api facade rather than the sans-I/O transport: concrete third-party service data is a convenience default the facade owns, not something the pure `method`/`bitcoin` layers should carry. Keeping it in api gives `lib/_e2e-helpers.ts` a real exported source to consume, so its private per-network copies collapse to one table shared by the CLI and the e2e scripts.
+
+Presets are a **separate** constant, not new keys on `DEFAULT_BITCOIN_NETWORK_CONFIG`. That object is `as const` and consumed by `resolveConnectionOptions`, which spreads `defaults.rest`/`defaults.rpc` into transport config; adding faucet/explorer keys there would leak presentation data into the transport and muddy its single responsibility. A sibling map keeps each concern independent while sharing the `NetworkName` key.
+
+### Data shape (minimal)
+
+```ts
+export interface NetworkPreset {
+  /** Faucet page URL for funding testnet beacon addresses. Absent for regtest/mainnet. */
+  faucetUrl?       : string;
+  /** Block-explorer base. The CLI appends `/tx/<txid>` and `/address/<addr>`. Absent for regtest. */
+  explorerBaseUrl? : string;
+  /** Human hint for confirmation cadence, e.g. '~30 seconds' (mutinynet). */
+  blockTimeHint?   : string;
+}
+
+export const NETWORK_PRESETS: Record<NetworkName, NetworkPreset>;
+
+// Pure helpers (undefined when the network has no explorer/faucet):
+export function explorerTxUrl(network: NetworkName, txid: string): string | undefined;
+export function explorerAddressUrl(network: NetworkName, address: string): string | undefined;
+export function faucetUrl(network: NetworkName): string | undefined;
+```
+
+Values, lifted from `_e2e-helpers.ts`: mutinynet `{ faucetUrl: 'https://faucet.mutinynet.com/', explorerBaseUrl: 'https://mutinynet.com', blockTimeHint: '~30 seconds' }`; signet, testnet3, testnet4 use their mempool.space explorer bases and existing faucet URLs; regtest `{}` (no public faucet/explorer); bitcoin `{ explorerBaseUrl: 'https://mempool.space' }` with **no** faucet. The testnet `(or another X faucet)` prose is dropped so a preset holds a clean, clickable URL.
+
+### What is deliberately cut
+
+The first design carried more surface; the adversarial review trimmed it to what the demo actually uses.
+
+- **No per-network CAS gateway.** mutinynet has no dedicated CAS gateway, CAS is opt-in (ADR 073), and the single global `DEFAULT_CAS_GATEWAY` already owns this. A reserved-but-unset field is dead surface (ADR 078); adding an optional field later is non-breaking, so reserving it now buys nothing.
+- **No `profiles.<name>.explorer`/`faucet` override.** There is no current demand, it would require editing `config-schema.ts`, the `config set` validation, and the `ConfigFile` type, and a scalar profile field is network-blind (a `bitcoin` profile's explorer would leak onto a mutinynet tx link). Deferred; it is additive later. The values are network-scoped constants, not per-invocation endpoints, so there are also **no** new CLI flags or env vars (a flag surface would be the dead weight ADR 078 warns against).
+- **No `config effective` preset section and no `config doctor` probe.** Adding a `preset` block to `EffectiveConfig` changes the `config effective` JSON shape for a question the demo never asks. Faucet/explorer are human web pages, not health-checkable API endpoints; probing them would add noise and false negatives.
+
+### Which commands consume presets
+
+Preset-derived links are **stderr hints in text mode**, suppressed under `--quiet` and `--output json`, following the existing convention (`create.ts` already prints a stderr provenance note only when `g.output !== 'json'`; ADR 081 keeps hints off machine output). Machine (JSON) output is unchanged, so no JSON consumer breaks and the api `DidUpdateResult` type is not polluted with presentation data.
+
+- **`create` (KEY / `-t k`), only when `faucetUrl(network)` is defined** (i.e. testnets; nothing new prints on regtest/mainnet/external, which also keeps mainnet from ever showing a fund-me affordance): derive the initial P2WPKH beacon address offline via `BeaconUtils.createBeaconService(did, 'p2wpkh', 'SingletonBeacon')` (DID-string only; it decodes the DID and calls `getNetwork` internally, so the printed address is the same `#initialP2WPKH` service the resolver produces, not a divergent re-derivation), then print a stderr block: the beacon address, `Faucet: <faucetUrl>`, `Explorer: <explorerAddressUrl(network, beaconAddr)>`. All three KEY input modes have the pubkey (generated, stored, or raw `--bytes`); EXTERNAL (`-t x`) has none and prints no beacon hint.
+- **`update` / `deactivate`:** print `Watch: <explorerTxUrl(deriveNetwork(did), data.txid)>` on stderr when `explorerBaseUrl` is defined. No SDK/api change.
+
+The choice of `BeaconUtils.createBeaconService` (over `generateBeaconServices`) is deliberate: the latter takes a `BTCNetwork` object built by `getNetwork` from `@did-btcr2/bitcoin`, which is not a CLI dependency; the former takes only the DID string.
+
+### Dedupe
+
+Once `NETWORK_PRESETS` exists, `explorerUrl()`/`faucetHint()`/`blockTimeHint()` in `_e2e-helpers.ts` read from it, so the faucet/explorer/block-time data has exactly one home shared by the CLI, the e2e scripts, and (via display) the DEMO.
+
+## Consequences
+
+**Positive.** The demo's manual URL construction collapses to printed output: after `create`, the operator sees the fundable beacon address next to its faucet and explorer links; after `update`, a watch link for the txid. The faucet/explorer table has a single source of truth. Machine output is untouched, so scripts and CI are unaffected. The design reuses the existing hint-gating machinery rather than inventing new plumbing.
+
+**Costs / breaking surface.** The CLI's printed text output is a breaking surface per the release convention, so the new stderr hints ride a cli MINOR bump (see ADR 083, which lands with this). `create` now surfaces a beacon address it did not before (new stderr line in text mode). The new api exports are purely additive, so `@did-btcr2/api` takes a MINOR. Third-party testnet faucet URLs can rot; preset values are best-effort human hints, not health-checked, and a stale one is a cosmetic wrong link, never a functional failure.
+
+**Deferred.** Per-network CAS gateway, profile faucet/explorer overrides, a `config effective` preset section, `resolve` funding-hint output, and a first-class `--beacon` selector to replace the DEMO `jq`. Presets feed ADR 083's `quickstart`, whose next-step block prints the same faucet/explorer hints.

--- a/docs/adr/083-cli-quickstart.md
+++ b/docs/adr/083-cli-quickstart.md
@@ -1,0 +1,105 @@
+---
+title: "ADR 083: A btcr2 quickstart Command that Composes Onboarding into One Step"
+---
+
+# ADR 083: A `btcr2 quickstart` Command that Composes Onboarding into One Step
+
+**Status:** Accepted
+
+**Date:** 2026-07-14
+
+**Branch / PR:** `feat/cli-mutinynet-quickstart`
+
+**References:** [ADR 079](079-cli-state-directory-consolidation.md), [ADR 080](080-keystore-lifecycle-and-dev-keystores.md), [ADR 081](081-cli-keystore-session-unlock.md), [ADR 082](082-network-presets.md)
+
+## Context
+
+Getting from nothing to "ready to create a DID on a testnet" is a 3-4 command sequence the workshop (DEMO.md Part 0) spells out by hand:
+
+```
+btcr2 init
+btcr2 config set defaults.network mutinynet
+btcr2 keystore unlock --ttl 2h        # Path A only
+btcr2 config doctor -n mutinynet
+```
+
+Each command already exists and is settled: `init` scaffolds the home, config, and keystore (ADR 079/080); `keystore unlock` caches the passphrase for the session (ADR 081); `config doctor` probes endpoint reachability; `config set defaults.network` records the network so later commands can drop `-n`. The friction is not any single command but the sequence: four lines the presenter reads out, one of which (`config set defaults.network`) is pure ceremony that both demo paths repeat, and a network name (`mutinynet`) typed three times.
+
+Comparable CLIs converge on a convention: name the scaffold `init` and give the zero-to-running composite its own verb. Folding network selection into the scaffold and printing next-step hints (including funding/explorer links) is standard.
+
+## Decision
+
+Add a top-level **`btcr2 quickstart`** that **composes** the existing primitives into one step, and fold `-n/--network` into `init` as a cheap complement that removes the separate `config set defaults.network` line from both demo paths. `quickstart` reimplements nothing: it calls the factored bodies of `init`, `keystore unlock`, and `config doctor`.
+
+### Naming
+
+`quickstart`, not `init --demo` and not `bootstrap`. `init` stays the plain scaffold. `bootstrap` is **reserved** for a future zero-to-DID superset that also mints a key and creates a DID; keeping `quickstart` short of that preserves the DEMO Part 0 (setup) / Part 1 (own your keys) boundary. `quickstart` mints no key and creates no DID.
+
+### What quickstart does
+
+```
+btcr2 quickstart [-n|--network <net>] [--dev] [--unlock] [--ttl <dur>] [--no-doctor] [--allow-mainnet] [--force]
+```
+
+1. **Scaffold** via the factored `runInit()` (init's own body): create the home, a default config if none exists, and establish the keystore if none exists (encrypted by default, `--dev` for an unencrypted testnet keystore). Idempotent exactly as `init`: existing files are left intact, and `--force` re-scaffolds the regenerable config but **never** overwrites the keystore.
+2. **Record the network.** Default network is **mutinynet** (zero local infra, 30s blocks, a free faucet: the demo target). The `defaults.network` write is idempotent and keyed on the **raw** config value: it writes when `-n` is explicit **or** the raw `defaults.network` is unset, so a defaulted re-run never clobbers a network the operator set earlier. (It must read `file?.defaults?.network` directly, not `resolveDefaultNetwork`, which never returns undefined and would make the write never fire.)
+3. **Optionally cache the session** (`--unlock`, opt-in, default OFF): see below.
+4. **Optionally probe** (`config doctor`, on by default, advisory): see below.
+5. **Print** the result envelope plus text-mode next-step hints, including the ADR 082 faucet/explorer preset lines.
+
+### Session caching is opt-in (`--unlock`)
+
+ADR 081 deliberately separates *establishing* a passphrase from *caching* it: `init` establishes and then `clearSession`s, so a fresh scaffold never leaves a cached passphrase behind. `quickstart` preserves that boundary. Without `--unlock`, `runInit`'s `clearSession` stands and no session is written. With `--unlock`, the merged "set and cache" behavior is the operator's explicit request, documented as a posture consequence (one command both sets the passphrase and caches it, `0600` on disk, for the TTL).
+
+Under `--unlock`:
+
+- **Fresh encrypted keystore:** capture the establish-time confirmed passphrase (via the `initKeystore` `getPassphrase` closure), verify it against the new verifier, and write the session with **no second prompt**. This is the one place `quickstart` reuses the passphrase it already collected; it adds no at-rest exposure beyond the `0600` base64url session file ADR 081 already defines.
+- **Existing encrypted keystore:** first check `readSessionStatus`; if a live matching session already exists, **skip** (idempotent re-run), else acquire the passphrase (env / file / prompt), verify, and write.
+- **`--dev`:** skip unlock entirely (a dev keystore has no passphrase to cache).
+
+`--ttl` reuses the exported `resolveSessionTtl` (default 1h, max 24h, `$BTCR2_KEYSTORE_TTL`) and is ignored under `--dev`.
+
+### Doctor is on by default and advisory
+
+`quickstart` runs `runDoctor` by default and treats it as **advisory**: a failed probe prints a warning but `quickstart` still exits `0`. This is a deliberate divergence from standalone `config doctor` (which exits `1` on a failed probe): a setup command should not "fail" because a public endpoint was briefly slow, and the operator can re-run `config doctor` for an authoritative check. `--no-doctor` skips the probe.
+
+### Mainnet is guarded before any writes
+
+The mainnet posture from ADR 080/081 is preserved and checked **before** any file is written: `-n bitcoin` requires `--allow-mainnet` (`MAINNET_QUICKSTART_REFUSED_ERROR`), and `-n bitcoin --dev` is refused unconditionally (a dev keystore never operates on mainnet). Because `quickstart`'s default network is a testnet, the guard never fires on the demo path. The factored `unlockSession()` takes `{ network, allowMainnet }` **explicitly** rather than re-deriving from config, so ADR 081's mainnet early-refusal is order-independent even though `quickstart` may have just written `defaults.network`.
+
+### `init` gains `-n/--network`
+
+`btcr2 init` gains `-n/--network` with the same write-if-explicit-or-unset rule, and its `{action:'init'}` data envelope gains a `network: NetworkOption` field so `init -n <net> -o json` is machine-verifiable. This removes the `config set defaults.network` line from the non-quickstart path too.
+
+### Output shape
+
+New `CommandResult` variant:
+
+```ts
+{ action: 'quickstart'; data: {
+  home: string; config: string; keystore: string; network: NetworkOption;
+  created: string[]; protection: 'encrypted' | 'dev' | 'absent';
+  unlocked: boolean; session?: { expiresAt: number; ttlSeconds: number };
+  doctor?: DoctorReport;
+} }
+```
+
+Text mode prints the data plus stderr next-step hints (gated on `!g.quiet && g.output !== 'json'`): `btcr2 home ready at <home> on <network>.`; if unlocked, the session expiry; if dev, the plaintext/mainnet-refused warning; `Next: btcr2 key generate --name demo --set-active`; plus the ADR 082 `Faucet:`/`Explorer:` lines when the network has them.
+
+**Non-TTY.** `--dev` is fully non-interactive. An encrypted keystore with an env/file passphrase source establishes (and, under `--unlock`, caches) with no prompt. An encrypted keystore with no passphrase source and no TTY is fatal on a **fresh** keystore (establishment throws), but on an **existing** encrypted keystore the `--unlock` step is a non-fatal **skip** (warn, `unlocked: false`, exit 0).
+
+### Refactors (behavior-preserving)
+
+- Extract `runInit()` from `init.ts`; the `init` command action becomes a thin wrapper.
+- Extract `unlockSession()` from the `keystore unlock` action; both it and `quickstart` call it.
+- Export `resolveSessionTtl` (currently private in `keystore.ts`).
+
+Existing `init` and `keystore` tests stay green.
+
+## Consequences
+
+**Positive.** The demo's Part 0 collapses to one command (`btcr2 quickstart -n mutinynet [--unlock --ttl 2h] [--dev]`), the network is named once, and the tool prints the funding/explorer links the operator previously hand-copied. The `init -n` addition also shortens the non-quickstart path. Nothing is reimplemented, so the existing keystore/session guarantees (ADR 080/081) hold by construction: `quickstart` is exactly the four commands, run in order, with one prompt saved on the happy path.
+
+**Costs / breaking surface.** The CLI printed-output shape is a declared breaking surface that rides a MINOR at `0.x`; this adds a `quickstart` variant and a `network` field to the `init` variant, so `cli` takes a MINOR. `quickstart`'s advisory doctor exit code diverges from `config doctor`'s; this is intentional and documented.
+
+**Deferred.** `bootstrap` (the zero-to-DID superset) is named but not built. `method` and `bitcoin` do not change: no new symbols are added there.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -158,3 +158,5 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 079 | 2026-07-08 | [Consolidate CLI State Under a Single ~/.btcr2 Home Directory](079-cli-state-directory-consolidation.md) |
 | 080 | 2026-07-08 | [Keystore Lifecycle, a Confirmed First Passphrase, and Opt-In Dev Keystores](080-keystore-lifecycle-and-dev-keystores.md) |
 | 081 | 2026-07-14 | [A Session Unlock Agent for the Encrypted Keystore](081-cli-keystore-session-unlock.md) |
+| 082 | 2026-07-14 | [Per-Network Presets for Human-Facing Faucet and Explorer Links](082-network-presets.md) |
+| 083 | 2026-07-14 | [A btcr2 quickstart Command that Composes Onboarding into One Step](083-cli-quickstart.md) |

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @did-btcr2/api
 
+## 0.17.0
+
+### Minor Changes
+
+- Add per-network presets: human-facing faucet and explorer metadata beside the endpoint config (ADR 082).
+
+  - New `NETWORK_PRESETS` map (keyed by `NetworkName`) and the `NetworkPreset` type, carrying an optional `faucetUrl`, `explorerBaseUrl`, and `blockTimeHint` per network. mutinynet, signet, and the testnets get a faucet and explorer; regtest has neither; mainnet has an explorer but no faucet.
+  - New pure helpers `explorerTxUrl(network, txid)`, `explorerAddressUrl(network, address)`, and `faucetUrl(network)`, each returning `undefined` for a network without the corresponding datum.
+  - These are the single source of truth for the faucet/explorer/block-time data previously duplicated privately in the `lib/` e2e scripts, and are consumed by the CLI to print funding and watch links.
+
+  Purely additive: no existing export changes.
+
 ## 0.16.1
 
 ### Patch Changes

--- a/packages/api/lib/_e2e-helpers.ts
+++ b/packages/api/lib/_e2e-helpers.ts
@@ -12,7 +12,7 @@
  *       discovery) goes through Esplora/REST.
  */
 import type { BitcoinConnection } from '@did-btcr2/bitcoin';
-import { BitcoinApi } from '../src/index.js';
+import { BitcoinApi, NETWORK_PRESETS, explorerAddressUrl, faucetUrl } from '../src/index.js';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -98,26 +98,18 @@ async function promptYes(message: string): Promise<void> {
   }
 }
 
-/** Public mempool.space-style explorer host per network (for operator hints). */
+/**
+ * Explorer address URL for operator hints. Reads the shared per-network preset
+ * (ADR 082); falls back to mainnet mempool for any network without an explorer
+ * base (only reached if a caller passes regtest, which the funding paths do not).
+ */
 function explorerUrl(network: E2ENetwork, address: string): string {
-  switch (network) {
-    case 'mutinynet':  return `https://mutinynet.com/address/${address}`;
-    case 'signet':     return `https://mempool.space/signet/address/${address}`;
-    case 'testnet3':   return `https://mempool.space/testnet/address/${address}`;
-    case 'testnet4':   return `https://mempool.space/testnet4/address/${address}`;
-    default:           return `https://mempool.space/address/${address}`;
-  }
+  return explorerAddressUrl(network, address) ?? `https://mempool.space/address/${address}`;
 }
 
-/** Faucet URL hint per public network. */
+/** Faucet URL hint per public network, from the shared preset (ADR 082). */
 function faucetHint(network: E2ENetwork): string | undefined {
-  switch (network) {
-    case 'mutinynet': return 'https://faucet.mutinynet.com/';
-    case 'signet':    return 'https://signetfaucet.com/';
-    case 'testnet3':  return 'https://coinfaucet.eu/en/btc-testnet/ (or another testnet3 faucet)';
-    case 'testnet4':  return 'https://mempool.space/testnet4/faucet (or another testnet4 faucet)';
-    default:          return undefined;
-  }
+  return faucetUrl(network);
 }
 
 /**
@@ -266,12 +258,7 @@ export function persistKey(args: {
   return filepath;
 }
 
+/** Block-time hint per network, from the shared preset (ADR 082). */
 function blockTimeHint(n: E2ENetwork): string {
-  switch (n) {
-    case 'mutinynet': return '~30 seconds';
-    case 'signet':    return '~10 minutes';
-    case 'testnet3':  return '~10 minutes (highly variable)';
-    case 'testnet4':  return '~10 minutes';
-    default:          return 'on-demand';
-  }
+  return NETWORK_PRESETS[n].blockTimeHint ?? 'on-demand';
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ export * from './types.js';
 export * from './helpers.js';
 export * from './bitcoin.js';
 export * from './cas.js';
+export * from './presets.js';
 export * from './key-manager.js';
 export * from './crypto.js';
 export * from './did.js';

--- a/packages/api/src/presets.ts
+++ b/packages/api/src/presets.ts
@@ -1,0 +1,90 @@
+import type { NetworkName } from '@did-btcr2/bitcoin';
+
+/**
+ * Ancillary, human-facing metadata for a Bitcoin network: the URLs a testnet
+ * operator uses on every run (a faucet to fund a beacon address, an explorer to
+ * watch a transaction or address). Presets carry links and hints only, never
+ * connection behavior: the endpoint config a network resolves to lives in
+ * {@link DEFAULT_BITCOIN_NETWORK_CONFIG}, and presets sit beside it so
+ * presentation data never leaks into the transport (ADR 082).
+ *
+ * @public
+ */
+export interface NetworkPreset {
+  /** Faucet page URL for funding testnet beacon addresses. Absent for regtest/mainnet. */
+  faucetUrl?       : string;
+  /** Block-explorer base URL. The helpers append `/tx/<txid>` and `/address/<addr>`. Absent for regtest. */
+  explorerBaseUrl? : string;
+  /** Human hint for confirmation cadence, e.g. `'~30 seconds'` (mutinynet). */
+  blockTimeHint?   : string;
+}
+
+/**
+ * Per-network human-facing presets keyed by {@link NetworkName}. The single
+ * source of truth for faucet/explorer/block-time metadata, shared by the CLI's
+ * text-mode hints and the `lib/` e2e scripts (ADR 082).
+ *
+ * The explorer base is deliberately its own datum, not derived from the REST
+ * host: `mutinynet.com` differs from the `mutinynet.com/api` REST endpoint, and
+ * `mempool.space/signet` from `mempool.space/signet/api`, so stripping `/api`
+ * is not a reliable shortcut. Regtest has no public faucet or explorer; mainnet
+ * has an explorer but intentionally no faucet.
+ *
+ * @public
+ */
+export const NETWORK_PRESETS: Record<NetworkName, NetworkPreset> = {
+  bitcoin : {
+    explorerBaseUrl : 'https://mempool.space',
+    blockTimeHint   : '~10 minutes',
+  },
+  testnet3 : {
+    faucetUrl       : 'https://coinfaucet.eu/en/btc-testnet/',
+    explorerBaseUrl : 'https://mempool.space/testnet',
+    blockTimeHint   : '~10 minutes',
+  },
+  testnet4 : {
+    faucetUrl       : 'https://mempool.space/testnet4/faucet',
+    explorerBaseUrl : 'https://mempool.space/testnet4',
+    blockTimeHint   : '~10 minutes',
+  },
+  signet : {
+    faucetUrl       : 'https://signetfaucet.com/',
+    explorerBaseUrl : 'https://mempool.space/signet',
+    blockTimeHint   : '~10 minutes',
+  },
+  mutinynet : {
+    faucetUrl       : 'https://faucet.mutinynet.com/',
+    explorerBaseUrl : 'https://mutinynet.com',
+    blockTimeHint   : '~30 seconds',
+  },
+  regtest : {},
+};
+
+/**
+ * The block-explorer transaction URL for a network, or `undefined` when the
+ * network has no explorer (regtest). Appends `/tx/<txid>` to the explorer base.
+ * @public
+ */
+export function explorerTxUrl(network: NetworkName, txid: string): string | undefined {
+  const base = NETWORK_PRESETS[network]?.explorerBaseUrl;
+  return base ? `${base}/tx/${txid}` : undefined;
+}
+
+/**
+ * The block-explorer address URL for a network, or `undefined` when the network
+ * has no explorer (regtest). Appends `/address/<address>` to the explorer base.
+ * @public
+ */
+export function explorerAddressUrl(network: NetworkName, address: string): string | undefined {
+  const base = NETWORK_PRESETS[network]?.explorerBaseUrl;
+  return base ? `${base}/address/${address}` : undefined;
+}
+
+/**
+ * The faucet URL for a network, or `undefined` when the network has no public
+ * faucet (regtest, mainnet).
+ * @public
+ */
+export function faucetUrl(network: NetworkName): string | undefined {
+  return NETWORK_PRESETS[network]?.faucetUrl;
+}

--- a/packages/api/tests/presets.spec.ts
+++ b/packages/api/tests/presets.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import type { NetworkName } from '@did-btcr2/bitcoin';
+import { explorerAddressUrl, explorerTxUrl, faucetUrl, NETWORK_PRESETS } from '../src/index.js';
+
+describe('network presets (ADR 082)', () => {
+  const ALL: NetworkName[] = [ 'bitcoin', 'testnet3', 'testnet4', 'signet', 'mutinynet', 'regtest' ];
+
+  it('defines a preset entry for every supported network', () => {
+    for (const n of ALL) expect(NETWORK_PRESETS).to.have.property(n);
+  });
+
+  it('mutinynet carries the demo faucet, explorer, and block-time hint', () => {
+    const p = NETWORK_PRESETS.mutinynet;
+    expect(p.faucetUrl).to.equal('https://faucet.mutinynet.com/');
+    expect(p.explorerBaseUrl).to.equal('https://mutinynet.com');
+    expect(p.blockTimeHint).to.equal('~30 seconds');
+  });
+
+  it('regtest has no public faucet or explorer', () => {
+    expect(NETWORK_PRESETS.regtest.faucetUrl).to.equal(undefined);
+    expect(NETWORK_PRESETS.regtest.explorerBaseUrl).to.equal(undefined);
+  });
+
+  it('mainnet has an explorer but intentionally no faucet', () => {
+    expect(NETWORK_PRESETS.bitcoin.explorerBaseUrl).to.equal('https://mempool.space');
+    expect(NETWORK_PRESETS.bitcoin.faucetUrl).to.equal(undefined);
+  });
+
+  describe('explorerTxUrl', () => {
+    it('appends /tx/<txid> to the explorer base', () => {
+      expect(explorerTxUrl('mutinynet', 'deadbeef')).to.equal('https://mutinynet.com/tx/deadbeef');
+      expect(explorerTxUrl('signet', 'abc')).to.equal('https://mempool.space/signet/tx/abc');
+    });
+
+    it('returns undefined for a network without an explorer', () => {
+      expect(explorerTxUrl('regtest', 'abc')).to.equal(undefined);
+    });
+  });
+
+  describe('explorerAddressUrl', () => {
+    it('appends /address/<addr> to the explorer base', () => {
+      expect(explorerAddressUrl('mutinynet', 'tb1qxyz')).to.equal('https://mutinynet.com/address/tb1qxyz');
+    });
+
+    it('returns undefined for a network without an explorer', () => {
+      expect(explorerAddressUrl('regtest', 'bcrt1q')).to.equal(undefined);
+    });
+  });
+
+  describe('faucetUrl', () => {
+    it('returns the faucet for a testnet', () => {
+      expect(faucetUrl('mutinynet')).to.equal('https://faucet.mutinynet.com/');
+    });
+
+    it('returns undefined for regtest and mainnet', () => {
+      expect(faucetUrl('regtest')).to.equal(undefined);
+      expect(faucetUrl('bitcoin')).to.equal(undefined);
+    });
+  });
+});

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @did-btcr2/cli
 
+## 0.18.0
+
+### Minor Changes
+
+- Add a `quickstart` command, fold the network into `init`, and print faucet/explorer links (ADRs 082, 083).
+
+  - **`btcr2 quickstart`** collapses onboarding into one step: it composes `init` (home + config + keystore), records the network (default **mutinynet**), and optionally caches the session and probes endpoints. Flags: `-n/--network`, `--dev`, `--unlock` (opt-in session caching), `--ttl`, `--no-doctor`, `--allow-mainnet`, `--force`. Session caching stays opt-in so ADR 081's establish-vs-cache separation holds; on a fresh encrypted keystore `--unlock` reuses the establish-time passphrase with no second prompt. The endpoint probe runs by default but is advisory (a failed probe warns and still exits 0). Mainnet is guarded before any writes: `-n bitcoin` requires `--allow-mainnet`, and `-n bitcoin --dev` is refused.
+  - **`btcr2 init` gains `-n/--network`**, recording `defaults.network` so later commands can drop `-n`; its output envelope gains a `network` field. The network write is idempotent and never clobbers a network the operator set earlier.
+  - **Funding and watch links.** `create` on a testnet now prints the initial beacon address next to its faucet and explorer links; `update`/`deactivate` print a `Watch:` explorer link for the broadcast txid. These are text-mode stderr hints only, suppressed under `--quiet` and `--output json`, so machine output is unchanged.
+
+  Breaking output surface: adds a `quickstart` result shape, a `network` field on `init` output, and new stderr hint lines. Machine (JSON) output shape is otherwise unchanged.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.17.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/cli/DEMO.md
+++ b/packages/cli/DEMO.md
@@ -10,7 +10,7 @@ commands reuse shell variables set by earlier ones, so keep the same session ope
 output block is **illustrative** - your keys, DID strings, and Bitcoin addresses will be
 unique to you, but the shape will match.
 
-Targets `@did-btcr2/cli` **v0.17.0**.
+Targets `@did-btcr2/cli` **v0.18.0**.
 
 ---
 
@@ -66,27 +66,28 @@ btcr2 --version
 ```
 
 ```
-btcr2 0.17.0
+btcr2 0.18.0
 ```
 
-### Set up the btcr2 home and keystore
+### Set up in one command
 
-`btcr2 init` is the one command that gets you ready: it creates the btcr2 home
-directory, writes a default config, and establishes the keystore. Pick one of two paths.
+`btcr2 quickstart` gets you ready in a single step: it creates the btcr2 home directory,
+writes a default config, establishes the keystore, records the network (Mutinynet by
+default), and probes the endpoints so you know the network is reachable. Pick one of two
+paths.
 
 **Path A (recommended) - encrypted keystore, authenticate once per session.** This is the
-real product experience and shows off v0.17.0's session unlock agent. `init` prompts for a
-passphrase (twice, to confirm it) so your keys are encrypted at rest:
+real product experience and shows off the session unlock agent. It prompts for a
+passphrase (twice, to confirm it) so your keys are encrypted at rest, then `--unlock`
+caches it for the session:
 
 ```bash
-btcr2 init
-btcr2 config set defaults.network mutinynet
-btcr2 keystore unlock --ttl 2h
+btcr2 quickstart -n mutinynet --unlock --ttl 2h
 ```
 
-`keystore unlock` caches the passphrase for the session (here, 2 hours) so every later
-command in Parts 1 to 4 runs **without re-prompting**. You authenticate once, not on
-every signing step.
+`--unlock` caches the passphrase for the session (here, 2 hours) so every later command in
+Parts 1 to 4 runs **without re-prompting**. You authenticate once, not on every signing
+step. (Omit `--unlock` and you set the passphrase now but keep a per-use prompt.)
 
 **Path B (fastest) - unencrypted dev keystore, no passphrase at all.** For a smooth
 follow-along with zero passphrase typing, use a dev keystore. Keys are stored in
@@ -94,42 +95,39 @@ plaintext, so this is **testnet/regtest/signet/mutinynet only** (the CLI hard-re
 sign or generate a mainnet key with a dev keystore):
 
 ```bash
-btcr2 init --dev
-btcr2 config set defaults.network mutinynet
+btcr2 quickstart -n mutinynet --dev
 ```
 
-Either way, `init` prints where it put everything (text mode shows just the data; on
-Path B the `protection` reads `"dev"`):
+`quickstart` prints where it put everything, whether a session was cached, and the
+endpoint probe result (text mode shows just the data; on Path B the `protection` reads
+`"dev"` and `unlocked` is `false`):
 
 ```json
 {
   "home": "/home/you/.btcr2",
   "config": "/home/you/.btcr2/config.json",
   "keystore": "/home/you/.btcr2/keystore.json",
+  "network": "mutinynet",
   "created": ["config", "keystore"],
-  "protection": "encrypted"
+  "protection": "encrypted",
+  "unlocked": true,
+  "session": { "expiresAt": 1760000000000, "ttlSeconds": 7200 },
+  "doctor": { "checks": [ { "endpoint": "btc-rest", "target": "https://mutinynet.com/api", "ok": true } ] }
 }
 ```
 
-(Add `-o json` to any command, for example `btcr2 -o json init`, to get the full
+(Add `-o json` to any command, for example `btcr2 -o json quickstart`, to get the full
 `{"action": ..., "data": ...}` envelope instead.)
 
-> `init` is idempotent: run it again and it leaves existing files untouched (it never
-> overwrites a keystore, even with `--force`; re-establishing one is the explicit
-> `btcr2 keystore init --force`). Setting `defaults.network mutinynet` lets you drop
-> `-n mutinynet` from every later command.
-
-### Connectivity check
-
-Confirm your machine can reach Mutinynet's public infrastructure before you go further.
-This probes the resolved endpoints without depending on any particular DID's history:
-
-```bash
-btcr2 config doctor -n mutinynet
-```
-
-If it reports the endpoints reachable, you are ready. (You will also see a live resolve
-of your own DID in Part 3.)
+> `quickstart` is idempotent: run it again and it leaves existing files untouched (it never
+> overwrites a keystore, and it will not clobber a network you set earlier). The endpoint
+> probe is **advisory** - if an endpoint is briefly unreachable it warns but still succeeds;
+> re-run `btcr2 config doctor -n mutinynet` any time for an authoritative check. Pass
+> `--no-doctor` to skip the probe. `-n mutinynet` is the default, so you can drop it.
+>
+> Prefer to do it step by step? `btcr2 init -n mutinynet` scaffolds the home and records
+> the network, `btcr2 keystore unlock --ttl 2h` caches the session, and `btcr2 config
+> doctor` probes the endpoints - `quickstart` just runs those in order.
 
 ### See everything the tool can do
 
@@ -141,6 +139,8 @@ btcr2 --help
 Commands:
   init          Set up the btcr2 home: create the directory, a default config,
                 and establish the keystore.
+  quickstart    One-command onboarding: create the home + config + keystore,
+                record the network, and (optionally) cache the session and probe endpoints.
   create        Create an identifier and initial DID document
   resolve|read  Resolve the DID document of the identifier.
   update        Update a did:btcr2 document.
@@ -240,6 +240,21 @@ That string **is** the identifier. It was produced in milliseconds, with no fee.
 `create --signing-key` only reads the **public** key, so it never needs your passphrase,
 session or not. In text mode it prints the DID to stdout and a `Using stored key ...`
 note to stderr, which is why we redirect `2>/dev/null` when capturing `$DID`.)
+
+Because this DID is on a testnet, `create` also prints a **funding hint** to stderr - the
+initial beacon address next to its faucet and explorer links - so you know where to send
+coins before the on-chain update in Part 4. Run it without the `2>/dev/null` redirect to
+see it:
+
+```
+Fund the initial beacon to anchor updates:
+  Beacon:   tb1qme9lfnkgcqcfu2v43k9w0fy0zj43z8gdgp2ank
+  Faucet:   https://faucet.mutinynet.com/
+  Explorer: https://mutinynet.com/address/tb1qme9lfnkgcqcfu2v43k9w0fy0zj43z8gdgp2ank
+```
+
+(These links come from the per-network preset, so they are absent on regtest and mainnet.
+The `Beacon` address is the same `#initialP2WPKH` service you will resolve in Part 4.)
 
 A few things to show off:
 
@@ -361,6 +376,10 @@ BEACON_ADDR=$(btcr2 -o json resolve -i "$DID" \
 echo "Fund this address: $BEACON_ADDR"
 ```
 
+(This is the same `Beacon` address `create` printed in its funding hint back in Part 2 -
+here we pull it programmatically from the resolved document so the rest of the flow can
+reuse `$BEACON_ADDR`.)
+
 Then:
 
 1. Open https://faucet.mutinynet.com, paste `$BEACON_ADDR`, and request ~100,000 sats.
@@ -404,7 +423,8 @@ btcr2 -o json --signing-key demo update \
 transaction whose `OP_RETURN` carries the update hash. The command's `.data` is an
 enriched result (`.data.txid` is the broadcast transaction id, handy for watching the
 signal confirm); `.data.signedUpdate` is the off-chain half you keep, so we extract just
-that into `signed-update.json`.
+that into `signed-update.json`. In text mode `update` also prints a `Watch:` explorer link
+for the txid to stderr, so you can click straight through to the transaction.
 
 > If the beacon is not funded (or the payment has not confirmed), `update` stops before
 > broadcasting with a clear message, for example:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,6 +37,7 @@ npx @did-btcr2/cli resolve -i did:btcr2:k1qq...
 | Command | Alias | Description |
 |---|---|---|
 | `init` | - | Set up the btcr2 home: create the directory, a default config, and establish the keystore |
+| `quickstart` | - | One-command onboarding: `init` + record the network + (optionally) cache the session and probe endpoints |
 | `create` | - | Create an identifier and initial DID document |
 | `resolve` | `read` | Resolve a DID document |
 | `update` | - | Update a DID document (signs via the keystore) |
@@ -65,6 +66,8 @@ Creates an identifier and initial DID document. Two identifier types, selected b
 
 `--signing-key <ref>` (global) selects a stored key for the existing-key mode; it applies only to `-t k`.
 
+On a testnet with a public faucet, text-mode `create` (for a `-t k` identifier) also prints a **funding hint** on stderr: the initial P2WPKH beacon address next to its faucet and explorer links, from the per-network preset. It is suppressed under `--quiet` and `-o json`, and absent on regtest and mainnet.
+
 ### resolve (alias: read)
 
 Required flag: `-i/--identifier`. At most one of `-r` or `-p` may be given.
@@ -92,6 +95,8 @@ Required flags: `-s/--source-document`, `--source-version-id`, `-p/--patches`, `
 | `--fee-rate <satsPerVByte>` | Fee rate in sats/vByte for the beacon transaction (default: `5`). Raise it under congestion so the transaction confirms (also `BTCR2_FEE_RATE`, profile `btc.feeRate`) |
 | `--change-address <address>` | Send transaction change to this address instead of the beacon address, so a DID's announcements are not linked on-chain (profile `btc.changeAddress`) |
 
+On a network with a block explorer, text-mode `update` (and `deactivate`) also prints a `Watch:` link on stderr for the broadcast txid, suppressed under `--quiet` and `-o json`.
+
 ### deactivate (alias: delete)
 
 Permanently deactivates a DID. This is irreversible. Deactivation applies the `{ "op": "add", "path": "/deactivated", "value": true }` patch and routes through the same signed-update path as `update`, so it also signs via the keystore.
@@ -100,22 +105,37 @@ Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verificatio
 
 ### init
 
-`btcr2 init` is the one-command setup: it creates the btcr2 home directory, writes a default config if none exists, and establishes the keystore if none exists. It is idempotent (existing files are left untouched unless `--force`).
+`btcr2 init` is the one-command setup: it creates the btcr2 home directory, writes a default config if none exists, and establishes the keystore if none exists. It is idempotent (existing files are left untouched unless `--force`). For a single command that also records the network and (optionally) caches the session and probes the endpoints, see [`quickstart`](#quickstart).
 
 | Flag | Description |
 |---|---|
+| `-n, --network <network>` | Bitcoin network to record as `defaults.network` so later commands can drop `-n`. Written idempotently: it never clobbers a network you set earlier |
 | `--dev` | Establish an **unencrypted** dev keystore (plaintext keys, no passphrase). Testnet/regtest only; mainnet operations are refused |
-| `--force` | Re-create the config and keystore even if they already exist |
+| `--force` | Re-create the config even if it exists. **Never** re-creates the keystore (re-establishing one is the explicit `keystore init --force`) |
 
-By default `init` establishes an **encrypted** keystore and prompts (with confirmation) for a passphrase up front, so the first `key generate` never seals the keystore under an unconfirmed, mistyped passphrase. Supply the passphrase non-interactively with `BTCR2_KEYSTORE_PASSPHRASE` or `--passphrase-file` for scripted setup.
+By default `init` establishes an **encrypted** keystore and prompts (with confirmation) for a passphrase up front, so the first `key generate` never seals the keystore under an unconfirmed, mistyped passphrase. Supply the passphrase non-interactively with `BTCR2_KEYSTORE_PASSPHRASE` or `--passphrase-file` for scripted setup. The output envelope reports the resolved `network` alongside the paths and `protection`.
+
+### quickstart
+
+`btcr2 quickstart` collapses onboarding into one step: it runs `init`'s scaffold, records the network (default **mutinynet**), and optionally caches the session and probes the endpoints. It reimplements nothing - it composes `init`, `keystore unlock`, and `config doctor` - so the keystore and session guarantees hold unchanged.
+
+| Flag | Description |
+|---|---|
+| `-n, --network <network>` | Bitcoin network to set up. Default: `mutinynet` |
+| `--dev` | Establish an unencrypted dev keystore (testnet only) |
+| `--unlock` | Cache the passphrase for the session so later commands do not re-prompt. Opt-in; on a fresh encrypted keystore it reuses the establish-time passphrase with no second prompt |
+| `--ttl <duration>` | Session lifetime with `--unlock`: bare seconds or an `s`/`m`/`h` suffix (default `1h`, max `24h`; also `BTCR2_KEYSTORE_TTL`) |
+| `--no-doctor` | Skip the endpoint reachability probe (which is on by default and **advisory**: a failed probe warns but `quickstart` still exits 0) |
+| `--allow-mainnet` | Permit `-n bitcoin` (records mainnet as the default; dev keystores are still refused). Guarded before any writes |
+| `--force` | Re-create the config even if it exists (never the keystore) |
 
 The workshop happy path:
 
 ```bash
-btcr2 init --dev --network mutinynet   # (or: btcr2 init  for an encrypted keystore)
+btcr2 quickstart -n mutinynet --unlock --ttl 2h   # (or: --dev  for an unencrypted dev keystore)
 btcr2 key generate --set-active
-btcr2 create --network mutinynet
-# ...fund the beacon, resolve, update, deactivate...
+btcr2 create                                       # network comes from defaults.network
+# ...fund the beacon (create prints the faucet + explorer links), resolve, update, deactivate...
 ```
 
 ### key
@@ -141,10 +161,14 @@ Establish, inspect, and re-key the keystore. These operate on the keystore file 
 | Subcommand | Alias | Description |
 |---|---|---|
 | `keystore init` | - | Establish the keystore (encrypted by default; prompts and confirms the passphrase). `--dev` creates an unencrypted dev keystore; `--force` re-establishes an existing one (discards its keys) |
-| `keystore status` | - | Show the resolved path, protection mode (`encrypted`/`dev`/`absent`), whether a passphrase is established, and the key count. Never decrypts or prompts |
-| `keystore change-passphrase` | `passwd` | Re-seal every key under a new passphrase (encrypted keystores only). Prompts for the current passphrase, then a new one (with confirmation) |
+| `keystore status` | - | Show the resolved path, protection mode (`encrypted`/`dev`/`absent`), whether a passphrase is established, the key count, and the `session` state (whether one is live and its remaining lifetime). Never decrypts or prompts |
+| `keystore change-passphrase` | `passwd` | Re-seal every key under a new passphrase (encrypted keystores only). Prompts for the current passphrase, then a new one (with confirmation). Clears any cached session |
+| `keystore unlock` | - | Cache the verified passphrase for the session so later commands do not re-prompt. `--ttl <duration>` sets the lifetime (default `1h`, max `24h`; also `BTCR2_KEYSTORE_TTL`); `--allow-mainnet` permits unlocking a `bitcoin`-default context |
+| `keystore lock` | - | Revoke the cached session so later commands prompt again. Idempotent; needs no passphrase |
 
 **Encrypted vs dev keystores.** An encrypted keystore seals each secret with argon2id + XChaCha20-Poly1305 under one passphrase, and records a verifier so a mistyped passphrase fails loudly (with `Incorrect passphrase`) instead of sealing a key under an unknown or divergent passphrase. A **dev keystore** (`--dev`) stores secrets in plaintext and never prompts: it is for disposable testnet/regtest keys only, and the CLI **hard-refuses** to sign or generate a mainnet (`bitcoin`) key with one.
+
+**Session unlock.** `keystore unlock` caches the verified passphrase in `<home>/session.json` (`0600`) so a returning operator authenticates once instead of on every signing command. A cached session sits below `BTCR2_KEYSTORE_PASSPHRASE` / `--passphrase-file` and above the interactive prompt, so unattended and CI paths still win. Mainnet keeps per-use authentication: a `bitcoin` operation is withheld from a session that was not unlocked with `--allow-mainnet`. The cached passphrase is base64url-encoded, not encrypted; its only protection at rest is the `0600` file mode.
 
 ### config
 
@@ -292,6 +316,7 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_OUTPUT` | `-o, --output` |
 | `BTCR2_HOME` | `--home` |
 | `BTCR2_KEYSTORE_PASSPHRASE` | keystore passphrase (unattended use) |
+| `BTCR2_KEYSTORE_TTL` | session lifetime for `keystore unlock` / `quickstart --unlock` (default `1h`, max `24h`) |
 
 ### Home directory
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import {
   registerKeyCommand,
   registerKeystoreCommand,
   registerProfileCommand,
+  registerQuickstartCommand,
   registerResolveCommand,
   registerUpdateCommand,
 } from './commands/index.js';
@@ -77,6 +78,7 @@ export class DidBtcr2Cli {
     });
 
     registerInitCommand(this.program, globals);
+    registerQuickstartCommand(this.program, globals);
     registerCreateCommand(this.program, factory, keystoreFactory, globals);
     registerResolveCommand(this.program, factory, globals);
     registerUpdateCommand(this.program, keystoreFactory, globals);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,6 +3,7 @@ import type { Command } from 'commander';
 import type { ApiFactory, ConnectionOverrides } from '../config.js';
 import { assertKeystoreAllowedForNetwork, profileNetworkMismatch, resolveDefaultNetwork } from '../config.js';
 import { CLIError } from '../error.js';
+import { printCreateFundingHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
 import type { CommandResult, GlobalOptions, NetworkOption } from '../types.js';
@@ -115,6 +116,7 @@ export function registerCreateCommand(
         const genesisBytes = parseGenesisBytes(options.bytes, 'k');
         const did = factory().createDid('deterministic', genesisBytes, { network });
         print({ action: 'create', data: did });
+        printCreateFundingHint(g, network, did);
         return;
       }
 
@@ -128,6 +130,7 @@ export function registerCreateCommand(
           { action: 'create', data: did, keyId, publicKey: bytesToHex(publicKey) },
           `Using stored key ${keyId}.`,
         );
+        printCreateFundingHint(g, network, did);
         return;
       }
 
@@ -141,6 +144,7 @@ export function registerCreateCommand(
         { action: 'create', data: did, keyId, publicKey },
         `Generated and stored key ${keyId} (now the active key).`,
       );
+      printCreateFundingHint(g, network, did);
     });
 }
 

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -3,6 +3,7 @@ import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
+import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
 import type { GlobalOptions, UpdateCommandOptions } from '../types.js';
@@ -117,6 +118,7 @@ export function registerDeactivateCommand(
         ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'deactivate', data }, globals()));
+      printWatchHint(globals(), network, data.txid);
     });
 }
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 export { registerInitCommand } from './init.js';
+export { registerQuickstartCommand } from './quickstart.js';
 export { registerCreateCommand } from './create.js';
 export { registerResolveCommand } from './resolve.js';
 export { registerUpdateCommand } from './update.js';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,22 +1,142 @@
 import type { Command } from 'commander';
 import { existsSync } from 'node:fs';
-import { defaultConfigPath, resolveKeystorePath, writeDefaultConfigFile } from '../config.js';
+import {
+  assertSupportedNetwork,
+  defaultConfigPath,
+  persistDefaultNetwork,
+  resolveKeystorePath,
+  writeDefaultConfigFile,
+} from '../config.js';
 import { ensureDir } from '../keystore/atomic.js';
 import { initKeystore, keystoreSummary } from '../keystore/file-key-store.js';
 import { acquirePassphrase } from '../keystore/passphrase.js';
 import { clearSession } from '../keystore/session.js';
 import { formatResult } from '../output.js';
 import { defaultSessionPath, resolveHome } from '../paths.js';
-import type { CommandResult, GlobalOptions } from '../types.js';
+import type { CommandResult, GlobalOptions, KeystoreProtectionLabel, NetworkOption } from '../types.js';
+
+/** Options for the shared {@link runInit} scaffolding step. */
+export interface RunInitOptions {
+  /** Establish an UNENCRYPTED dev keystore (plaintext keys, testnet only). */
+  dev?     : boolean;
+  /** Re-scaffold the regenerable config even if it exists (never the keystore). */
+  force?   : boolean;
+  /** Explicit network from `-n/--network`, already validated. Persisted to `defaults.network`. */
+  network? : NetworkOption;
+  /**
+   * Network to persist when `-n` is absent and `defaults.network` is unset: a
+   * command's opinionated default (mutinynet for `quickstart`). Omitted by plain
+   * `init`, which never persists a merely-defaulted network.
+   */
+  fallbackNetwork? : NetworkOption;
+  /**
+   * Capture the establish-time confirmed passphrase so the caller can seed a
+   * session with no second prompt (`quickstart --unlock`). Only populated when a
+   * fresh ENCRYPTED keystore is established in this call. Never printed.
+   */
+  captureEstablishedPassphrase? : boolean;
+}
+
+/** Result of the shared {@link runInit} scaffolding step. */
+export interface RunInitResult {
+  home       : string;
+  config     : string;
+  keystore   : string;
+  network    : NetworkOption;
+  created    : string[];
+  protection : KeystoreProtectionLabel;
+  /**
+   * The confirmed passphrase from a fresh ENCRYPTED establishment in this call,
+   * present only when {@link RunInitOptions.captureEstablishedPassphrase} was set
+   * and a keystore was established. Consumed to seed a session; never printed.
+   */
+  establishedPassphrase? : string;
+}
+
+/**
+ * The shared scaffolding step behind `btcr2 init` and `btcr2 quickstart` (ADR
+ * 079/080/083): create the home, a default config if none exists, and establish
+ * the keystore if none exists (encrypted by default, `--dev` for unencrypted).
+ * Idempotent: existing files are left untouched, and `--force` re-scaffolds only
+ * the regenerable config, never the keystore. Records `defaults.network` via
+ * {@link persistDefaultNetwork}. Returns the resolved paths, network, protection,
+ * and (when asked) the establish-time passphrase for session seeding.
+ */
+export function runInit(g: GlobalOptions, options: RunInitOptions = {}): RunInitResult {
+  const home = resolveHome(g);
+  const configPath = g.config ?? defaultConfigPath(g);
+  const keystorePath = resolveKeystorePath(g);
+  ensureDir(home, 0o700);
+
+  const created: string[] = [];
+
+  // The config is regenerable, so --force may re-scaffold it.
+  if (!existsSync(configPath) || options.force) {
+    writeDefaultConfigFile(configPath);
+    created.push('config');
+  }
+
+  // The keystore holds unrecoverable secret keys, so init never overwrites an
+  // existing one, even with --force: re-establishing a keystore is the explicit,
+  // deliberate `keystore init --force`. init only establishes when none exists.
+  const keystoreExists = existsSync(keystorePath);
+  if (keystoreExists && options.force && !g.quiet) {
+    process.stderr.write(
+      `note: a keystore already exists at ${keystorePath} and was left intact. `
+      + 'To re-establish it (discarding its keys), run "btcr2 keystore init --force".\n',
+    );
+  }
+
+  let establishedPassphrase: string | undefined;
+  if (!keystoreExists) {
+    if (options.dev && !g.quiet) {
+      process.stderr.write(
+        'warning: establishing an UNENCRYPTED dev keystore. Keys are stored in plaintext. '
+        + 'Use it only for disposable testnet material; mainnet operations will be refused.\n',
+      );
+    }
+    initKeystore(keystorePath, {
+      protection    : options.dev ? 'none' : 'passphrase',
+      getPassphrase : (opts) => {
+        const passphrase = acquirePassphrase({
+          passphraseFile : g.passphraseFile,
+          confirm        : opts?.confirm,
+          prompt         : 'New keystore passphrase: ',
+        });
+        // Capture only a fresh ENCRYPTED establishment, for session seeding.
+        if (options.captureEstablishedPassphrase && !options.dev) establishedPassphrase = passphrase;
+        return passphrase;
+      },
+    });
+    // A freshly established keystore mints a new verifier (or none, for --dev), so
+    // any cached session holds a passphrase for a keystore that no longer exists.
+    // Drop it, matching `keystore init` / `change-passphrase` (ADR 081).
+    clearSession(defaultSessionPath(g));
+    created.push('keystore');
+  }
+
+  // Record the network as defaults.network idempotently (ADR 083): an explicit
+  // -n always writes; a merely-defaulted network writes only when the raw config
+  // has none yet, so a re-run never clobbers an operator's earlier choice.
+  const { network } = persistDefaultNetwork(configPath, {
+    explicit  : options.network,
+    fallback  : options.fallbackNetwork,
+    overrides : g,
+  });
+
+  const protection = keystoreSummary(keystorePath).protection;
+  return { home, config: configPath, keystore: keystorePath, network, created, protection, establishedPassphrase };
+}
 
 /**
  * Registers the top-level `btcr2 init`: the one-command entry point that creates
  * the btcr2 home (ADR 079), writes a default config if none exists, and
  * establishes the keystore if none exists (encrypted with a confirmed passphrase
- * by default, or `--dev` for an unencrypted testnet keystore). Idempotent:
- * existing files are left untouched unless `--force` is given. Establishing the
- * passphrase here, up front and confirmed, is what keeps the first `key generate`
- * off the accidental-first-seal path (ADR 080).
+ * by default, or `--dev` for an unencrypted testnet keystore). `-n/--network`
+ * records `defaults.network` so later commands can drop `-n` (ADR 083).
+ * Idempotent: existing files are left untouched unless `--force` is given.
+ * Establishing the passphrase here, up front and confirmed, is what keeps the
+ * first `key generate` off the accidental-first-seal path (ADR 080).
  */
 export function registerInitCommand(program: Command, globals: () => GlobalOptions): void {
   const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
@@ -24,57 +144,29 @@ export function registerInitCommand(program: Command, globals: () => GlobalOptio
   program
     .command('init')
     .description('Set up the btcr2 home: create the directory, a default config, and establish the keystore.')
+    .option(
+      '-n, --network <network>',
+      'Bitcoin network to record as defaults.network <bitcoin|testnet3|testnet4|signet|mutinynet|regtest>',
+    )
     .option('--dev', 'Establish an UNENCRYPTED dev keystore: plaintext keys, no passphrase. Testnet only.', false)
-    .option('--force', 'Re-create the config and keystore even if they already exist.', false)
-    .action((options: { dev?: boolean; force?: boolean }) => {
+    .option('--force', 'Re-create the config even if it already exists (never the keystore).', false)
+    .action((options: { network?: string; dev?: boolean; force?: boolean }) => {
       const g = globals();
-      const home = resolveHome(g);
-      const configPath = g.config ?? defaultConfigPath(g);
-      const keystorePath = resolveKeystorePath(g);
-      ensureDir(home, 0o700);
-
-      const created: string[] = [];
-
-      // The config is regenerable, so --force may re-scaffold it.
-      if (!existsSync(configPath) || options.force) {
-        writeDefaultConfigFile(configPath);
-        created.push('config');
-      }
-
-      // The keystore holds unrecoverable secret keys, so `init` never overwrites
-      // an existing one, even with --force: re-establishing a keystore is the
-      // explicit, deliberate `keystore init --force`. `init` only establishes a
-      // keystore when none exists.
-      const keystoreExists = existsSync(keystorePath);
-      if (keystoreExists && options.force && !g.quiet) {
-        process.stderr.write(
-          `note: a keystore already exists at ${keystorePath} and was left intact. `
-          + 'To re-establish it (discarding its keys), run "btcr2 keystore init --force".\n',
-        );
-      }
-      if (!keystoreExists) {
-        if (options.dev && !g.quiet) {
-          process.stderr.write(
-            'warning: establishing an UNENCRYPTED dev keystore. Keys are stored in plaintext. '
-            + 'Use it only for disposable testnet material; mainnet operations will be refused.\n',
-          );
-        }
-        initKeystore(keystorePath, {
-          protection    : options.dev ? 'none' : 'passphrase',
-          getPassphrase : (opts) => acquirePassphrase({ passphraseFile: g.passphraseFile, confirm: opts?.confirm, prompt: 'New keystore passphrase: ' }),
-        });
-        // A freshly established keystore mints a new verifier (or none, for --dev),
-        // so any cached session holds a passphrase for a keystore that no longer
-        // exists. Drop it, matching `keystore init` / `change-passphrase`, rather
-        // than leave a stale plaintext passphrase behind (ADR 081).
-        clearSession(defaultSessionPath(g));
-        created.push('keystore');
-      }
-
-      const protection = keystoreSummary(keystorePath).protection;
-      print({ action: 'init', data: { home, config: configPath, keystore: keystorePath, created, protection } });
+      const network = options.network ? assertSupportedNetwork(options.network) : undefined;
+      const result = runInit(g, { dev: options.dev, force: options.force, network });
+      print({
+        action : 'init',
+        data   : {
+          home       : result.home,
+          config     : result.config,
+          keystore   : result.keystore,
+          network    : result.network,
+          created    : result.created,
+          protection : result.protection,
+        },
+      });
       if (!g.quiet && g.output !== 'json') {
-        process.stderr.write(`btcr2 home ready at ${home}. Next: btcr2 key generate --set-active\n`);
+        process.stderr.write(`btcr2 home ready at ${result.home} on ${result.network}. Next: btcr2 key generate --set-active\n`);
       }
     });
 }

--- a/packages/cli/src/commands/keystore.ts
+++ b/packages/cli/src/commands/keystore.ts
@@ -17,11 +17,12 @@ import {
   MAX_SESSION_TTL_MS,
   parseTtlToMs,
   readSessionStatus,
+  type SessionFile,
   writeSession,
 } from '../keystore/session.js';
 import { formatResult } from '../output.js';
 import { defaultSessionPath } from '../paths.js';
-import { blankToUndef, type CommandResult, type GlobalOptions } from '../types.js';
+import { blankToUndef, type CommandResult, type GlobalOptions, type NetworkOption } from '../types.js';
 
 /**
  * Registers the `keystore` command group: establish, inspect, and re-key the
@@ -129,62 +130,17 @@ export function registerKeystoreCommand(program: Command, globals: () => GlobalO
     .action((options: { ttl?: string; allowMainnet?: boolean }) => {
       const g = globals();
       const path = resolveKeystorePath(g);
-      const summary = keystoreSummary(path);
-      if (summary.protection === 'absent') {
-        throw new CLIError(`No keystore at ${path}. Run "btcr2 init" or "btcr2 keystore init" first.`, 'INVALID_ARGUMENT_ERROR', { path });
-      }
-      if (summary.protection === 'dev') {
-        throw new CLIError(
-          `The keystore at ${path} is an unencrypted dev keystore; it has no passphrase to cache, so no unlock is needed.`,
-          'INVALID_ARGUMENT_ERROR',
-          { path },
-        );
-      }
-      if (!summary.established) {
-        throw new CLIError(
-          `The keystore at ${path} has no passphrase established yet. `
-          + 'Establish one with "btcr2 keystore init" or the first "btcr2 key generate".',
-          'INVALID_ARGUMENT_ERROR',
-          { path },
-        );
-      }
-      // An unlocked encrypted keystore signs prompt-free for the whole TTL,
-      // silently removing per-use passphrase auth. Two guards, both keyed to
-      // --allow-mainnet (ADR 081): this early refusal when the *configured* default
-      // network is mainnet (a clear signal before caching anything), plus the
-      // authoritative one at consumption, where the session records `allowMainnet`
-      // (below) and a `bitcoin` operation, whose network is derived from the DID
-      // rather than the config, is withheld from a session that lacks it. The
-      // active network defaults to a testnet, so this early refusal never fires
-      // for the demo.
-      if (!options.allowMainnet && resolveDefaultNetwork(g) === 'bitcoin') {
-        throw new CLIError(
-          `Refusing to unlock for a mainnet (bitcoin) context: caching the passphrase suspends per-use `
-          + 'authentication for the session. Pass --allow-mainnet to override, or keep signing mainnet '
-          + 'updates with a per-use passphrase prompt.',
-          'MAINNET_UNLOCK_REFUSED_ERROR',
-          { path },
-        );
-      }
       const ttlMs = resolveSessionTtl(options.ttl);
-      // Acquire the passphrase directly (env / file / prompt) with NO session
-      // consultation and NO confirm, verify it against the keystore verifier, and
-      // only then cache it. A wrong passphrase writes no session file.
-      const passphrase = acquirePassphrase({ passphraseFile: g.passphraseFile, prompt: 'Keystore passphrase: ' });
-      if (!verifyKeystorePassphrase(path, passphrase)) {
-        throw new CLIError(`Incorrect passphrase for the keystore at ${path}; no session was created.`, 'DECRYPT_ERROR', { path });
-      }
-      const verifierId = keystoreVerifierId(path);
-      if (!verifierId) {
-        // An established keystore always carries a verifier; defensive guard.
-        throw new CLIError(`The keystore at ${path} has no verifier to bind a session to.`, 'INVALID_ARGUMENT_ERROR', { path });
-      }
-      const session = writeSession(defaultSessionPath(g), {
+      // The op network for the mainnet gate is the configured default here; the
+      // session records `allowMainnet` and the authoritative check happens at
+      // consumption, where a `bitcoin` operation (network derived from the DID) is
+      // withheld from a session that lacks it.
+      const session = unlockSession({
+        g,
         keystorePath : path,
-        verifierId,
-        passphrase,
-        ttlMs,
+        network      : resolveDefaultNetwork(g),
         allowMainnet : !!options.allowMainnet,
+        ttlMs,
       });
       print({ action: 'keystore-unlock', data: { keystore: path, expiresAt: session.expiresAt, ttlSeconds: session.ttlSeconds } });
     });
@@ -202,13 +158,97 @@ export function registerKeystoreCommand(program: Command, globals: () => GlobalO
     });
 }
 
+/** Input for the shared {@link unlockSession} step. */
+export interface UnlockSessionInput {
+  g            : GlobalOptions;
+  /** The resolved keystore path to unlock. */
+  keystorePath : string;
+  /** The operation network for the mainnet gate, passed explicitly (never re-derived). */
+  network      : NetworkOption;
+  /** Whether a mainnet (bitcoin) unlock is permitted (`--allow-mainnet`). */
+  allowMainnet : boolean;
+  /** Session lifetime in milliseconds (already resolved via {@link resolveSessionTtl}). */
+  ttlMs        : number;
+  /**
+   * A pre-acquired passphrase to reuse instead of prompting (the establish-time
+   * passphrase from `quickstart --unlock` on a fresh keystore). Still verified
+   * against the keystore verifier before caching.
+   */
+  passphrase?  : string;
+}
+
+/**
+ * The shared unlock step behind `keystore unlock` and `quickstart --unlock` (ADR
+ * 081/083): validate the keystore, enforce the mainnet gate against the passed
+ * `network`, acquire (or reuse) and verify the passphrase, and write the session.
+ * Refuses an absent, dev, or unestablished keystore. A wrong passphrase writes no
+ * session file. Returns the written {@link SessionFile}. The op network is passed
+ * in rather than re-derived so the mainnet gate is order-independent even when a
+ * caller has just written `defaults.network`.
+ */
+export function unlockSession(input: UnlockSessionInput): SessionFile {
+  const { g, keystorePath: path, network, allowMainnet, ttlMs } = input;
+  const summary = keystoreSummary(path);
+  if (summary.protection === 'absent') {
+    throw new CLIError(`No keystore at ${path}. Run "btcr2 init" or "btcr2 keystore init" first.`, 'INVALID_ARGUMENT_ERROR', { path });
+  }
+  if (summary.protection === 'dev') {
+    throw new CLIError(
+      `The keystore at ${path} is an unencrypted dev keystore; it has no passphrase to cache, so no unlock is needed.`,
+      'INVALID_ARGUMENT_ERROR',
+      { path },
+    );
+  }
+  if (!summary.established) {
+    throw new CLIError(
+      `The keystore at ${path} has no passphrase established yet. `
+      + 'Establish one with "btcr2 keystore init" or the first "btcr2 key generate".',
+      'INVALID_ARGUMENT_ERROR',
+      { path },
+    );
+  }
+  // An unlocked encrypted keystore signs prompt-free for the whole TTL, silently
+  // removing per-use passphrase auth. Refuse a bitcoin context unless allowed; the
+  // authoritative per-use check still happens at consumption from the session's
+  // recorded `allowMainnet` (ADR 081).
+  if (!allowMainnet && network === 'bitcoin') {
+    throw new CLIError(
+      'Refusing to unlock for a mainnet (bitcoin) context: caching the passphrase suspends per-use '
+      + 'authentication for the session. Pass --allow-mainnet to override, or keep signing mainnet '
+      + 'updates with a per-use passphrase prompt.',
+      'MAINNET_UNLOCK_REFUSED_ERROR',
+      { path },
+    );
+  }
+  // Acquire the passphrase directly (env / file / prompt) with NO session
+  // consultation and NO confirm, or reuse a caller-provided one, then verify it
+  // against the keystore verifier before caching. A wrong passphrase writes no
+  // session file.
+  const passphrase = input.passphrase ?? acquirePassphrase({ passphraseFile: g.passphraseFile, prompt: 'Keystore passphrase: ' });
+  if (!verifyKeystorePassphrase(path, passphrase)) {
+    throw new CLIError(`Incorrect passphrase for the keystore at ${path}; no session was created.`, 'DECRYPT_ERROR', { path });
+  }
+  const verifierId = keystoreVerifierId(path);
+  if (!verifierId) {
+    // An established keystore always carries a verifier; defensive guard.
+    throw new CLIError(`The keystore at ${path} has no verifier to bind a session to.`, 'INVALID_ARGUMENT_ERROR', { path });
+  }
+  return writeSession(defaultSessionPath(g), {
+    keystorePath : path,
+    verifierId,
+    passphrase,
+    ttlMs,
+    allowMainnet,
+  });
+}
+
 /**
  * Resolves the session TTL in milliseconds from the `--ttl` flag, then
  * `$BTCR2_KEYSTORE_TTL`, then the one-hour default. Rejects a non-positive,
  * malformed, or over-24h value with a {@link CLIError} that names the actual
  * source (the flag or the env var) so the operator fixes the right input.
  */
-function resolveSessionTtl(flag?: string): number {
+export function resolveSessionTtl(flag?: string): number {
   const fromFlag = blankToUndef(flag);
   const raw = fromFlag ?? blankToUndef(process.env[ENV_KEYSTORE_TTL]);
   if (raw === undefined) return DEFAULT_SESSION_TTL_MS;

--- a/packages/cli/src/commands/quickstart.ts
+++ b/packages/cli/src/commands/quickstart.ts
@@ -1,0 +1,209 @@
+import { faucetUrl } from '@did-btcr2/api';
+import type { Command } from 'commander';
+import {
+  assertSupportedNetwork,
+  readConfiguredDefaultNetwork,
+  runDoctor,
+  type DoctorReport,
+} from '../config.js';
+import { CLIError } from '../error.js';
+import { keystoreVerifierId } from '../keystore/file-key-store.js';
+import { ENV_KEYSTORE_TTL, readSessionStatus } from '../keystore/session.js';
+import { formatResult } from '../output.js';
+import { defaultSessionPath } from '../paths.js';
+import type { CommandResult, GlobalOptions, NetworkOption } from '../types.js';
+import { runInit, type RunInitResult } from './init.js';
+import { resolveSessionTtl, unlockSession } from './keystore.js';
+
+/** The opinionated default network for `quickstart`: zero local infra, a free faucet, 30s blocks. */
+const QUICKSTART_DEFAULT_NETWORK: NetworkOption = 'mutinynet';
+
+/** The session sub-object reported in the quickstart envelope. */
+type SessionReport = { expiresAt: number; ttlSeconds: number };
+
+/**
+ * Registers the top-level `btcr2 quickstart` (ADR 083): a one-command onboarding
+ * that COMPOSES the existing primitives - the {@link runInit} scaffold, the
+ * network record, the optional {@link unlockSession} cache, and the advisory
+ * {@link runDoctor} probe - into a single step for a workshop follow-along.
+ * Reimplements nothing; the ADR 080/081 keystore and session guarantees hold by
+ * construction.
+ */
+export function registerQuickstartCommand(program: Command, globals: () => GlobalOptions): void {
+  const print = (result: CommandResult): void => console.log(formatResult(result, globals()));
+
+  program
+    .command('quickstart')
+    .description('One-command onboarding: create the home + config + keystore, record the network, and (optionally) cache the session and probe endpoints.')
+    .option(
+      '-n, --network <network>',
+      'Bitcoin network to set up <bitcoin|testnet3|testnet4|signet|mutinynet|regtest> (default: mutinynet)',
+    )
+    .option('--dev', 'Establish an UNENCRYPTED dev keystore: plaintext keys, no passphrase. Testnet only.', false)
+    .option('--unlock', 'Cache the passphrase for the session so later commands do not re-prompt (ADR 081).', false)
+    .option('--ttl <duration>', `Session lifetime with --unlock: bare seconds or an s/m/h suffix (default 1h, max 24h). Also $${ENV_KEYSTORE_TTL}.`)
+    .option('--no-doctor', 'Skip the endpoint reachability probe.')
+    .option('--allow-mainnet', 'Permit -n bitcoin (records mainnet as the default; dev keystores are still refused).', false)
+    .option('--force', 'Re-create the config even if it already exists (never the keystore).', false)
+    .action(async (options: {
+      network?      : string;
+      dev?          : boolean;
+      unlock?       : boolean;
+      ttl?          : string;
+      doctor        : boolean; // commander sets false for --no-doctor, true otherwise
+      allowMainnet? : boolean;
+      force?        : boolean;
+    }) => {
+      const g = globals();
+      const explicit = options.network ? assertSupportedNetwork(options.network) : undefined;
+      // The network quickstart will operate on, computed BEFORE any write so the
+      // mainnet guard sees the real target: explicit -n, else an existing
+      // defaults.network, else the mutinynet default. runInit resolves to the
+      // same value.
+      const network = explicit ?? readConfiguredDefaultNetwork(g) ?? QUICKSTART_DEFAULT_NETWORK;
+
+      // Mainnet is guarded before any files are written (ADR 083). A dev keystore
+      // never operates on mainnet; an encrypted mainnet setup needs the explicit
+      // opt-in that also gates the session-unlock mainnet suspension.
+      if (network === 'bitcoin') {
+        if (options.dev) {
+          throw new CLIError(
+            'Refusing to quickstart a mainnet (bitcoin) dev keystore: dev keystores store keys in plaintext '
+            + 'and never operate on mainnet. Drop --dev, or choose a testnet with -n.',
+            'MAINNET_QUICKSTART_REFUSED_ERROR',
+            { network },
+          );
+        }
+        if (!options.allowMainnet) {
+          throw new CLIError(
+            'Refusing to quickstart on mainnet (bitcoin) without --allow-mainnet. Pass --allow-mainnet to '
+            + 'record mainnet as the default, or choose a testnet with -n (the default is mutinynet).',
+            'MAINNET_QUICKSTART_REFUSED_ERROR',
+            { network },
+          );
+        }
+      }
+
+      // 1-2. Scaffold and record the network. An explicit -n always writes; a
+      // merely-defaulted mutinynet writes only when defaults.network is unset.
+      const init = runInit(g, {
+        dev                          : options.dev,
+        force                        : options.force,
+        network                      : explicit,
+        fallbackNetwork              : explicit ? undefined : QUICKSTART_DEFAULT_NETWORK,
+        captureEstablishedPassphrase : !!options.unlock && !options.dev,
+      });
+
+      // 3. Optionally cache the session (ADR 081 opt-in; never on a dev keystore).
+      let unlocked = false;
+      let session: SessionReport | undefined;
+      if (options.unlock && !options.dev) {
+        const outcome = cacheSession(g, init, options.ttl, !!options.allowMainnet);
+        unlocked = outcome.unlocked;
+        session = outcome.session;
+      }
+
+      // 4. Advisory endpoint probe (on by default; a failed probe warns, exit 0).
+      let doctor: DoctorReport | undefined;
+      if (options.doctor) {
+        doctor = await runDoctor(init.network, g);
+      }
+
+      print({
+        action : 'quickstart',
+        data   : {
+          home       : init.home,
+          config     : init.config,
+          keystore   : init.keystore,
+          network    : init.network,
+          created    : init.created,
+          protection : init.protection,
+          unlocked,
+          ...(session ? { session } : {}),
+          ...(doctor ? { doctor } : {}),
+        },
+      });
+
+      if (!g.quiet && g.output !== 'json') {
+        printNextSteps(init, unlocked, session, doctor);
+      }
+    });
+}
+
+/**
+ * Caches the session for `quickstart --unlock`. On a fresh keystore, reuses the
+ * establish-time confirmed passphrase (no second prompt). On an existing keystore
+ * with a live matching session, skips (idempotent re-run). Otherwise acquires and
+ * verifies the passphrase. In a non-interactive context with no passphrase source
+ * on an existing keystore, the step is a non-fatal skip (warn, `unlocked: false`),
+ * so `quickstart` still exits 0 (ADR 083).
+ */
+function cacheSession(
+  g            : GlobalOptions,
+  init         : RunInitResult,
+  ttlFlag      : string | undefined,
+  allowMainnet : boolean,
+): { unlocked: boolean; session?: SessionReport } {
+  const ttlMs = resolveSessionTtl(ttlFlag);
+  const freshlyEstablished = init.created.includes('keystore');
+
+  // Existing encrypted keystore already unlocked: report it and skip re-writing.
+  if (!freshlyEstablished) {
+    const status = readSessionStatus(defaultSessionPath(g), init.keystore, keystoreVerifierId(init.keystore));
+    if (status.active && status.expiresAt !== undefined) {
+      return { unlocked: true, session: { expiresAt: status.expiresAt, ttlSeconds: status.secondsRemaining ?? 0 } };
+    }
+  }
+
+  try {
+    const written = unlockSession({
+      g,
+      keystorePath : init.keystore,
+      network      : init.network,
+      allowMainnet,
+      ttlMs,
+      // Reuse the establish-time passphrase on a fresh keystore: no second prompt.
+      passphrase   : freshlyEstablished ? init.establishedPassphrase : undefined,
+    });
+    return { unlocked: true, session: { expiresAt: written.expiresAt, ttlSeconds: written.ttlSeconds } };
+  } catch (error) {
+    // On an EXISTING keystore with no passphrase source and no terminal, caching
+    // is a non-fatal skip: the scaffold already succeeded (ADR 083). A fresh
+    // keystore cannot reach here (its passphrase was just captured), and an
+    // interactive wrong passphrase still propagates.
+    const type = (error as { type?: string }).type;
+    if (!freshlyEstablished && !process.stdin.isTTY && type === 'PASSPHRASE_REQUIRED_ERROR') {
+      if (!g.quiet) {
+        process.stderr.write(
+          'note: no passphrase source and no terminal; skipped caching the session. '
+          + 'Run "btcr2 keystore unlock" later to cache it.\n',
+        );
+      }
+      return { unlocked: false };
+    }
+    throw error;
+  }
+}
+
+/** Prints the text-mode next-step hints after quickstart (ADR 082/083). */
+function printNextSteps(
+  init     : RunInitResult,
+  unlocked : boolean,
+  session  : SessionReport | undefined,
+  doctor   : DoctorReport | undefined,
+): void {
+  const lines: string[] = [`btcr2 home ready at ${init.home} on ${init.network}.`];
+  if (unlocked && session) {
+    lines.push(`Session cached until ${new Date(session.expiresAt).toISOString()}; signing will not re-prompt until it expires.`);
+  }
+  if (init.protection === 'dev') {
+    lines.push('Dev keystore: keys are stored in plaintext; mainnet operations are refused.');
+  }
+  if (doctor && doctor.checks.some((c) => !c.ok)) {
+    lines.push('Warning: one or more endpoints were unreachable (see the doctor report). Re-run "btcr2 config doctor" for detail.');
+  }
+  lines.push('Next: btcr2 key generate --name demo --set-active');
+  const faucet = faucetUrl(init.network);
+  if (faucet) lines.push(`Faucet (fund your beacon after "btcr2 create"): ${faucet}`);
+  process.stderr.write(`${lines.join('\n')}\n`);
+}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -3,6 +3,7 @@ import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
+import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
 import type { GlobalOptions, UpdateCommandOptions } from '../types.js';
@@ -117,6 +118,7 @@ export function registerUpdateCommand(
         ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'update', data }, globals()));
+      printWatchHint(globals(), network, data.txid);
     });
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -399,6 +399,81 @@ export function resolveDefaultNetwork(overrides?: ConnectionOverrides): NetworkO
 }
 
 /**
+ * The network recorded at `defaults.network` in the config file, validated, or
+ * `undefined` when the file is absent, malformed, or the value is unset/unknown.
+ * Unlike {@link resolveDefaultNetwork} this consults ONLY the raw
+ * `defaults.network` (no profile fallback, no regtest default), so `quickstart`
+ * can distinguish "the operator set a default" from "there is none yet" before
+ * it writes (ADR 083). Never throws: a malformed config is surfaced loudly by
+ * the write path, so this pre-write read stays quiet.
+ */
+export function readConfiguredDefaultNetwork(overrides?: ConnectionOverrides): NetworkOption | undefined {
+  const configPath = overrides?.config ?? defaultConfigPath(overrides);
+  let raw: Record<string, unknown> | undefined;
+  try {
+    raw = parseConfigFileRaw(configPath);
+  } catch {
+    return undefined;
+  }
+  const value = raw ? getConfigPath(raw, 'defaults.network') : undefined;
+  return typeof value === 'string' && SUPPORTED_NETWORKS.includes(value as NetworkOption)
+    ? value as NetworkOption
+    : undefined;
+}
+
+/**
+ * Persists `defaults.network` idempotently and returns the resolved network,
+ * the shared network-recording step behind `btcr2 init -n` and `btcr2 quickstart`
+ * (ADR 083). Writes when `explicit` (an explicit `-n`) is given, or when a
+ * `fallback` is given and the raw config has no `defaults.network` yet. Keyed on
+ * the **raw** file value (not {@link resolveDefaultNetwork}, which never returns
+ * undefined), so a defaulted re-run never clobbers a network the operator set
+ * earlier. When neither condition writes, the existing default is returned
+ * unchanged. Assumes `configPath` names a parseable config (the caller has just
+ * scaffolded one, or an existing one that a malformed-JSON read surfaces loudly).
+ */
+export function persistDefaultNetwork(
+  configPath : string,
+  opts       : { explicit?: NetworkOption; fallback?: NetworkOption; overrides?: ConnectionOverrides },
+): { network: NetworkOption; wrote: boolean } {
+  const raw = parseConfigFileRaw(configPath);
+  const rawValue = raw ? getConfigPath(raw, 'defaults.network') : undefined;
+  const rawNetwork = typeof rawValue === 'string' && SUPPORTED_NETWORKS.includes(rawValue as NetworkOption)
+    ? rawValue as NetworkOption
+    : undefined;
+
+  if (opts.explicit) {
+    if (opts.explicit !== rawNetwork) {
+      writeConfigFile(configPath, (r) => setConfigPath(r, 'defaults.network', opts.explicit));
+      return { network: opts.explicit, wrote: true };
+    }
+    return { network: opts.explicit, wrote: false };
+  }
+  if (rawNetwork) return { network: rawNetwork, wrote: false };
+  if (opts.fallback) {
+    writeConfigFile(configPath, (r) => setConfigPath(r, 'defaults.network', opts.fallback));
+    return { network: opts.fallback, wrote: true };
+  }
+  return { network: resolveDefaultNetwork(opts.overrides), wrote: false };
+}
+
+/**
+ * Validates an explicit network string against {@link SUPPORTED_NETWORKS},
+ * returning it typed as a {@link NetworkOption} or throwing a {@link CLIError}.
+ * Shared by the `-n/--network` flags on `init` and `quickstart` (ADR 083).
+ */
+export function assertSupportedNetwork(value: string): NetworkOption {
+  if (!SUPPORTED_NETWORKS.includes(value as NetworkOption)) {
+    throw new CLIError(
+      `Invalid network "${value}". Must be one of ${SUPPORTED_NETWORKS.join(', ')}.`,
+      'INVALID_ARGUMENT_ERROR',
+      { network: value },
+    );
+  }
+  return value as NetworkOption;
+}
+
+/**
  * Reports a coherence conflict between the network a `create` run is about to
  * encode and the network the active profile declares, so the CLI can warn
  * instead of silently minting an identifier on one network while wiring

--- a/packages/cli/src/hints.ts
+++ b/packages/cli/src/hints.ts
@@ -1,0 +1,51 @@
+import { explorerAddressUrl, explorerTxUrl, faucetUrl } from '@did-btcr2/api';
+import { BeaconUtils } from '@did-btcr2/method';
+import type { GlobalOptions, NetworkOption } from './types.js';
+
+/**
+ * Text-mode stderr hints derived from the per-network presets (ADR 082). All of
+ * these are suppressed under `--quiet` and `--output json` so machine output is
+ * never touched, and they never throw: a presentation hint must never break the
+ * command that produced the real result.
+ */
+
+/**
+ * Prints a funding hint after a KEY `create` on a network with a public faucet:
+ * the derived initial P2WPKH beacon address next to the faucet and explorer
+ * links the operator would otherwise hand-copy. A no-op on a network without a
+ * faucet (regtest/mainnet), which also keeps mainnet from showing a fund-me
+ * affordance. The beacon address is derived from the DID string alone via
+ * {@link BeaconUtils.createBeaconService}, so it matches the resolver's
+ * `#initialP2WPKH` service rather than a divergent re-derivation.
+ */
+export function printCreateFundingHint(g: GlobalOptions, network: NetworkOption, did: string): void {
+  if (g.quiet || g.output === 'json') return;
+  const faucet = faucetUrl(network);
+  if (!faucet) return;
+  let beaconAddress: string;
+  try {
+    const { serviceEndpoint } = BeaconUtils.createBeaconService(did, 'p2wpkh', 'SingletonBeacon');
+    beaconAddress = serviceEndpoint.replace(/^bitcoin:/, '');
+  } catch {
+    return;
+  }
+  const explorer = explorerAddressUrl(network, beaconAddress);
+  const lines = [
+    'Fund the initial beacon to anchor updates:',
+    `  Beacon:   ${beaconAddress}`,
+    `  Faucet:   ${faucet}`,
+  ];
+  if (explorer) lines.push(`  Explorer: ${explorer}`);
+  process.stderr.write(`${lines.join('\n')}\n`);
+}
+
+/**
+ * Prints a watch link after an `update`/`deactivate` broadcast: the
+ * block-explorer URL for the signal txid. A no-op on a network without an
+ * explorer (regtest).
+ */
+export function printWatchHint(g: GlobalOptions, network: NetworkOption, txid: string): void {
+  if (g.quiet || g.output === 'json') return;
+  const url = explorerTxUrl(network, txid);
+  if (url) process.stderr.write(`Watch: ${url}\n`);
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -56,7 +56,18 @@ export type CommandResult =
   | { action: 'key-export'; data: { keyId: string; publicKey?: string; secretWrittenTo?: string } }
   | { action: 'key-delete'; data: { keyId: string; deleted: true } }
   | { action: 'key-use'; data: { keyId: string; active: true } }
-  | { action: 'init'; data: { home: string; config: string; keystore: string; created: string[]; protection: KeystoreProtectionLabel } }
+  | { action: 'init'; data: { home: string; config: string; keystore: string; network: NetworkOption; created: string[]; protection: KeystoreProtectionLabel } }
+  | { action: 'quickstart'; data: {
+      home       : string;
+      config     : string;
+      keystore   : string;
+      network    : NetworkOption;
+      created    : string[];
+      protection : KeystoreProtectionLabel;
+      unlocked   : boolean;
+      session?   : { expiresAt: number; ttlSeconds: number };
+      doctor?    : DoctorReport;
+    } }
   | { action: 'config-init'; data: { path: string } }
   | { action: 'config-get'; data: unknown }
   | { action: 'config-set'; data: { path: string } }

--- a/packages/cli/tests/create-commands.spec.ts
+++ b/packages/cli/tests/create-commands.spec.ts
@@ -136,4 +136,32 @@ describe('create command', () => {
     expect(out[0]).to.match(/^did:btcr2:k1/);
     expect(err.join(' ')).to.match(/Generated and stored key urn:kms:secp256k1:[0-9a-f]{32} \(now the active key\)/);
   });
+
+  describe('funding hint (ADR 082)', () => {
+    it('text mode on a testnet with a faucet prints the beacon, faucet, and explorer', async () => {
+      const pk = freshPublicKeyHex();
+      await run('create', '-t', 'k', '-n', 'mutinynet', '-b', pk);
+      const e = err.join(' ');
+      expect(e).to.match(/Fund the initial beacon/i);
+      expect(e).to.match(/Faucet:\s+https:\/\/faucet\.mutinynet\.com\//);
+      expect(e).to.match(/Explorer:\s+https:\/\/mutinynet\.com\/address\/tb1/);
+    });
+
+    it('omits the funding hint under -o json (machine output stays clean)', async () => {
+      const pk = freshPublicKeyHex();
+      await run('-o', 'json', 'create', '-t', 'k', '-n', 'mutinynet', '-b', pk);
+      expect(err.join(' ')).to.not.match(/Fund the initial beacon/i);
+    });
+
+    it('omits the funding hint on a network without a faucet (regtest)', async () => {
+      const pk = freshPublicKeyHex();
+      await run('create', '-t', 'k', '-n', 'regtest', '-b', pk);
+      expect(err.join(' ')).to.not.match(/Fund the initial beacon/i);
+    });
+
+    it('omits the funding hint for an external (-t x) identifier (no beacon key)', async () => {
+      await run('create', '-t', 'x', '-n', 'mutinynet', '-b', 'ab'.repeat(32));
+      expect(err.join(' ')).to.not.match(/Fund the initial beacon/i);
+    });
+  });
 });

--- a/packages/cli/tests/quickstart.spec.ts
+++ b/packages/cli/tests/quickstart.spec.ts
@@ -1,0 +1,216 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DidBtcr2Cli } from '../src/cli.js';
+import type { ArgonParams } from '../src/keystore/envelope.js';
+import { initKeystore, keystoreSummary } from '../src/keystore/file-key-store.js';
+import { ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
+import { ENV_KEYSTORE_TTL } from '../src/keystore/session.js';
+import { createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
+
+const FAST: ArgonParams = { t: 1, m: 256, p: 1, dkLen: 32 };
+const ENV_KEYS = [ 'BTCR2_HOME', ENV_KEYSTORE_PASSPHRASE, ENV_KEYSTORE_TTL ];
+/** A refused endpoint so the advisory doctor probe fails fast and offline. */
+const REFUSED = 'http://127.0.0.1:1';
+
+describe('quickstart (ADR 083)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let dir: string;
+  let home: string;
+  let passFile: string;
+  let out: string[];
+  let err: string[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-quickstart-'));
+    home = join(dir, 'home');
+    passFile = join(dir, 'pass.txt');
+    writeFileSync(passFile, 'pw\n');
+    out = [];
+    err = [];
+    console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };
+    console.error = (m?: unknown) => { if (m !== undefined) err.push(String(m)); };
+    process.stderr.write = ((chunk: unknown): boolean => { err.push(String(chunk)); return true; }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = 0;
+    for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function run(...args: string[]): Promise<void> {
+    await new DidBtcr2Cli(createTestApiFactory()).run(['node', 'btcr2', '--home', home, ...args]);
+  }
+
+  const keystorePath = (): string => join(home, 'keystore.json');
+  const configPath = (): string => join(home, 'config.json');
+  const sessionPath = (): string => join(home, 'session.json');
+
+  /** Establishes a FAST encrypted keystore (empty, established) at the home default. */
+  function establishEncrypted(): void {
+    initKeystore(keystorePath(), { protection: 'passphrase', argonParams: FAST, getPassphrase: () => 'pw' });
+  }
+
+  /** The `defaults.network` recorded in the config file, or undefined. */
+  function recordedNetwork(): unknown {
+    if (!existsSync(configPath())) return undefined;
+    return (JSON.parse(readFileSync(configPath(), 'utf-8')).defaults ?? {}).network;
+  }
+
+  const parse = (): { action: string; data: Record<string, unknown> } => JSON.parse(out.join('\n'));
+
+  describe('scaffold and network', () => {
+    it('--dev seeds home/config/keystore and records mutinynet by default', async () => {
+      await run('-o', 'json', 'quickstart', '--dev', '--no-doctor');
+      const result = parse();
+      expect(result.action).to.equal('quickstart');
+      expect(result.data.network).to.equal('mutinynet');
+      expect(result.data.created).to.have.members([ 'config', 'keystore' ]);
+      expect(result.data.protection).to.equal('dev');
+      expect(result.data.unlocked).to.equal(false);
+      expect(result.data).to.not.have.property('doctor');
+      expect(recordedNetwork()).to.equal('mutinynet');
+    });
+
+    it('an explicit -n records that network', async () => {
+      await run('-o', 'json', 'quickstart', '-n', 'signet', '--dev', '--no-doctor');
+      expect(parse().data.network).to.equal('signet');
+      expect(recordedNetwork()).to.equal('signet');
+    });
+
+    it('a bare re-run does not clobber a network the operator set earlier', async () => {
+      await run('init', '--dev');
+      await run('config', 'set', 'defaults.network', 'signet');
+      out = [];
+      await run('-o', 'json', 'quickstart', '--dev', '--no-doctor');
+      expect(parse().data.network).to.equal('signet');
+      expect(recordedNetwork()).to.equal('signet');
+    });
+
+    it('an explicit -n overrides an existing default', async () => {
+      await run('init', '--dev');
+      await run('config', 'set', 'defaults.network', 'signet');
+      out = [];
+      await run('-o', 'json', 'quickstart', '-n', 'testnet4', '--dev', '--no-doctor');
+      expect(parse().data.network).to.equal('testnet4');
+      expect(recordedNetwork()).to.equal('testnet4');
+    });
+  });
+
+  describe('mainnet gate (before any writes)', () => {
+    it('refuses -n bitcoin without --allow-mainnet and writes nothing', async () => {
+      await run('quickstart', '-n', 'bitcoin', '--dev', '--no-doctor');
+      expect(err.join(' ')).to.match(/mainnet/i);
+      expect(existsSync(configPath())).to.equal(false);
+      expect(existsSync(keystorePath())).to.equal(false);
+    });
+
+    it('refuses -n bitcoin --dev even with --allow-mainnet', async () => {
+      await run('quickstart', '-n', 'bitcoin', '--dev', '--allow-mainnet', '--no-doctor');
+      expect(err.join(' ')).to.match(/dev keystore/i);
+      expect(existsSync(keystorePath())).to.equal(false);
+    });
+  });
+
+  describe('session caching is opt-in (--unlock)', () => {
+    it('without --unlock, caches no session (fresh encrypted keystore)', async function () {
+      this.timeout(30_000); // real establishment at production argon2id cost
+      await run('-o', 'json', '--passphrase-file', passFile, 'quickstart', '--no-doctor');
+      const result = parse();
+      expect(result.data.protection).to.equal('encrypted');
+      expect(result.data.unlocked).to.equal(false);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+
+    it('with --unlock on a fresh encrypted keystore, caches a session with no second prompt', async function () {
+      this.timeout(30_000);
+      await run('-o', 'json', '--passphrase-file', passFile, 'quickstart', '--unlock', '--ttl', '30m', '--no-doctor');
+      const result = parse();
+      expect(result.data.protection).to.equal('encrypted');
+      expect(result.data.unlocked).to.equal(true);
+      expect((result.data.session as { ttlSeconds: number }).ttlSeconds).to.equal(1800);
+      expect(existsSync(sessionPath())).to.equal(true);
+      // The passphrase must never appear in output.
+      expect(`${out.join(' ')} ${err.join(' ')}`).to.not.match(/\bpw\b/);
+    });
+
+    it('with --unlock on an existing keystore that already has a live session, skips (idempotent)', async () => {
+      establishEncrypted();
+      await run('--passphrase-file', passFile, 'keystore', 'unlock');
+      expect(existsSync(sessionPath())).to.equal(true);
+      out = [];
+      // No passphrase source: a live session means no prompt and no re-write.
+      await run('-o', 'json', 'quickstart', '--unlock', '--no-doctor');
+      expect(parse().data.unlocked).to.equal(true);
+      expect(existsSync(sessionPath())).to.equal(true);
+    });
+
+    it('with --unlock on an existing encrypted keystore, non-TTY with no passphrase source, skips non-fatally', async function () {
+      if (process.stdin.isTTY) return this.skip(); // relies on a non-interactive runner
+      establishEncrypted();
+      await run('-o', 'json', 'quickstart', '--unlock', '--no-doctor');
+      expect(parse().data.unlocked).to.equal(false);
+      expect(existsSync(sessionPath())).to.equal(false);
+      expect(err.join(' ')).to.match(/skipped caching the session/i);
+      expect(process.exitCode).to.not.equal(1);
+    });
+
+    it('--dev never caches a session, even with --unlock', async () => {
+      await run('-o', 'json', 'quickstart', '--dev', '--unlock', '--no-doctor');
+      expect(parse().data.unlocked).to.equal(false);
+      expect(existsSync(sessionPath())).to.equal(false);
+    });
+  });
+
+  describe('advisory doctor', () => {
+    it('runs by default and a failed probe does not fail quickstart', async function () {
+      this.timeout(15_000);
+      await run(
+        '-o', 'json',
+        '--btc-rest', `${REFUSED}/api`,
+        '--cas-gateway', REFUSED,
+        'quickstart', '--dev',
+      );
+      const result = parse();
+      expect(result.data).to.have.property('doctor');
+      const checks = (result.data.doctor as { checks: Array<{ ok: boolean }> }).checks;
+      expect(checks.some((c) => !c.ok)).to.equal(true);
+      expect(process.exitCode).to.not.equal(1); // advisory: a failed probe still exits 0
+    });
+
+    it('--no-doctor skips the probe', async () => {
+      await run('-o', 'json', 'quickstart', '--dev', '--no-doctor');
+      expect(parse().data).to.not.have.property('doctor');
+    });
+  });
+
+  describe('init -n complement', () => {
+    it('init -n records the network in the envelope and config', async () => {
+      await run('-o', 'json', 'init', '-n', 'signet', '--dev');
+      const result = parse();
+      expect(result.action).to.equal('init');
+      expect(result.data.network).to.equal('signet');
+      expect(recordedNetwork()).to.equal('signet');
+    });
+
+    it('init without -n does not persist a network', async () => {
+      await run('-o', 'json', 'init', '--dev');
+      // resolveDefaultNetwork falls back to regtest, but nothing is written.
+      expect(parse().data.network).to.equal('regtest');
+      expect(recordedNetwork()).to.equal(undefined);
+      expect(keystoreSummary(keystorePath()).protection).to.equal('dev');
+    });
+
+    it('rejects an invalid -n before any work', async () => {
+      await run('quickstart', '-n', 'notanet', '--dev', '--no-doctor');
+      expect(err.join(' ')).to.match(/Invalid network/i);
+      expect(existsSync(keystorePath())).to.equal(false);
+    });
+  });
+});

--- a/packages/cli/tests/update.spec.ts
+++ b/packages/cli/tests/update.spec.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
 import type { ApiFactory } from '../src/config.js';
 import { CLIError } from '../src/error.js';
-import { createKeystoreTestApiFactory, createTestApiFactory, expect, originalConsoleLog } from './helpers.js';
+import { createKeystoreTestApiFactory, createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
 
 function sub(cli: DidBtcr2Cli, name: string): Command {
   const c = cli.program.commands.find(x => x.name() === name);
@@ -211,5 +211,64 @@ describe('update and deactivate (signing)', () => {
       { from: 'user' },
     );
     expect(captured.params.broadcastOptions.feeEstimator.satsPerVbyte).to.equal(7);
+  });
+});
+
+describe('update/deactivate watch hint (ADR 082)', () => {
+  let dir: string;
+  let keystore: string;
+  let err: string[];
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-watch-'));
+    keystore = join(dir, 'keystore.json');
+    err = [];
+    console.log = () => {};
+    console.error = (m?: unknown) => { if (m !== undefined) err.push(String(m)); };
+    originalStderrWrite = process.stderr.write;
+    process.stderr.write = ((chunk: unknown) => { err.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    createKeystoreTestApiFactory(keystore, 'pw')().kms.generateKey({ setActive: true });
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    process.stderr.write = originalStderrWrite;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** A signing stub whose update returns a fixed txid, so the watch hint can be observed. */
+  function txidStub(txid: string): ApiFactory {
+    return () => {
+      const realApi = createKeystoreTestApiFactory(keystore, 'pw')();
+      return {
+        kms   : realApi.kms,
+        btcr2 : { update: async () => ({ txid }) },
+      } as unknown as DidBtcr2Api;
+    };
+  }
+
+  const didFor = (network: string): string =>
+    createApi().createDid('deterministic', SchnorrKeyPair.generate().publicKey.compressed, { network: network as never });
+
+  it('prints a Watch link for the txid on a network with an explorer', async () => {
+    const did = didFor('mutinynet');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), txidStub('cafe1234'));
+    await sub(cli, 'update').parseAsync(
+      ['-s', JSON.stringify({ id: did }), '--source-version-id', '1', '-p', '[]', '-m', '#k0', '-b', '"#beacon-0"'],
+      { from: 'user' },
+    );
+    expect(err.join(' ')).to.match(/Watch:\s+https:\/\/mutinynet\.com\/tx\/cafe1234/);
+  });
+
+  it('omits the Watch link on a network without an explorer (regtest)', async () => {
+    const did = didFor('regtest');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), txidStub('cafe1234'));
+    await sub(cli, 'deactivate').parseAsync(
+      ['-s', JSON.stringify({ id: did }), '--source-version-id', '1', '-m', '#k0', '-b', '"#beacon-0"'],
+      { from: 'user' },
+    );
+    expect(err.join(' ')).to.not.match(/Watch:/);
   });
 });


### PR DESCRIPTION
* chore(release): bump api 0.17.0, cli 0.18.0
* test(cli,api): quickstart matrix, create/update hint gating, network presets
* feat(api): NETWORK_PRESETS + explorerTxUrl/explorerAddressUrl/faucetUrl
* feat(cli): quickstart command, init -n, create funding hint, update/deactivate link
* docs(adr): 082 network presets, 083 quickstart