### PR TITLE
fix coverage badge glyph spacing + smarter badge publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,30 @@ jobs:
 
       # Publish the regenerated badge + report to the dedicated ci-badges
       # branch (single orphan commit, force-pushed) so the README badge tracks
-      # every main run without ever putting an automated commit on main
-      # (ADR 084). GITHUB_TOKEN pushes cannot retrigger workflows, and the
-      # [skip ci] marker documents that no CI is expected on that branch.
-      - name: Publish coverage badge (main only)
-        if: github.ref == 'refs/heads/main'
+      # main without ever putting an automated commit on main (ADR 084).
+      # Publishes only when (a) the branch does not exist yet (first-run seed,
+      # from any branch, so the README badge is never a dead link) or (b) this
+      # is a main run and the rendered badge actually changed. GITHUB_TOKEN
+      # pushes cannot retrigger workflows, and the [skip ci] marker documents
+      # that no CI is expected on that branch.
+      - name: Publish coverage badge
         run: |
           if [ ! -f .github/badges/coverage.svg ] || [ ! -f COVERAGE.md ]; then
             echo "coverage artifacts missing (coverage report failed?); skipping badge publish"
             exit 0
+          fi
+          if git ls-remote --exit-code --heads origin ci-badges >/dev/null; then
+            if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+              echo "ci-badges exists and this is not main; skipping badge publish"
+              exit 0
+            fi
+            git fetch -q --depth 1 origin ci-badges
+            if git show FETCH_HEAD:.github/badges/coverage.svg | cmp -s - .github/badges/coverage.svg; then
+              echo "badge unchanged; skipping publish (COVERAGE.md refreshes with the next badge change)"
+              exit 0
+            fi
+          else
+            echo "ci-badges branch missing; seeding it from this run"
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/docs/adr/084-ci-published-coverage-badge.md
+++ b/docs/adr/084-ci-published-coverage-badge.md
@@ -37,22 +37,31 @@ squash-rebased work).
 
 ### CI publishes the badge and report to a dedicated `ci-badges` branch
 
-- **On every `main` run**, after the existing `coverage:report` step, CI commits the
-  regenerated `.github/badges/coverage.svg` and `COVERAGE.md` to a dedicated `ci-badges`
-  branch and force-pushes it. The branch is created as an orphan on each publish, so it
-  always contains exactly one commit holding exactly two files: it has no history worth
-  preserving, and force-pushing makes concurrent runs a last-writer-wins non-event
-  rather than a push race.
+- **On every `main` run**, after the existing `coverage:report` step, CI compares the
+  regenerated `.github/badges/coverage.svg` against the copy on a dedicated `ci-badges`
+  branch and, **only when the rendered badge changed**, commits the badge plus
+  `COVERAGE.md` there and force-pushes. The branch is created as an orphan on each
+  publish, so it always contains exactly one commit holding exactly two files: it has no
+  history worth preserving, and force-pushing makes concurrent runs a last-writer-wins
+  non-event rather than a push race. Publishing on change (in either direction) keeps
+  the badge honest while avoiding a pointless push per commit; `COVERAGE.md`'s
+  covered/total counts refresh whenever the badge does, and the always-current number
+  for any run lives in that run's job summary.
+- **The first run seeds the branch, from any branch.** When `ci-badges` does not exist
+  yet, the publish step creates it regardless of which branch triggered CI, so the
+  README badge resolves from the very first CI run after this change rather than
+  dangling until the change reaches `main`. Once the branch exists, only `main` runs
+  update it.
 - **`main` no longer tracks the artifacts.** The committed copies are removed,
   `/.github/badges/` and `/COVERAGE.md` are git-ignored, and the README badge points at
   the `ci-badges` copy (`raw.githubusercontent.com/.../ci-badges/...` for the image,
   the branch's `COVERAGE.md` blob for the click-through). Local `pnpm coverage` runs
   still produce both files for inspection; they just no longer dirty the tree.
-- **The publish step is `main`-gated and non-recursive.** It runs only for
-  `refs/heads/main`. Pushes made with the workflow's own `GITHUB_TOKEN` cannot trigger
-  workflows (a GitHub Actions guarantee), and the commit message carries `[skip ci]` as
-  documentation of that intent. The job gains `permissions: contents: write` for the
-  push; every other step only reads.
+- **The publish step is non-recursive.** Updates after the seed run only for
+  `refs/heads/main` (enforced inside the step). Pushes made with the workflow's own
+  `GITHUB_TOKEN` cannot trigger workflows (a GitHub Actions guarantee), and the commit
+  message carries `[skip ci]` as documentation of that intent. The job gains
+  `permissions: contents: write` for the push; every other step only reads.
 - **Failure stays advisory.** `coverage:report` keeps `continue-on-error: true`; if it
   produced no artifacts, the publish step logs and exits zero, leaving the previous
   badge in place. A missing badge never fails an otherwise green build.
@@ -78,8 +87,12 @@ reporters, report-only coverage with no threshold gate, and the dependency-audit
 - The badge image is served by `raw.githubusercontent.com` from this repository's own
   branch. No coverage data leaves the repository and no external rendering service is
   involved, preserving ADR 064's constraint.
-- Until the first `main` CI run after this change, the `ci-badges` branch does not
-  exist and the README badge 404s. This heals on the first push to `main`.
+- Between this change landing in a working tree and the first CI run of any branch
+  carrying it, the README badge is a dead link; the first CI run seeds `ci-badges` and
+  resolves it. No committed placeholder is needed.
+- Between badge changes, `COVERAGE.md`'s covered/total counts can lag the latest `main`
+  run (the rounded badge percentage, the number the README advertises, cannot). Each
+  run's exact figure remains in its CI job summary.
 - Contributors no longer regenerate the badge as part of a change; a PR's coverage
   effect becomes visible on `main` after merge rather than in the diff. The per-run job
   summary still shows the number for any branch.
@@ -101,3 +114,12 @@ reporters, report-only coverage with no threshold gate, and the dependency-audit
   concurrent runs. The branch's only job is to hold the current files.
 - **Keeping the tracked copies on `main` alongside the published ones.** Two sources of
   truth, one guaranteed stale: the confusion this ADR exists to remove.
+- **A committed placeholder/default badge on `main` to cover the bootstrap gap.** Same
+  dual-source problem in miniature, and it lingers forever for a gap that lasts exactly
+  one CI run; first-run seeding closes the gap with zero residue.
+- **Updating the badge only when coverage *increases*.** Turns the badge into a
+  high-water mark: after a regression it keeps advertising the best number ever
+  achieved, which is worse than a stale badge because it is precise, current-looking,
+  and wrong. Publish-on-change delivers the same update economy while staying honest;
+  if a ratchet is ever wanted, the honest form is a `c8 --check-coverage` floor that
+  fails CI (left open by ADR 064), not a badge that cannot go down.

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -57,11 +57,19 @@ function color(pct) {
   return '#e05d44';                    // red
 }
 function badge(label, message, fill) {
-  const w = s => Math.round(s.length * 6.4) + 12;
-  const lw = w(label), mw = w(message), total = lw + mw;
+  // Per-glyph advance widths for Verdana 11px (the badge's declared font at
+  // font-size 110 / scale .1). textLength is set to the MEASURED text width so
+  // renderers normalize spacing without compressing the glyphs; a flat
+  // per-char estimate undersizes wide glyphs like '%' and squeezes them
+  // together ("91%" needs ~25px, the old formula allotted 19px).
+  const CHAR_W = { '%': 11.0, '.': 4.0, ' ': 3.9, 'r': 4.7, 'c': 6.1, 'e': 6.7 };
+  const charW = ch => CHAR_W[ch] ?? (/[0-9]/.test(ch) ? 6.98 : /[A-Z]/.test(ch) ? 7.9 : 6.9);
+  const textW = s => Math.round([...s].reduce((sum, ch) => sum + charW(ch), 0));
+  const PAD = 10; // 5px horizontal padding each side of a text box
+  const lw = textW(label) + PAD, mw = textW(message) + PAD, total = lw + mw;
   const lx = Math.round((lw / 2) * 10);
   const mx = Math.round((lw + mw / 2) * 10);
-  const ltl = (lw - 12) * 10, mtl = (mw - 12) * 10;
+  const ltl = (lw - PAD) * 10, mtl = (mw - PAD) * 10;
   return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${total}" height="20" role="img" aria-label="${label}: ${message}">
   <title>${label}: ${message}</title>
   <linearGradient id="s" x2="0" y2="100%">


### PR DESCRIPTION
* ci: seed ci-badges from any branch; main republishes only on change
* docs(adr): 084 publish policy amendments
* fix(scripts): badge textLength = measured Verdana width, 5px padding