### PR TITLE
harden proof domain validation and resolver update processing

### DIFF
--- a/packages/api/tests/did-method-api-cas-policy.spec.ts
+++ b/packages/api/tests/did-method-api-cas-policy.spec.ts
@@ -514,7 +514,7 @@ describe('DidMethodApi resolve() SMT proof handling', () => {
     const smtRootHex = 'ab'.repeat(32);
     const signalTx = {
       vout   : [{ scriptpubkey_asm: `OP_RETURN OP_PUSHBYTES_32 ${smtRootHex}` }],
-      status : { block_height: 100, block_time: 1700000000 },
+      status : { confirmed: true, block_height: 100, block_time: 1700000000 },
     };
     const btcMock = {
       connection : {

--- a/packages/cryptosuite/src/data-integrity-proof/index.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/index.ts
@@ -123,29 +123,15 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
 
     // Check if the expectedDomain is defined
     if(expectedDomain) {
-      // Check if expectedDomain is an array with at least one entry
-      if(Array.isArray(expectedDomain) && expectedDomain.length) {
-        // Check that the domain arrays match in length
-        if(expectedDomain.length !== proof.domain?.length) {
-          // Else throw DataIntegrityProofError
-          throw new DataIntegrityProofError(
-            'Domain mismatch: expectedDomain length does not match proof.domain length',
-            PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
-          );
-        }
-        // Check that each entry in expectedDomain can be found in proof.domain
-        else if(expectedDomain.every(url => proof.domain?.includes(url))) {
-          // Else throw DataIntegrityProofError
-          throw new DataIntegrityProofError(
-            'Domain mismatch: expectedDomain and proof.domain do not match',
-            PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
-          );
-        }
-      }
-      // Else expectedDomain is a string, check that it matches proof.domain
-      else if(proof.domain !== expectedDomain) {
+      // Normalize both sides to arrays: proof.domain and expectedDomain may each
+      // be a single string or a list of strings.
+      const expectedDomains = Array.isArray(expectedDomain) ? expectedDomain : [expectedDomain];
+      const proofDomains = Array.isArray(proof.domain) ? proof.domain : (proof.domain ? [proof.domain] : []);
+
+      // Every expected domain must be present in the proof's domain list.
+      if(!expectedDomains.every(url => proofDomains.includes(url))) {
         throw new DataIntegrityProofError(
-          'Domain mismatch: proof.domain !== expectedDomain',
+          'Domain mismatch: expectedDomain not present in proof.domain',
           PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
         );
       }

--- a/packages/cryptosuite/tests/data-integrity-proof.spec.ts
+++ b/packages/cryptosuite/tests/data-integrity-proof.spec.ts
@@ -57,4 +57,58 @@ describe('Data Integrity Proof', () => {
       expect(verifiedProof.verified).to.be.true;
     });
   });
+
+  describe('verifyProof domain validation', () => {
+    // addProof mutates its inputs (attaches proof / proofValue in place), and the
+    // shared fixtures above are already secured by the time these tests run.
+    // Describe bodies execute at load time, so these captures are pristine.
+    const pristineDocument = { ...unsecuredDocument };
+    const pristineConfig = { ...config };
+
+    it('passes when the expected domain (string) matches proof.domain (string)', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, domain: 'https://example.com' }
+      );
+      const result = diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, 'https://example.com'
+      );
+      expect(result.verified).to.be.true;
+    });
+
+    it('passes when every expected domain is present in proof.domain (arrays)', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, domain: ['https://a.example', 'https://b.example'] }
+      );
+      const result = diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, ['https://a.example', 'https://b.example']
+      );
+      expect(result.verified).to.be.true;
+    });
+
+    it('passes when a single expected domain is one of several proof domains', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, domain: ['https://a.example', 'https://b.example'] }
+      );
+      const result = diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, 'https://b.example'
+      );
+      expect(result.verified).to.be.true;
+    });
+
+    it('throws when the expected domain is not present in proof.domain', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, domain: 'https://attacker.example' }
+      );
+      expect(() => diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, 'https://example.com'
+      )).to.throw(/Domain mismatch/);
+    });
+
+    it('throws when the proof carries no domain but one is expected', () => {
+      const securedDocument = diProof.addProof({ ...pristineDocument }, { ...pristineConfig });
+      expect(() => diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, 'https://example.com'
+      )).to.throw(/Domain mismatch/);
+    });
+  });
 });

--- a/packages/method/src/core/beacon/signal-discovery.ts
+++ b/packages/method/src/core/beacon/signal-discovery.ts
@@ -83,6 +83,13 @@ export class BeaconSignalDiscovery {
 
       // Iterate over each signal
       for (const beaconSignal of beaconSignals) {
+        // Skip unconfirmed (mempool) transactions: a beacon signal must be included
+        // in a block. Treating mempool txs as signals yields NaN confirmations and
+        // lets unconfirmed data drive resolution.
+        if(!beaconSignal.status.confirmed) {
+          continue;
+        }
+
         // Get the last vout in the transaction
         const signalVout = beaconSignal.vout.slice(-1)[0];
 

--- a/packages/method/src/core/interfaces.ts
+++ b/packages/method/src/core/interfaces.ts
@@ -46,6 +46,16 @@ export interface ResolutionOptions extends DidResolutionOptions {
    * document is well-formed, the resolver simply stopped at the caller's limit.
    */
   maxDiscoveryRounds?: number;
+
+  /**
+   * Minimum number of block confirmations a beacon signal's transaction must have
+   * before the resolver will act on it. Per the spec, defaults to 6 when not
+   * provided. Signals below the threshold are ignored: they neither apply, nor
+   * confirm duplicates, nor affect resolution metadata. Set a lower value (e.g. 1
+   * or 0) only on regtest/signet-style workflows where shallow confirmations are
+   * expected; on mainnet a low value makes resolution vulnerable to reorgs.
+   */
+  minConf?: number;
 }
 
 /**

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -50,6 +50,13 @@ export interface DidResolutionResponse {
   }
 }
 
+/**
+ * Default minimum block confirmations required before a beacon signal is
+ * considered valid, per the spec (6 when resolutionOptions.minConf is not
+ * provided). Signals below the threshold are ignored during resolution.
+ */
+export const DEFAULT_MIN_CONFIRMATIONS = 6;
+
 /** The resolver needs a genesis document whose hash matches genesisHash. */
 export interface NeedGenesisDocument {
   readonly kind: 'NeedGenesisDocument';
@@ -226,19 +233,28 @@ export class Resolver {
   #discoveryRounds = 0;
 
   /**
+   * Minimum block confirmations a beacon signal's transaction must have before the
+   * resolver will act on it. Defaults to {@link DEFAULT_MIN_CONFIRMATIONS} per the
+   * spec; overridable via ResolutionOptions.minConf.
+   */
+  readonly #minConf: number;
+
+  /**
    * @internal Use {@link DidBtcr2.resolve} to create instances.
    */
   constructor(
     didComponents: DidComponents,
     sidecarData: SidecarData,
     currentDocument: DidDocument | null,
-    options?: { versionId?: string; versionTime?: string; genesisDocument?: object; maxDiscoveryRounds?: number }
+    options?: { versionId?: string; versionTime?: string; genesisDocument?: object; maxDiscoveryRounds?: number; minConf?: number }
   ) {
     this.#didComponents = didComponents;
     this.#sidecarData = sidecarData;
     this.#currentDocument = currentDocument;
     this.#versionId = options?.versionId;
     this.#versionTime = options?.versionTime;
+    const minConf = options?.minConf;
+    this.#minConf = typeof minConf === 'number' && minConf >= 0 ? minConf : DEFAULT_MIN_CONFIRMATIONS;
     // Discovery is unbounded by default; a positive maxDiscoveryRounds opts into a
     // finite resource guard. A non-positive or omitted value means no limit.
     const rounds = options?.maxDiscoveryRounds;
@@ -367,6 +383,8 @@ export class Resolver {
    * @param {{ currentVersionId: number; updateHashHistory: HashBytes[] }} [resolutionState]
    *   Version counter and update-hash history carried from earlier discovery rounds.
    *   Standalone callers omit it and start fresh at version 1 with an empty history.
+   * @param {number} [minConf] Minimum confirmations a signal's transaction must have
+   *   to be processed. Defaults to {@link DEFAULT_MIN_CONFIRMATIONS} (spec default 6).
    * @returns {DidResolutionResponse} The updated DID Document, number of confirmations, and version id.
    */
   static updates(
@@ -375,7 +393,8 @@ export class Resolver {
     versionTime?: string,
     versionId?: string,
     resolutionState: { currentVersionId: number; updateHashHistory: HashBytes[] } =
-    { currentVersionId: 1, updateHashHistory: [] }
+    { currentVersionId: 1, updateHashHistory: [] },
+    minConf: number = DEFAULT_MIN_CONFIRMATIONS
   ): DidResolutionResponse {
     // Continue the version counter and update-hash history from earlier discovery
     // rounds so the whole resolution is one monotonic sequence, matching the spec's
@@ -402,13 +421,28 @@ export class Resolver {
 
     // Iterate over each (update block) pair
     for(const [update, block] of updates) {
+      // If resolutionOptions.versionId is defined and currentVersionId has reached
+      // it, return the current document. The spec evaluates this before processing
+      // each tuple; checking it here (rather than after an apply) is what makes
+      // time-travel resolution to an earlier version possible.
+      const versionIdNumber = Number(versionId);
+      if(!isNaN(versionIdNumber) && versionIdNumber <= currentVersionId) {
+        return response;
+      }
+
       // Get the hash of the current document as raw bytes
       const currentDocumentHash = canonicalHashBytes(response.didDocument);
 
       // Safely convert block.time to timestamp
       const blocktime = DateUtils.blocktimeToTimestamp(block.time);
 
-      // TODO: How to detect if block is unconfirmed and exit gracefully or return without it
+      // Spec: a beacon signal is only valid once its transaction is included in a
+      // block with at least minConf confirmations (6 when not provided). Signals
+      // below the threshold are not beacon signals: skip them so they neither
+      // apply, nor confirm duplicates, nor clobber resolution metadata. A later
+      // tuple that chains to a skipped update then correctly surfaces as a
+      // late-publishing error.
+      if(block.confirmations < minConf) continue;
 
       // Set the updated field to the blocktime of the current update
       response.metadata.updated = DateUtils.toISOStringNonFractional(blocktime);
@@ -486,12 +520,6 @@ export class Resolver {
 
       // Set response.versionId to be the new currentVersionId
       response.metadata.versionId = `${currentVersionId}`;
-
-      // If resolutionOptions.versionId is defined and <= currentVersionId, return currentDocument
-      const versionIdNumber = Number(versionId);
-      if(!isNaN(versionIdNumber) && versionIdNumber <= currentVersionId) {
-        return response;
-      }
 
       // Check if the current document is deactivated before further processing
       if(response.didDocument.deactivated) {
@@ -601,6 +629,20 @@ export class Resolver {
       throw new ResolveError('No verificationMethod found in update', INVALID_DID_UPDATE, update);
     }
 
+    // Spec "Check update.proof": the update's verificationMethod must be authorized
+    // for capabilityInvocation in the current document. A key listed only under
+    // verificationMethod (or another relationship) must not be able to authorize
+    // DID updates. Entries may be string references or embedded method objects.
+    const authorized = currentDocument.capabilityInvocation?.some(entry =>
+      typeof entry === 'string' ? entry === verificationMethodId : entry.id === verificationMethodId
+    );
+    if(!authorized) {
+      throw new ResolveError(
+        'Invalid update: verificationMethod is not authorized for capabilityInvocation',
+        INVALID_DID_UPDATE, { verificationMethodId, capabilityInvocation: currentDocument.capabilityInvocation }
+      );
+    }
+
     // Get the verificationMethod from the DID Document using the verificationMethodId.
     const vm = DidBtcr2.getSigningMethod(currentDocument, verificationMethodId);
 
@@ -632,6 +674,16 @@ export class Resolver {
 
     // Verify that updatedDocument is conformant to DID Core v1.1.
     DidDocument.validate(updatedDocument);
+
+    // Spec "Apply update": the patched document's id must equal the DID being
+    // resolved. Without this check an update could rebind the document to a
+    // different did:btcr2 identifier.
+    if(updatedDocument.id !== currentDocument.id) {
+      throw new ResolveError(
+        'Invalid update: updated document id does not match the resolved DID',
+        INVALID_DID_UPDATE, { expected: currentDocument.id, actual: updatedDocument.id }
+      );
+    }
 
     // Canonicalize and hash the updatedDocument to get the currentDocumentHash (raw bytes).
     const currentDocumentHash = canonicalHashBytes(updatedDocument);
@@ -720,8 +772,14 @@ export class Resolver {
           const allNeeds: Array<DataNeed> = [];
 
           for(const [service, signals] of this.#beaconServicesSignals) {
-            // Skip already-processed services and services with no signals
-            if(this.#processedServices.has(service.id) || !signals.length) continue;
+            // Skip already-processed services and services with no signals. The
+            // processed key combines the service id with its Bitcoin address: an
+            // update can rotate a beacon to a new address while keeping the same
+            // service id, and keying by id alone would skip the rotated address
+            // and silently drop every update announced on it.
+            const serviceAddress = BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string);
+            const serviceKey = `${service.id}|${serviceAddress}`;
+            if(this.#processedServices.has(serviceKey) || !signals.length) continue;
 
             // Establish a typed beacon and process its signals
             const beacon = BeaconFactory.establish(service);
@@ -733,7 +791,7 @@ export class Resolver {
             } else {
               // All signals for this service resolved, collect updates, mark processed
               this.#unsortedUpdates.push(...result.updates);
-              this.#processedServices.add(service.id);
+              this.#processedServices.add(serviceKey);
             }
           }
 
@@ -758,7 +816,8 @@ export class Resolver {
               this.#unsortedUpdates,
               this.#versionTime,
               this.#versionId,
-              { currentVersionId: this.#currentVersionId, updateHashHistory: this.#updateHashHistory }
+              { currentVersionId: this.#currentVersionId, updateHashHistory: this.#updateHashHistory },
+              this.#minConf
             );
             // updates() reports the version it reached via metadata.versionId; carry
             // it forward so the next round continues the monotonic sequence.

--- a/packages/method/src/did-btcr2.ts
+++ b/packages/method/src/did-btcr2.ts
@@ -131,7 +131,8 @@ export class DidBtcr2 implements DidMethod {
       versionId          : resolutionOptions.versionId,
       versionTime        : resolutionOptions.versionTime,
       genesisDocument    : resolutionOptions.sidecar?.genesisDocument,
-      maxDiscoveryRounds : resolutionOptions.maxDiscoveryRounds
+      maxDiscoveryRounds : resolutionOptions.maxDiscoveryRounds,
+      minConf            : resolutionOptions.minConf
     });
   }
 

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, INVALID_DID_UPDATE, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
 import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
-import { LocalSigner } from '@did-btcr2/keypair';
+import { LocalSigner, CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { BTCR2MerkleTree, hashToHex } from '@did-btcr2/smt';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -167,12 +167,13 @@ function buildUpdateChain(
 function driveSingleBeacon(
   did: string,
   updates: Array<SignedBTCR2Update>,
-  options?: { versionId?: string; versionTime?: string; times?: Array<number> }
+  options?: { versionId?: string; versionTime?: string; times?: Array<number>; minConf?: number; confirmations?: number }
 ): ReturnType<typeof driveDiscoveryChain> {
   const resolver = DidBtcr2.resolve(did, {
     sidecar : { updates },
     ...(options?.versionId ? { versionId: options.versionId } : {}),
-    ...(options?.versionTime ? { versionTime: options.versionTime } : {})
+    ...(options?.versionTime ? { versionTime: options.versionTime } : {}),
+    ...(options?.minConf !== undefined ? { minConf: options.minConf } : {})
   });
   let state = resolver.resolve();
   if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
@@ -182,7 +183,7 @@ function driveSingleBeacon(
   signals.set(genesis, updates.map((update, i) => ({
     tx            : {} as any,
     signalBytes   : canonicalHash(update, { encoding: 'hex' }),
-    blockMetadata : { height: 100 + i, time: options?.times?.[i] ?? (1700000000 + i), confirmations: 6 }
+    blockMetadata : { height: 100 + i, time: options?.times?.[i] ?? (1700000000 + i), confirmations: options?.confirmations ?? 6 }
   })));
   resolver.provide(need, signals);
   state = resolver.resolve();
@@ -1642,5 +1643,124 @@ describe('Resolver', () => {
       expect(updateNeed.updateHash).to.equal(craftedHashHex);
       expect(() => resolver.provide(updateNeed, crafted as any)).to.throw(/not a signed BTCR2 update/i);
     });
+  });
+});
+
+describe('Resolver security regressions (audit batch 1)', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+  const vmOf = (doc: DidDocument) => doc.verificationMethod![0]!;
+
+  it('H1: rejects an update signed by a key not authorized for capabilityInvocation', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+
+    // v2 adds a second verification method to the document but deliberately does
+    // NOT add it to capabilityInvocation.
+    const secret2 = secp256k1.utils.randomSecretKey();
+    const vm2 = {
+      id                 : `${fixture.did}#key-1`,
+      type               : 'Multikey',
+      controller         : fixture.did,
+      publicKeyMultibase : new CompressedSecp256k1PublicKey(secp256k1.getPublicKey(secret2, true)).multibase.encoded
+    };
+    const addVmPatch: PatchOperation[] = [{ op: 'add', path: '/verificationMethod/-', value: vm2 }];
+    const u2 = Updater.sign(fixture.did, Updater.construct(sourceDocument, addVmPatch, 1), vmOf(sourceDocument), signer1);
+    const doc2 = JSONPatch.apply(sourceDocument, addVmPatch) as DidDocument;
+
+    // v3 is a well-formed, validly signed update, but its signing key is only in
+    // verificationMethod, never authorized for capabilityInvocation.
+    const u3 = Updater.sign(fixture.did, Updater.construct(doc2, benignPatch(fixture.did), 2), vm2 as any, new LocalSigner(secret2));
+
+    expect(() => driveSingleBeacon(fixture.did, [u2, u3])).to.throw(/capabilityInvocation/i);
+  });
+
+  it('M1: rejects an update that rebinds the document id to a different DID', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+
+    // Updater.construct refuses id-changing patches, so an attacker hand-crafts
+    // the unsigned update; Updater.sign does not repeat the check.
+    const rebindPatch: PatchOperation[] = [{ op: 'replace', path: '/id', value: deterministicData[0].did }];
+    const targetDocument = JSONPatch.apply(sourceDocument, rebindPatch);
+    const unsigned = {
+      '@context'      : [
+        'https://w3id.org/security/v2',
+        'https://w3id.org/zcap/v1',
+        'https://w3id.org/json-ld-patch/v1',
+        'https://btcr2.dev/context/v1'
+      ],
+      patch           : rebindPatch,
+      targetHash      : canonicalHash(targetDocument),
+      targetVersionId : 2,
+      sourceHash      : canonicalHash(sourceDocument),
+    };
+    const u2 = Updater.sign(fixture.did, unsigned, vmOf(sourceDocument), signer1);
+
+    expect(() => driveSingleBeacon(fixture.did, [u2])).to.throw(/does not match the resolved DID/i);
+  });
+
+  it('M2: versionId "1" returns the genesis document even when updates exist', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did), benignPatch(fixture.did)]);
+
+    const resolved = driveSingleBeacon(fixture.did, updates, { versionId: '1' });
+    expect(resolved.metadata.versionId).to.equal('1');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length);
+  });
+
+  it('M2: versionId "2" returns exactly the v2 document', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did), benignPatch(fixture.did)]);
+
+    const resolved = driveSingleBeacon(fixture.did, updates, { versionId: '2' });
+    expect(resolved.metadata.versionId).to.equal('2');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length + 1);
+  });
+
+  it('M3: processes updates announced on a rotated beacon address with the same service id', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+
+    // v2 rotates the genesis beacon to a new address but keeps the service id.
+    const secret = new Uint8Array(32);
+    secret[31] = 42;
+    const rotatedAddress = p2wpkh(secp256k1.getPublicKey(secret, true), getNetwork('regtest')).address!;
+    const genesisAddress = BeaconUtils.parseBitcoinAddress(sourceDocument.service[0]!.serviceEndpoint as string);
+
+    const rotatePatch: PatchOperation[] = [{ op: 'replace', path: '/service/0/serviceEndpoint', value: `bitcoin:${rotatedAddress}` }];
+    const u2 = Updater.sign(fixture.did, Updater.construct(sourceDocument, rotatePatch, 1), vmOf(sourceDocument), signer1);
+    const doc2 = JSONPatch.apply(sourceDocument, rotatePatch) as DidDocument;
+
+    // v3 is discoverable only on the rotated address, in a second discovery round.
+    const u3 = Updater.sign(fixture.did, Updater.construct(doc2, benignPatch(fixture.did), 2), vmOf(sourceDocument), signer1);
+
+    const signalByAddress = new Map<string, string>([
+      [genesisAddress, canonicalHash(u2, { encoding: 'hex' })],
+      [rotatedAddress, canonicalHash(u3, { encoding: 'hex' })]
+    ]);
+
+    const resolved = driveDiscoveryChain(fixture.did, [u2, u3], signalByAddress);
+    // v3 must have been applied; before the fix the rotated address was skipped
+    // and resolution completed silently at version 2.
+    expect(resolved.metadata.versionId).to.equal('3');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length + 1);
+  });
+
+  it('M4: ignores a signal below the default minConf threshold', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did)]);
+
+    const resolved = driveSingleBeacon(fixture.did, updates, { confirmations: 3 });
+    expect(resolved.metadata.versionId).to.equal('1');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length);
+  });
+
+  it('M4: applies a shallow signal when the caller lowers minConf', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did)]);
+
+    const resolved = driveSingleBeacon(fixture.did, updates, { confirmations: 3, minConf: 1 });
+    expect(resolved.metadata.versionId).to.equal('2');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length + 1);
   });
 });

--- a/packages/method/tests/signal-discovery.spec.ts
+++ b/packages/method/tests/signal-discovery.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { extractOpReturnSignal } from '../src/core/beacon/signal-discovery.js';
+import type { BitcoinConnection } from '@did-btcr2/bitcoin';
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { p2wpkh } from '@scure/btc-signer';
+import { BeaconSignalDiscovery, extractOpReturnSignal } from '../src/core/beacon/signal-discovery.js';
+import type { BeaconService } from '../src/core/beacon/interfaces.js';
 
 /**
  * Beacon signal extraction from a scriptPubKey asm string.
@@ -70,5 +75,49 @@ describe('extractOpReturnSignal', () => {
     // OP_RETURN must be the first token of a NULL_DATA output; a script that merely
     // contains the keyword elsewhere is not a beacon signal.
     expect(extractOpReturnSignal(`OP_DUP OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(null);
+  });
+});
+
+describe('BeaconSignalDiscovery.indexer', () => {
+  const SIGNAL_HEX = 'ab'.repeat(32);
+  const SIGNAL_ASM = `OP_RETURN OP_PUSHBYTES_32 ${SIGNAL_HEX}`;
+
+  const secret = new Uint8Array(32);
+  secret[31] = 7;
+  const address = p2wpkh(secp256k1.getPublicKey(secret, true), getNetwork('regtest')).address!;
+
+  const service: BeaconService = {
+    id              : 'did:btcr2:x#beacon-0',
+    type            : 'SingletonBeacon',
+    serviceEndpoint : `bitcoin:${address}`
+  };
+
+  /** Minimal BitcoinConnection stub: fixed tip height, canned address transactions. */
+  function mockBitcoin(txs: Array<unknown>): BitcoinConnection {
+    return {
+      rest : {
+        block   : { count: async () => 105 },
+        address : { getTxs: async () => txs }
+      }
+    } as unknown as BitcoinConnection;
+  }
+
+  it('skips mempool (unconfirmed) transactions', async () => {
+    const txs = [{ vout: [{ scriptpubkey_asm: SIGNAL_ASM }], status: { confirmed: false } }];
+    const signals = await BeaconSignalDiscovery.indexer([service], mockBitcoin(txs));
+    expect(signals.get(service)).to.have.lengthOf(0);
+  });
+
+  it('accepts confirmed transactions and computes confirmations from the tip', async () => {
+    const txs = [{
+      vout   : [{ scriptpubkey_asm: SIGNAL_ASM }],
+      status : { confirmed: true, block_height: 100, block_time: 1700000000 }
+    }];
+    const signals = await BeaconSignalDiscovery.indexer([service], mockBitcoin(txs));
+    const found = signals.get(service)!;
+    expect(found).to.have.lengthOf(1);
+    expect(found[0].signalBytes).to.equal(SIGNAL_HEX);
+    expect(found[0].blockMetadata.confirmations).to.equal(6);
+    expect(found[0].blockMetadata.height).to.equal(100);
   });
 });


### PR DESCRIPTION
* fix(cryptosuite): correct inverted expectedDomain check in verifyProof (audit H2)
* fix(method): enforce capabilityInvocation authz, id binding, versionId order, beacon rotation, minConf (audit H1, M1-M4)