### PR TITLE
typed errors across core packages, enforced by lint

### DIFF
--- a/docs/adr/085-typed-error-policy.md
+++ b/docs/adr/085-typed-error-policy.md
@@ -1,0 +1,151 @@
+---
+title: "ADR 085: Typed Errors Across Core Packages, Enforced by Lint"
+---
+
+# ADR 085: Typed Errors Across Core Packages, Enforced by Lint
+
+**Status:** Accepted
+
+**Date:** 2026-07-17
+
+**Branch / PR:** `refactor/typed-errors`
+
+**References:** [ADR 050](050-split-aggregation-packages.md) (precedent for
+package-scoped ESLint guard blocks)
+
+## Context
+
+`@did-btcr2/common` defines a typed error hierarchy rooted at `DidMethodError`:
+every subclass carries a stable `name`, a machine-readable `type` string, and an
+optional structured `data` payload, and the constructor normalizes prototype
+chains and V8 stack capture. The method, aggregation, cryptosuite, keypair, and
+key-manager packages all build their domain errors on this hierarchy, and prior
+resolver hardening work added regression tests asserting that malformed input
+surfaces as a typed error rather than a bare `TypeError`.
+
+An audit of every error construction across the workspace found the hierarchy
+was almost, but not quite, universal. The stragglers:
+
+- **common**: `DateUtils` threw bare `Error` for invalid dates;
+  `JSONUtils.deepEqual`/`clone` threw bare `Error` for depth and circularity
+  guards; `JSONPatch.validateOperations` returned bare `Error` objects (which
+  `apply()` then wrapped); and `NotImplementedError` extended `Error` directly,
+  outside the hierarchy, with a one-off options-object constructor.
+- **aggregation**: `InboxBuffer` threw bare `Error` for an invalid capacity;
+  the service runner failed cohorts with `new Error(reason)` for TTL expiry,
+  phase stalls, and validation rejections; the participant HTTP client's
+  internal `sleep()` rejected with `new Error('aborted')`.
+- **method**: `Appendix.getVerificationMethods` threw a bare `TypeError` for a
+  missing `didDocument` parameter.
+
+The cost of these gaps is that callers cannot uniformly `catch` on
+`instanceof DidMethodError`, cannot inspect `.type`/`.data` on the escaping
+errors, and the error contract differs from the one the rest of the codebase
+documents and tests.
+
+## Decision
+
+### 1. Core-package sources construct only typed errors
+
+In `common`, `keypair`, `cryptosuite`, `key-manager`, `method`, and
+`aggregation`, every error object constructed in `src/` is a `DidMethodError`
+subclass (from common's `errors.ts` or a package error module built on it),
+with a SCREAMING_SNAKE `type` string and, where useful, a structured `data`
+payload. The audit's specific fixes:
+
+- `DateUtils` throws `MethodError(..., 'INVALID_DATE')`.
+- `JSONUtils` guards throw `MethodError(..., 'MAX_DEPTH_EXCEEDED')` and
+  `MethodError(..., 'CIRCULAR_STRUCTURE')`.
+- `JSONPatch.validateOperations` returns `MethodError | null` with type
+  `'JSON_PATCH_VALIDATION_ERROR'` (its wrapper `apply()` already threw
+  `MethodError`).
+- `InboxBuffer` throws
+  `AggregationServiceError(..., 'INVALID_INBOX_CAPACITY', { capacity })`.
+- The service runner fails cohorts with `AggregationCohortError` typed
+  `'COHORT_TTL_EXCEEDED'`, `'COHORT_PHASE_STALLED'`, or
+  `'VALIDATION_REJECTED'`, each carrying `{ cohortId }` (and the rejecting
+  participant DID where relevant).
+- The HTTP client's `sleep()` rejects with
+  `HttpTransportError('aborted', 'SLEEP_ABORTED')`. This rejection is internal
+  control flow (always caught inside the subscribe loops), but typing it keeps
+  the package rule exception-free and lintable.
+- `Appendix.getVerificationMethods` throws `DidDocumentError` for the missing
+  parameter.
+
+Error **messages** at every touched site are unchanged, so message-matching
+callers and tests are unaffected; only the class, `name`, and `type` surface
+changed.
+
+### 2. `NotImplementedError` joins the hierarchy
+
+`NotImplementedError` now extends `DidMethodError` and gains the same
+positional constructor shape as every other subclass:
+`(message, type = 'NotImplementedError', data?)`. The legacy options-object
+second argument is retained as a deprecated overload so the change stays
+within a minor version of `@did-btcr2/common`: common is a 9.x package on
+strict semver, and a major there forces a coordinated republish of every
+dependent (all pin `^9.x`, so a lone major would leave consumer trees with two
+common instances and a split error hierarchy). The overload is slated for
+removal at the next natural common major. The one in-repo call site that used
+the object form (the api package's `DidMethodApi.deactivate`) now passes the
+type string `'DID_API_METHOD_NOT_IMPLEMENTED'` positionally, and that error's
+`name` now equals its `type` (previously the two were set to different
+strings).
+
+### 3. A lint rule prevents regression
+
+A `no-restricted-syntax` ESLint block (following the ADR 050 precedent of
+package-scoped guard blocks in `eslint.config.cjs`) bans construction of bare
+`Error`, `TypeError`, `RangeError`, `SyntaxError`, `EvalError`,
+`ReferenceError`, and `URIError` in the six packages' `src/` trees. The rule
+matches any construction, not just throw statements, so returned and
+promise-rejected errors are covered too. Tests are out of scope: they may
+construct whatever they need.
+
+### 4. Explicit exclusions
+
+- **smt** keeps standard JS errors (`RangeError`, `Error`) by design: it is a
+  zero-dependency package and importing common's hierarchy would break that.
+- **api, bitcoin, cli** still contain bare error constructions (19 in api, 7
+  in bitcoin, 1 in cli at the time of this audit). Sweeping them is
+  deliberate follow-up work, after which the lint block's `files` list should
+  be extended to cover them.
+- **`@web5/dids` `DidError` sites in method** (capability-id validation in
+  `Appendix.dereferenceZcapId`, resolution error codes in `did-btcr2.ts`)
+  remain. These are typed errors pinned to W3C DID resolution semantics; they
+  are just not from common's hierarchy. Whether to migrate them is left as an
+  open question for a future ADR, since it changes a documented error contract
+  for no functional gain.
+
+## Consequences
+
+- Everything escaping the six core packages' own code is `instanceof
+  DidMethodError`, with `.type` and (where populated) `.data` available for
+  programmatic handling; cohort failures now carry `cohortId` instead of only
+  a prose reason string.
+- The touched sites changed error class and `name` (for example an invalid
+  date now surfaces `name: 'INVALID_DATE'` instead of `'Error'`). Callers
+  matching on classes or names, rather than messages, will observe the change.
+  All affected packages are 0.x; the change rides the next MINOR bumps.
+- `NotImplementedError` gains `instanceof DidMethodError`; broad
+  `catch (e) { if (e instanceof DidMethodError) ... }` handlers now also see
+  not-implemented errors. External callers using the options-object
+  constructor keep working through the deprecated overload.
+- The lint rule turns the policy from convention into CI enforcement; a future
+  bare `throw new Error(...)` in a covered package fails `pnpm lint`.
+- Follow-up: sweep api, bitcoin, and cli to typed errors and extend the lint
+  block; revisit the `@web5/dids` `DidError` question when that sweep lands.
+
+## Rejected Alternatives
+
+- **Dedicated classes per utility (`DateError`, `JsonError`, ...)**: two or
+  three throw sites each do not justify new exported classes; `MethodError`
+  plus a `type` string is the idiom common itself already used in
+  `JSONPatch.apply`.
+- **Repo-wide lint enforcement now**: api, bitcoin, and cli still contain bare
+  constructions, so a workspace-wide rule would fail CI until that sweep
+  lands; scoping the rule to the already-clean packages makes it land green
+  and ratchet forward.
+- **Migrating smt to common errors**: breaks the zero-dependency design for no
+  consumer benefit; smt's `RangeError` usage is conventional for a standalone
+  data-structure library.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -161,3 +161,4 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 082 | 2026-07-14 | [Per-Network Presets for Human-Facing Faucet and Explorer Links](082-network-presets.md) |
 | 083 | 2026-07-14 | [A btcr2 quickstart Command that Composes Onboarding into One Step](083-cli-quickstart.md) |
 | 084 | 2026-07-16 | [Publish the Coverage Badge from CI to a Dedicated Branch](084-ci-published-coverage-badge.md) |
+| 085 | 2026-07-17 | [Typed Errors Across Core Packages, Enforced by Lint](085-typed-error-policy.md) |

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -118,6 +118,27 @@ module.exports = [
     }
   },
   {
+    // Typed-error policy (ADR 085): core-package sources construct typed errors
+    // from the common DidMethodError hierarchy (or a package error module built
+    // on it), never bare built-in errors. smt is exempt by design (zero-dependency
+    // package, standard JS error types); the api/bitcoin/cli sweep is tracked as
+    // follow-up work in ADR 085.
+    files : [
+      'packages/common/src/**/*.ts',
+      'packages/keypair/src/**/*.ts',
+      'packages/cryptosuite/src/**/*.ts',
+      'packages/key-manager/src/**/*.ts',
+      'packages/method/src/**/*.ts',
+      'packages/aggregation/src/**/*.ts',
+    ],
+    rules : {
+      'no-restricted-syntax': ['error', {
+        selector : 'NewExpression[callee.name=/^(Error|TypeError|RangeError|SyntaxError|EvalError|ReferenceError|URIError)$/]',
+        message  : 'Construct a typed error from the DidMethodError hierarchy instead of a bare built-in error (ADR 085).',
+      }],
+    }
+  },
+  {
     ignores: [
       '**/*.js',
       '**/*.cjs',

--- a/packages/aggregation/CHANGELOG.md
+++ b/packages/aggregation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @did-btcr2/aggregation
 
+## 0.5.0
+
+### Minor Changes
+
+- Typed errors for every error constructed in `src/` (ADR 085):
+
+  - Cohort failures surface `AggregationCohortError` with types `COHORT_TTL_EXCEEDED`, `COHORT_PHASE_STALLED`, or `VALIDATION_REJECTED`, each carrying `cohortId` in `data` (validation rejections also carry the rejecting `participantDid`). Previously these were bare `Error(reason)`.
+  - `InboxBuffer` rejects an invalid capacity with `AggregationServiceError` (type `INVALID_INBOX_CAPACITY`, `data.capacity`).
+  - The participant HTTP client's internal sleep abort rejects with `HttpTransportError` (type `SLEEP_ABORTED`); this rejection never escapes the subscribe loops.
+
+  Reason strings are unchanged.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/common@9.2.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/aggregation/package.json
+++ b/packages/aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/aggregation",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Multi-party coordination for did:btcr2 aggregate beacons: sans-I/O AggregationService and AggregationParticipant state machines, MuSig2 (BIP-327) signing sessions, cohort conditions, and pluggable transports (Nostr, HTTP, in-memory).",
   "main": "./dist/cjs/index.js",

--- a/packages/aggregation/src/participant/http-client.ts
+++ b/packages/aggregation/src/participant/http-client.ts
@@ -388,7 +388,7 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     const onAbort = (): void => {
       clearTimeout(timer);
-      reject(new Error('aborted'));
+      reject(new HttpTransportError('aborted', 'SLEEP_ABORTED'));
     };
     const timer = setTimeout(() => {
       signal.removeEventListener('abort', onAbort);

--- a/packages/aggregation/src/service/inbox-buffer.ts
+++ b/packages/aggregation/src/service/inbox-buffer.ts
@@ -1,3 +1,5 @@
+import { AggregationServiceError } from '../core/errors.js';
+
 export interface StoredEvent {
   /** Monotonic ID assigned at append time. Stable across the buffer's lifetime. */
   id: string;
@@ -22,7 +24,7 @@ export class InboxBuffer {
   #nextId = 1;
 
   constructor(capacity = 100) {
-    if(capacity < 1) throw new Error(`InboxBuffer capacity must be >= 1; got ${capacity}`);
+    if(capacity < 1) throw new AggregationServiceError(`InboxBuffer capacity must be >= 1; got ${capacity}`, 'INVALID_INBOX_CAPACITY', { capacity });
     this.#capacity = capacity;
   }
 

--- a/packages/aggregation/src/service/service-runner.ts
+++ b/packages/aggregation/src/service/service-runner.ts
@@ -1,5 +1,5 @@
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
-import { AggregationServiceError } from '../core/errors.js';
+import { AggregationCohortError, AggregationServiceError } from '../core/errors.js';
 import type { BaseMessage } from '../core/messages/base.js';
 import {
   COHORT_OPT_IN,
@@ -447,7 +447,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       ctx.cohortTtlTimer = setTimeout(() => {
         const reason = `Cohort ${ctx.cohortId} exceeded TTL of ${this.#cohortTtlMs}ms`;
         this.emit('cohort-failed', { cohortId: ctx.cohortId, reason });
-        this.#failCohort(ctx, new Error(reason));
+        this.#failCohort(ctx, new AggregationCohortError(reason, 'COHORT_TTL_EXCEEDED', { cohortId: ctx.cohortId }));
       }, this.#cohortTtlMs);
     }
     this.#resetPhaseTimer(ctx);
@@ -470,7 +470,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       }
       const reason = `Cohort ${ctx.cohortId} stalled in phase ${ctx.lastObservedPhase ?? '?'} for ${this.#phaseTimeoutMs}ms`;
       this.emit('cohort-failed', { cohortId: ctx.cohortId, reason });
-      this.#failCohort(ctx, new Error(reason));
+      this.#failCohort(ctx, new AggregationCohortError(reason, 'COHORT_PHASE_STALLED', { cohortId: ctx.cohortId }));
     }, this.#phaseTimeoutMs);
   }
 
@@ -778,7 +778,7 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       if(phase === ServiceCohortPhase.Failed) {
         const reason = `Validation rejected by participant ${msg.from}`;
         this.emit('cohort-failed', { cohortId: ctx.cohortId, reason });
-        this.#failCohort(ctx, new Error(reason));
+        this.#failCohort(ctx, new AggregationCohortError(reason, 'VALIDATION_REJECTED', { cohortId: ctx.cohortId, participantDid: msg.from }));
         return;
       }
 

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @did-btcr2/api
 
+## 0.18.0
+
+### Minor Changes
+
+- `DidMethodApi.deactivate()` now rejects with a `NotImplementedError` whose `name` and `type` are both `DID_API_METHOD_NOT_IMPLEMENTED` (ADR 085); previously `name` was `NOT_IMPLEMENTED_ERROR` while `type` was `DID_API_METHOD_NOT_IMPLEMENTED`. The error is also now `instanceof DidMethodError` via the reparented `NotImplementedError` in `@did-btcr2/common`.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/common@9.2.0
+  - @did-btcr2/method@0.55.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -457,10 +457,7 @@ export class DidMethodApi {
   async deactivate(): Promise<SignedBTCR2Update> {
     throw new NotImplementedError(
       'DidMethodApi.deactivate is not implemented yet.',
-      {
-        type : 'DID_API_METHOD_NOT_IMPLEMENTED',
-        name : 'NOT_IMPLEMENTED_ERROR'
-      }
+      'DID_API_METHOD_NOT_IMPLEMENTED'
     );
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @did-btcr2/cli
 
+## 0.18.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.18.0
+  - @did-btcr2/common@9.2.0
+  - @did-btcr2/method@0.55.0
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @did-btcr2/common
+
+## 9.2.0
+
+### Minor Changes
+
+- Typed errors for the utility surface (ADR 085): every error constructed in `src/` is now a `DidMethodError` subclass.
+
+  - `DateUtils.toISOStringNonFractional` and `toUnixSeconds` throw `MethodError` with type `INVALID_DATE` (was bare `Error`).
+  - The `JSONUtils.deepEqual`/`clone` guards throw `MethodError` with types `MAX_DEPTH_EXCEEDED` and `CIRCULAR_STRUCTURE` (was bare `Error`).
+  - `JSONPatch.validateOperations` returns `MethodError` with type `JSON_PATCH_VALIDATION_ERROR` (was bare `Error`); its declared return type narrows from `Error | null` to `MethodError | null`.
+  - `NotImplementedError` now extends `DidMethodError` and gains the standard `(message, type?, data?)` constructor. The legacy options-object second argument remains as a deprecated overload, slated for removal at the next major.
+
+  Error messages are unchanged at every touched site; only the class, `name`, and `type` surfaces changed.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/common",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "type": "module",
   "description": "Common utilities, types, interfaces, etc. shared across the did-btcr2-js monorepo packages.",
   "main": "./dist/cjs/index.js",

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -159,25 +159,6 @@ type V8ErrorConstructor = ErrorConstructor & {
   captureStackTrace?: (target: object, ctor: Function) => void;
 };
 
-export class NotImplementedError extends Error {
-  override name: string = 'NotImplementedError';
-  type: string = 'NotImplementedError';
-
-  constructor(message: string, options: ErrorOptions = {}) {
-    super(message);
-    this.type = options.type ?? this.type;
-    this.name = options.name ?? this.name;
-
-    // Ensures that instanceof works properly, the correct prototype chain when using inheritance,
-    // and that V8 stack traces (like Chrome, Edge, and Node.js) are more readable and relevant.
-    Object.setPrototypeOf(this, new.target.prototype);
-
-    // Captures the stack trace in V8 engines (like Chrome, Edge, and Node.js).
-    // In non-V8 environments, the stack trace will still be captured.
-    (Error as V8ErrorConstructor).captureStackTrace?.(this, NotImplementedError);
-  }
-}
-
 export class DidMethodError extends Error {
   override name: string = 'DidMethodError';
   type: string = 'DidMethodError';
@@ -202,6 +183,22 @@ export class DidMethodError extends Error {
 export class MethodError extends DidMethodError {
   constructor(message: string, type: string = 'MethodError', data?: Record<string, any>) {
     super(message, { type, name: type, data });
+  }
+}
+
+export class NotImplementedError extends DidMethodError {
+  constructor(message: string, type?: string, data?: Record<string, any>);
+  /** @deprecated Pass the type string and data object positionally instead. */
+  constructor(message: string, options?: ErrorOptions);
+  constructor(message: string, typeOrOptions: string | ErrorOptions = 'NotImplementedError', data?: Record<string, any>) {
+    const opts: ErrorOptions = typeof typeOrOptions === 'string'
+      ? { type: typeOrOptions, name: typeOrOptions, data }
+      : {
+        type : typeOrOptions.type ?? 'NotImplementedError',
+        name : typeOrOptions.name ?? 'NotImplementedError',
+        data : typeOrOptions.data
+      };
+    super(message, opts);
   }
 }
 

--- a/packages/common/src/json-patch.ts
+++ b/packages/common/src/json-patch.ts
@@ -97,16 +97,16 @@ export class JSONPatch {
   /**
  * Validate JSON Patch operations.
  * @param {PatchOperation[]} operations - The operations to validate.
- * @returns {Error | null} An Error if validation fails, otherwise null.
+ * @returns {MethodError | null} A MethodError if validation fails, otherwise null.
  */
-  static validateOperations(operations: PatchOperation[]): Error | null {
-    if (!Array.isArray(operations)) return new Error('Operations must be an array');
+  static validateOperations(operations: PatchOperation[]): MethodError | null {
+    if (!Array.isArray(operations)) return new MethodError('Operations must be an array', 'JSON_PATCH_VALIDATION_ERROR');
     for (const op of operations) {
-      if (!op || typeof op !== 'object') return new Error('Operation must be an object');
-      if (typeof op.op !== 'string') return new Error('Operation.op must be a string');
-      if (typeof op.path !== 'string') return new Error('Operation.path must be a string');
+      if (!op || typeof op !== 'object') return new MethodError('Operation must be an object', 'JSON_PATCH_VALIDATION_ERROR');
+      if (typeof op.op !== 'string') return new MethodError('Operation.op must be a string', 'JSON_PATCH_VALIDATION_ERROR');
+      if (typeof op.path !== 'string') return new MethodError('Operation.path must be a string', 'JSON_PATCH_VALIDATION_ERROR');
       if ((op.op === 'move' || op.op === 'copy') && typeof op.from !== 'string') {
-        return new Error(`Operation.from must be a string for op=${op.op}`);
+        return new MethodError(`Operation.from must be a string for op=${op.op}`, 'JSON_PATCH_VALIDATION_ERROR');
       }
     }
     return null;

--- a/packages/common/src/utils/date.ts
+++ b/packages/common/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { MethodError } from '../errors.js';
+
 /**
  * Utility class for date-related operations.
  * @name DateUtils
@@ -12,7 +14,7 @@ export class DateUtils {
   static toISOStringNonFractional(date: Date = new Date()): string {
     const time = date.getTime();
     if (Number.isNaN(time)) {
-      throw new Error(`Invalid date: ${date}`);
+      throw new MethodError(`Invalid date: ${date}`, 'INVALID_DATE');
     }
     return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
   }
@@ -25,7 +27,7 @@ export class DateUtils {
   static toUnixSeconds(date: Date = new Date()): number {
     const time = date.getTime();
     if (Number.isNaN(time)) {
-      throw new Error(`Invalid date: ${date}`);
+      throw new MethodError(`Invalid date: ${date}`, 'INVALID_DATE');
     }
     return Math.floor(date.getTime() / 1000);
   }

--- a/packages/common/src/utils/json.ts
+++ b/packages/common/src/utils/json.ts
@@ -1,3 +1,4 @@
+import { MethodError } from '../errors.js';
 import type { JSONObject, Prototyped, Unprototyped } from '../types.js';
 
 /**
@@ -110,7 +111,7 @@ export class JSONUtils {
     depth: number = 0
   ): boolean {
     if (depth > 1024) {
-      throw new Error('Maximum comparison depth exceeded');
+      throw new MethodError('Maximum comparison depth exceeded', 'MAX_DEPTH_EXCEEDED');
     }
     if (Object.is(a, b)) return true;
 
@@ -256,7 +257,7 @@ export class JSONUtils {
     depth: number = 0
   ): any {
     if (depth > 1024) {
-      throw new Error('Maximum clone depth exceeded');
+      throw new MethodError('Maximum clone depth exceeded', 'MAX_DEPTH_EXCEEDED');
     }
     const transformed = options.transform ? options.transform(value) : value;
     if (transformed !== value) return transformed;
@@ -266,7 +267,7 @@ export class JSONUtils {
     }
 
     if (seen.has(value as object)) {
-      throw new Error('Cannot clone circular structure');
+      throw new MethodError('Cannot clone circular structure', 'CIRCULAR_STRUCTURE');
     }
 
     // Handle arrays and typed arrays

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @did-btcr2/method
 
+## 0.55.0
+
+### Minor Changes
+
+- `Appendix.getVerificationMethods` throws a typed `DidDocumentError` from `@did-btcr2/common` instead of a bare `TypeError` when called without a `didDocument` (ADR 085). Message unchanged.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/common@9.2.0
+
 ## 0.54.1
 
 ### Patch Changes

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.54.1",
+    "version": "0.55.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/utils/appendix.ts
+++ b/packages/method/src/utils/appendix.ts
@@ -7,6 +7,7 @@ import {
   DidErrorCode,
   DidVerificationRelationship
 } from '@web5/dids';
+import { DidDocumentError } from '@did-btcr2/common';
 import type { RootCapability } from '../core/interfaces.js';
 
 /**
@@ -66,10 +67,10 @@ export class Appendix {
    * Extracts the verification methods from a given DID Document.
    * @param didDocument The DID Document to extract the verification methods from
    * @returns An array of DidVerificationMethod objects
-   * @throws TypeError if the didDocument is not provided
+   * @throws {DidDocumentError} if the didDocument is not provided
    */
   public static getVerificationMethods(didDocument: DidDocument): DidVerificationMethod[] {
-    if (!didDocument) throw new TypeError(`Required parameter missing: 'didDocument'`);
+    if (!didDocument) throw new DidDocumentError(`Required parameter missing: 'didDocument'`);
     const verificationMethods: DidVerificationMethod[] = [];
     // Check the 'verificationMethod' array.
     verificationMethods.push(...didDocument.verificationMethod?.filter(Appendix.isDidVerificationMethod) ?? []);


### PR DESCRIPTION
* chore(release): common 9.2.0, method 0.55.0, aggregation 0.5.0, api 0.18.0, cli 0.18.1
* ci(lint): ban bare built-in errors in six core packages src
* fix(method): appendix missing didDocument throws DidDocumentError
* fix(api): deactivate passes NotImplementedError type positionally
* feat(aggregation): typed cohort-fail, inbox-capacity, abort errors
* feat(common): throw MethodError w/ type codes; add NotImplementedError to DidMethodError
* docs(adr): 085 typed-error policy; smt exempt; api/bitcoin/cli next