### PR TITLE
stop secret-key leakage and tighten key/proof handling

### DIFF
--- a/packages/cryptosuite/src/cryptosuite/index.ts
+++ b/packages/cryptosuite/src/cryptosuite/index.ts
@@ -71,23 +71,26 @@ export class BIP340Cryptosuite implements Cryptosuite {
     document: UnsecuredDocument,
     config: DataIntegrityProofOptions
   ): DataIntegrityProofObject {
-    // Set the context using the document context or the existing config context
-    config['@context'] = (document['@context'] as string | string[] | undefined) ?? config['@context'];
+    // Build the proof as a fresh object: the caller's config is neither mutated
+    // nor aliased into the returned proof, so post-hoc mutation of the caller's
+    // config cannot alter the secured document (and vice versa).
+    const proof: DataIntegrityProofObject = {
+      ...config,
+      // Set the context using the document context or the existing config context
+      '@context' : (document['@context'] as string | string[] | undefined) ?? config['@context'],
+    } as DataIntegrityProofObject;
 
     // Create a canonical form of the proof configuration
-    const canonicalConfig = this.proofConfiguration(config);
+    const canonicalConfig = this.proofConfiguration(proof);
 
     // Transform the document into a canonical form
-    const canonicalDocument = this.transformDocument(document, config);
+    const canonicalDocument = this.transformDocument(document, proof);
 
     // Generate a hash of the canonical proof configuration and canonical document
     const hash = this.generateHash(canonicalConfig, canonicalDocument);
 
     // Serialize the proof
-    const serialized = this.proofSerialization(hash, config);
-
-    // Cast the config to a data integrity proof object
-    const proof = config as DataIntegrityProofObject;
+    const serialized = this.proofSerialization(hash, proof);
 
     // Encode the proof bytes to base58btc
     proof.proofValue = base58btc.encode(serialized);
@@ -210,6 +213,16 @@ export class BIP340Cryptosuite implements Cryptosuite {
       if(!DateUtils.isValidXsdDateTime(config.created))
         throw new CryptosuiteError(
           'Invalid config: "created" must be a valid XMLSchema DateTime string',
+          PROOF_GENERATION_ERROR, config
+        );
+    }
+
+    // Check if config.expires is defined
+    if(config.expires) {
+      // Check if config.expires is a valid XMLSchema DateTime string, if not throw CryptosuiteError
+      if(!DateUtils.isValidXsdDateTime(config.expires))
+        throw new CryptosuiteError(
+          'Invalid config: "expires" must be a valid XMLSchema DateTime string',
           PROOF_GENERATION_ERROR, config
         );
     }

--- a/packages/cryptosuite/src/data-integrity-proof/index.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/index.ts
@@ -1,4 +1,4 @@
-import { DataIntegrityProofError, PROOF_GENERATION_ERROR, PROOF_VERIFICATION_ERROR } from '@did-btcr2/common';
+import { DataIntegrityProofError, DateUtils, PROOF_GENERATION_ERROR, PROOF_VERIFICATION_ERROR } from '@did-btcr2/common';
 import type { BIP340Cryptosuite } from '../cryptosuite/index.js';
 import type { VerificationResult } from '../cryptosuite/interface.js';
 import type { DataIntegrityProof, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from './interface.js';
@@ -61,11 +61,10 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
         );
     }
 
-    // Attach the proof, securing the document
-    const signedDocument = unsignedDocument as SecuredDocument<T>;
-
-    // Set the proof in the document and return the secured document
-    signedDocument.proof = proof;
+    // Attach the proof to a fresh copy of the document, securing it. The caller's
+    // document is not mutated in place, so a proof object can never be retroactively
+    // swapped onto (or off of) a document the caller still holds.
+    const signedDocument = { ...unsignedDocument, proof } as SecuredDocument<T>;
 
     // Return the secured document
     return signedDocument;
@@ -133,6 +132,24 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
         throw new DataIntegrityProofError(
           'Domain mismatch: expectedDomain not present in proof.domain',
           PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
+        );
+      }
+    }
+
+    // Check if the proof carries an expiry
+    if(proof.expires) {
+      // Validate the format
+      if(!DateUtils.isValidXsdDateTime(proof.expires)) {
+        throw new DataIntegrityProofError(
+          'Invalid proof: "expires" must be a valid XMLSchema DateTime string',
+          PROOF_VERIFICATION_ERROR, { proof }
+        );
+      }
+      // A captured proof must not verify past its expiry
+      if(DateUtils.dateStringToTimestamp(proof.expires).getTime() <= Date.now()) {
+        throw new DataIntegrityProofError(
+          'Proof expired: current time is past proof.expires',
+          PROOF_VERIFICATION_ERROR, { proof }
         );
       }
     }

--- a/packages/cryptosuite/src/multikey/index.ts
+++ b/packages/cryptosuite/src/multikey/index.ts
@@ -1,7 +1,7 @@
 import type { Bytes, SignatureBytes } from '@did-btcr2/common';
 import { MultikeyError, VERIFICATION_METHOD_ERROR } from '@did-btcr2/common';
 import type { Signer } from '@did-btcr2/keypair';
-import { CompressedSecp256k1PublicKey, SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
+import { CompressedSecp256k1PublicKey, SchnorrKeyPair, Secp256k1SecretKey, wipe } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1';
 import type { DidVerificationMethod } from '@web5/dids';
 import { randomBytes } from '@noble/hashes/utils';
@@ -164,7 +164,13 @@ export class SchnorrMultikey implements Multikey {
       throw new MultikeyError('Cannot sign: no secretKey', 'SIGN_ERROR');
     }
 
-    return schnorr.sign(data, this.secretKey.bytes, randomBytes(32));
+    const secretBytes = this.secretKey.bytes;
+    try {
+      return schnorr.sign(data, secretBytes, randomBytes(32));
+    } finally {
+      // Wipe the transient copy pulled from the secret key for this call
+      wipe(secretBytes);
+    }
   }
 
   /**
@@ -212,10 +218,29 @@ export class SchnorrMultikey implements Multikey {
   }
 
   /**
-   * Convert the multikey to a JSON object.
-   * @returns {MultikeyObject} The multikey as a JSON object.
+   * Safe JSON representation. Only includes public material: the embedded keyPair
+   * serializes public-key-only. Called implicitly by JSON.stringify().
+   * Use {@link exportJSON} for full serialization including the secret key.
+   * @returns {MultikeyObject} The multikey as a JSON object (public material only).
    */
   public toJSON(): MultikeyObject {
+    return {
+      id                 : this.id,
+      controller         : this.controller,
+      fullId             : this.fullId(),
+      signer             : this.signer,
+      keyPair            : this.keyPair.toJSON(),
+      verificationMethod : this.toVerificationMethod()
+    };
+  }
+
+  /**
+   * Exports the full multikey as a JSON object. Contains secret key material:
+   * the result must never appear in logs, error payloads, or telemetry.
+   * @returns {MultikeyObject} The multikey as a JSON object including the secret key.
+   * @throws {KeyPairError} If the keyPair carries no secret key.
+   */
+  public exportJSON(): MultikeyObject {
     return {
       id                 : this.id,
       controller         : this.controller,

--- a/packages/cryptosuite/src/multikey/interface.ts
+++ b/packages/cryptosuite/src/multikey/interface.ts
@@ -1,13 +1,18 @@
-import type { KeyBytes, MessageBytes, SchnorrKeyPairObject, SignatureBytes } from '@did-btcr2/common';
+import type { KeyBytes, MessageBytes, PublicKeyObject, SchnorrKeyPairObject, SignatureBytes } from '@did-btcr2/common';
 import type { CompressedSecp256k1PublicKey, SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
 import type { DidVerificationMethod } from '@web5/dids';
 
+/**
+ * JSON shape of a SchnorrMultikey. `keyPair` is public-key-only when produced by
+ * `SchnorrMultikey.toJSON()` (the safe, implicit serialization) and carries the
+ * full secret material only when produced by the explicit `exportJSON()`.
+ */
 export type MultikeyObject = {
   id: string;
   controller: string;
   fullId: string;
   signer: boolean;
-  keyPair: SchnorrKeyPairObject;
+  keyPair: SchnorrKeyPairObject | { publicKey: PublicKeyObject };
   verificationMethod: DidVerificationMethod;
 }
 export interface DidParams {

--- a/packages/cryptosuite/tests/data-integrity-proof.spec.ts
+++ b/packages/cryptosuite/tests/data-integrity-proof.spec.ts
@@ -111,4 +111,63 @@ describe('Data Integrity Proof', () => {
       )).to.throw(/Domain mismatch/);
     });
   });
+
+  describe('expiry enforcement (audit L3)', () => {
+    const pristineDocument = { ...unsecuredDocument };
+    const pristineConfig = { ...config };
+
+    it('verifies a proof whose expires is in the future', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, expires: '2999-01-01T00:00:00Z' }
+      );
+      const result = diProof.verifyProof(JSON.stringify(securedDocument), 'attestationMethod');
+      expect(result.verified).to.be.true;
+    });
+
+    it('throws for a proof whose expires is in the past', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, expires: '2020-01-01T00:00:00Z' }
+      );
+      expect(() => diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod'
+      )).to.throw(/expired/);
+    });
+
+    it('throws for a malformed expires', () => {
+      // addProof validates the format at generation, so tamper post-signing
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, expires: '2999-01-01T00:00:00Z' }
+      );
+      securedDocument.proof.expires = 'not-a-date';
+      expect(() => diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod'
+      )).to.throw(/expires/);
+    });
+  });
+
+  describe('input isolation (audit L4)', () => {
+    it('addProof mutates neither the caller document nor the caller config', () => {
+      const doc = { ...unsecuredDocument };
+      const cfg = { ...config };
+
+      const secured = diProof.addProof(doc, cfg);
+
+      // The returned document carries the proof...
+      expect(secured).to.have.property('proof');
+      expect(secured.proof).to.have.property('proofValue');
+
+      // ...but the caller's objects are untouched
+      expect(doc).to.not.have.property('proof');
+      expect(cfg).to.not.have.property('proofValue');
+    });
+
+    it('mutating the caller config after addProof does not alter the secured proof', () => {
+      const cfg = { ...config, domain: 'https://example.com' };
+      const secured = diProof.addProof({ ...unsecuredDocument }, cfg);
+
+      cfg.domain = 'https://attacker.example';
+
+      expect(secured.proof.domain).to.equal('https://example.com');
+    });
+  });
 });

--- a/packages/cryptosuite/tests/multikey.spec.ts
+++ b/packages/cryptosuite/tests/multikey.spec.ts
@@ -414,3 +414,31 @@ describe('SchnorrMultikey', () => {
     });
   });
 });
+describe('serialization safety (audit H3)', () => {
+  const skBytes = new Uint8Array([
+    69, 112, 198, 176,  14, 103, 100,  73,
+    35, 179, 169,  83,  80, 213, 189, 190,
+    118, 200,   5,  43,  20,  46, 148,  60,
+    109,  37, 134, 164, 162, 174, 185, 201
+  ]);
+  const id = '#initialKey';
+  const controller = 'did:btcr2:k1qqpkyr20hr2ugzcdctulmprrdkz5slj3an64l0x4encgc6kpfz7g5dsaaw53r';
+
+  it('toJSON never exposes secret key material', () => {
+    const multikey = new SchnorrMultikey({ id, controller, keyPair: new SchnorrKeyPair({ secretKey: skBytes }) });
+    const json = multikey.toJSON();
+    expect(json.keyPair).to.not.have.property('secretKey');
+
+    // JSON.stringify path (implicit toJSON) must also be safe
+    const stringified = JSON.stringify(multikey);
+    expect(stringified).to.not.include('secretKey');
+    expect(stringified).to.not.include(Buffer.from(skBytes).toString('hex'));
+  });
+
+  it('exportJSON explicitly includes the secret key', () => {
+    const multikey = new SchnorrMultikey({ id, controller, keyPair: new SchnorrKeyPair({ secretKey: skBytes }) });
+    const exported = multikey.exportJSON();
+    expect(exported.keyPair).to.have.property('secretKey');
+    expect((exported.keyPair as any).secretKey.hex).to.equal(Buffer.from(skBytes).toString('hex'));
+  });
+});

--- a/packages/key-manager/src/local-key-manager.ts
+++ b/packages/key-manager/src/local-key-manager.ts
@@ -120,7 +120,8 @@ export class LocalKeyManager implements KeyManager {
    * @throws {KeyManagerError} If key not found or no active key set.
    */
   getPublicKey(id?: KeyIdentifier): KeyBytes {
-    return this.#getEntryOrThrow(id).publicKey;
+    // Return a copy so callers cannot mutate the store's key material in place
+    return new Uint8Array(this.#getEntryOrThrow(id).publicKey);
   }
 
   /**
@@ -132,7 +133,8 @@ export class LocalKeyManager implements KeyManager {
    */
   getEntry(id?: KeyIdentifier): { publicKey: KeyBytes; tags?: Record<string, string> } {
     const entry = this.#getEntryOrThrow(id);
-    return { publicKey: entry.publicKey, ...(entry.tags && { tags: entry.tags }) };
+    // Copies only: callers must not be able to mutate store state in place
+    return { publicKey: new Uint8Array(entry.publicKey), ...(entry.tags && { tags: { ...entry.tags } }) };
   }
 
   /**

--- a/packages/key-manager/tests/local-key-manager.spec.ts
+++ b/packages/key-manager/tests/local-key-manager.spec.ts
@@ -335,3 +335,32 @@ describe('LocalKeyManager', () => {
     });
   });
 });
+
+describe('store buffer isolation (audit L1)', () => {
+  it('getPublicKey returns a copy: mutating it does not corrupt the store', () => {
+    const kms = new LocalKeyManager();
+    const kp = SchnorrKeyPair.generate();
+    const id = kms.importKey(kp);
+
+    const fetched = kms.getPublicKey(id);
+    const original = new Uint8Array(fetched);
+    fetched[0]! ^= 0xff;
+
+    expect(kms.getPublicKey(id)).to.deep.equal(original);
+  });
+
+  it('getEntry returns a copy: mutating it does not corrupt the store', () => {
+    const kms = new LocalKeyManager();
+    const kp = SchnorrKeyPair.generate();
+    const id = kms.importKey(kp, { tags: { label: 'original' } });
+
+    const entry = kms.getEntry(id);
+    const original = new Uint8Array(entry.publicKey);
+    entry.publicKey[0]! ^= 0xff;
+    entry.tags!.label = 'tampered';
+
+    const again = kms.getEntry(id);
+    expect(again.publicKey).to.deep.equal(original);
+    expect(again.tags!.label).to.equal('original');
+  });
+});

--- a/packages/keypair/src/pair.ts
+++ b/packages/keypair/src/pair.ts
@@ -95,9 +95,9 @@ export class SchnorrKeyPair implements KeyPair {
     if(!this.#secretKey.isValid()) {
       throw new KeyPairError('Secret key is not valid', 'SECRET_KEY_ERROR');
     }
-    // Return a copy of the secret key
-    const secret = this.#secretKey;
-    return secret;
+    // Return a copy of the secret key so a caller cannot destroy() or otherwise
+    // affect the keypair's stored secret through the getter.
+    return new Secp256k1SecretKey(this.#secretKey.bytes);
   }
 
   /**

--- a/packages/keypair/src/public.ts
+++ b/packages/keypair/src/public.ts
@@ -295,7 +295,9 @@ export class CompressedSecp256k1PublicKey implements PublicKey {
   }
 
   /**
-   * Verify a signature using schnorr or ecdsa.
+   * Verify a signature using schnorr or ecdsa. For 'ecdsa', the signature must be
+   * DER-encoded and low-S and `data` must already be the 32-byte sighash, matching
+   * the {@link signWithScheme} contract (`prehash: false`).
    * @param {SignatureBytes} signature Signature for verification.
    * @param {string} data Data for verification.
    * @param {CryptoOptions} opts Options for signing.
@@ -307,7 +309,7 @@ export class CompressedSecp256k1PublicKey implements PublicKey {
     opts ??= { scheme: 'schnorr' };
 
     if(opts.scheme === 'ecdsa') {
-      return secp256k1.verify(signature, data, this.compressed);
+      return secp256k1.verify(signature, data, this.compressed, { format: 'der', lowS: true, prehash: false });
     }
     else if(opts.scheme === 'schnorr') {
       return schnorr.verify(signature, data, this.x);

--- a/packages/keypair/src/secret.ts
+++ b/packages/keypair/src/secret.ts
@@ -17,6 +17,7 @@ import { base58 } from '@scure/base';
 import { CompressedSecp256k1PublicKey } from './public.js';
 import type { CryptoOptions } from './types.js';
 import { equalBytes } from '@noble/curves/utils.js';
+import { wipe } from './utils.js';
 
 /** Fixed secret key header bytes per the Data Integrity BIP340 Cryptosuite spec: [0x81, 0x26] */
 const BIP340_SECRET_KEY_MULTIBASE_PREFIX: Bytes = new Uint8Array([0x81, 0x26]);
@@ -133,7 +134,10 @@ export class Secp256k1SecretKey implements SecretKey {
   }
 
   /**
-   * Zeros out secret key material from memory.
+   * Best-effort zeroization of the secret key bytes held by this instance.
+   * The bigint seed and any strings or byte copies previously returned (hex,
+   * multibase, exportJSON output) are immutable or caller-owned JS values that
+   * cannot be reclaimed here; treat those as live until garbage-collected.
    * The instance should not be used after calling this method.
    */
   public destroy(): void {
@@ -262,7 +266,9 @@ export class Secp256k1SecretKey implements SecretKey {
 
   /**
    * Produce a signature over arbitrary data using schnorr or ecdsa.
-   * @param {MessageBytes} data Data to be signed.
+   * @param {MessageBytes} data Data to be signed. For 'ecdsa', `data` must already
+   *   be the 32-byte sighash: the contract matches {@link signWithScheme}
+   *   (DER-encoded, low-S, `prehash: false`).
    * @param {CryptoOptions} opts Options for signing.
    * @param {('ecdsa' | 'schnorr')} opts.scheme The signature scheme to use. Default is 'schnorr'.
    * @returns {SignatureBytes} Signature byte array.
@@ -272,21 +278,28 @@ export class Secp256k1SecretKey implements SecretKey {
     // Set default options if not provided
     opts ??= { scheme: 'schnorr' };
 
-    if(opts.scheme === 'ecdsa') {
-      return secp256k1.sign(data, this.bytes);
-    }
+    // Copy once, wipe the copy on all exit paths
+    const keyBytes = this.bytes;
+    try {
+      if(opts.scheme === 'ecdsa') {
+        return secp256k1.sign(data, keyBytes, { format: 'der', lowS: true, prehash: false });
+      }
 
-    if(opts.scheme === 'schnorr') {
-      return schnorr.sign(data, this.bytes);
+      if(opts.scheme === 'schnorr') {
+        return schnorr.sign(data, keyBytes);
+      }
+    } finally {
+      wipe(keyBytes);
     }
 
     throw new SecretKeyError(`Invalid scheme: ${opts.scheme}.`, 'SIGN_ERROR', opts);
   }
 
   /**
-   * Decodes the multibase string to the 34-byte secret key (2 byte prefix + 32 byte key).
+   * Decodes the multibase string to the 32-byte secret key (multicodec prefix
+   * validated and stripped).
    * @param {string} multibase The multibase string to decode
-   * @returns {Bytes} The decoded secret key.
+   * @returns {Bytes} The 32-byte secret key.
    */
   public static decode(multibase: string): Bytes {
     // Decode the public key multibase string
@@ -314,8 +327,8 @@ export class Secp256k1SecretKey implements SecretKey {
       );
     }
 
-    // Return the decoded key bytes
-    return decoded;
+    // Return the decoded key bytes with the 2-byte multicodec prefix stripped
+    return decoded.slice(2);
   }
 
   /**

--- a/packages/keypair/src/signer.ts
+++ b/packages/keypair/src/signer.ts
@@ -4,6 +4,7 @@ import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { randomBytes } from '@noble/hashes/utils.js';
 import { taprootTweakPrivKey } from '@scure/btc-signer/utils.js';
 import { Secp256k1SecretKey } from './secret.js';
+import { wipe } from './utils.js';
 
 /**
  * Sign `data` with a 32-byte raw secret key under the requested scheme. The
@@ -52,7 +53,12 @@ export function signWithScheme(
       secretKey,
       opts?.merkleRoot ?? new Uint8Array(0),
     );
-    return schnorr.sign(data, tweaked, randomBytes(32));
+    try {
+      return schnorr.sign(data, tweaked, randomBytes(32));
+    } finally {
+      // The tweaked key is fresh secret material derived for this call only
+      wipe(tweaked);
+    }
   }
   throw new KeyPairError(
     `signWithScheme: unsupported signing scheme: ${scheme as string}`,
@@ -173,6 +179,12 @@ export class LocalSigner implements Signer {
    * place so this signer and `LocalKeyManager` cannot drift.
    */
   sign(data: Bytes, scheme: SigningScheme, opts?: SignOptions): SignatureBytes {
-    return signWithScheme(this.#secretKey.bytes, data, scheme, opts);
+    const secretBytes = this.#secretKey.bytes;
+    try {
+      return signWithScheme(secretBytes, data, scheme, opts);
+    } finally {
+      // Wipe the transient copy pulled from the secret key for this call
+      wipe(secretBytes);
+    }
   }
 }

--- a/packages/keypair/tests/pair.spec.ts
+++ b/packages/keypair/tests/pair.spec.ts
@@ -199,3 +199,18 @@ describe('SchnorrKeyPair instantiated', () => {
     });
   });
 });
+describe('secretKey getter isolation (audit L6)', () => {
+  it('returns a distinct instance on each access', () => {
+    const kp = SchnorrKeyPair.generate();
+    expect(kp.secretKey).to.not.equal(kp.secretKey);
+  });
+
+  it('destroy() on a returned copy does not affect the keypair', () => {
+    const kp = SchnorrKeyPair.generate();
+    const leaked = kp.secretKey;
+    leaked.destroy();
+    // The keypair's stored secret is untouched
+    expect(kp.secretKey.isValid()).to.be.true;
+    expect(kp.secretKey.hex).to.not.equal(leaked.hex);
+  });
+});

--- a/packages/keypair/tests/secret.spec.ts
+++ b/packages/keypair/tests/secret.spec.ts
@@ -152,10 +152,26 @@ describe('Secp256k1SecretKey', () => {
     });
 
     it('should sign and verify with ecdsa', () => {
+      // The class-level ecdsa path matches the signWithScheme contract:
+      // DER-encoded, low-S, no prehash over the 32-byte sighash.
       const signature = secretKey.sign(message, { scheme: 'ecdsa' });
       expect(signature).to.be.instanceOf(Uint8Array);
-      expect(signature.length).to.equal(64);
+      expect(signature[0]).to.equal(0x30); // DER sequence tag
       expect(publicKey.verify(signature, message, { scheme: 'ecdsa' })).to.be.true;
+    });
+
+    it('produces ecdsa signatures compatible with the signWithScheme contract (audit M10)', () => {
+      // A class-level signature must verify under the explicit DER/lowS/prehash:false
+      // options that signWithScheme (LocalSigner, LocalKeyManager) uses.
+      const signature = secretKey.sign(message, { scheme: 'ecdsa' });
+      expect(
+        secp256k1.verify(signature, message, publicKey.compressed, { format: 'der', lowS: true, prehash: false })
+      ).to.be.true;
+    });
+
+    it('rejects a compact-format ecdsa signature under the class-level verify (audit M10)', () => {
+      const compact = secp256k1.sign(message, bytes, { format: 'compact', prehash: false });
+      expect(publicKey.verify(compact, message, { scheme: 'ecdsa' })).to.be.false;
     });
 
     it('should reject tampered message', () => {
@@ -209,8 +225,8 @@ describe('Secp256k1SecretKey', () => {
       const sk = new Secp256k1SecretKey(bytes);
       const encoded = sk.multibase;
       const decoded = Secp256k1SecretKey.decode(encoded);
-      expect(decoded.length).to.equal(34);
-      expect(decoded.slice(2)).to.deep.equal(bytes);
+      expect(decoded.length).to.equal(32);
+      expect(decoded).to.deep.equal(bytes);
     });
   });
 });


### PR DESCRIPTION
* fix(cryptosuite): public-only multikey toJSON, non-aliasing proof inputs, expires enforcement (audit H3, L3, L4)
* fix(keypair): copy-on-access secretKey getter, 32-byte decode, DER/low-S ecdsa contract, wiped transient secrets (audit L2, L5, L6, M10)
* fix(key-manager): return copies from getPublicKey/getEntry instead of live store buffers (audit L1)