### PR TITLE
authenticate aggregation transport senders and bind protocol consent

### DIFF
--- a/packages/aggregation/src/core/messages/bodies.ts
+++ b/packages/aggregation/src/core/messages/bodies.ts
@@ -90,6 +90,8 @@ export interface DistributeAggregatedDataBody {
 export interface ValidationAckBody {
   cohortId: string;
   approved: boolean;
+  /** Hex-encoded signal bytes being (dis)approved; binds consent to a distribution round. */
+  signalBytesHex: string;
 }
 
 // ── Signing (Step 4) ──────────────────────────────────────────────────────
@@ -282,7 +284,8 @@ export function isDistributeAggregatedDataMessage(m: BaseMessage): m is Distribu
 export function isValidationAckMessage(m: BaseMessage): m is ValidationAckMessage {
   return m.type === VALIDATION_ACK
     && hasStr(m.body, 'cohortId')
-    && hasBool(m.body, 'approved');
+    && hasBool(m.body, 'approved')
+    && hasStr(m.body, 'signalBytesHex');
 }
 
 export function isAuthorizationRequestMessage(m: BaseMessage): m is AuthorizationRequestMessage {

--- a/packages/aggregation/src/core/messages/factories.ts
+++ b/packages/aggregation/src/core/messages/factories.ts
@@ -143,6 +143,12 @@ type ValidationAckMessage = {
   to: string;
   cohortId: string;
   approved: boolean;
+  /**
+   * Hex-encoded signal bytes the participant validated and is (dis)approving.
+   * Binds consent to a specific distribution round: an ack without the current
+   * signal hash is not consent to it.
+   */
+  signalBytesHex: string;
 };
 
 /**

--- a/packages/aggregation/src/core/transport/envelope-auth.ts
+++ b/packages/aggregation/src/core/transport/envelope-auth.ts
@@ -1,0 +1,100 @@
+import type { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { equalBytes } from '@noble/curves/utils.js';
+import type { Logger } from '../logger.js';
+import { CONSOLE_LOGGER } from '../logger.js';
+import { reviveFromWire, verifyEnvelope } from './http/envelope.js';
+import type { SignedEnvelope } from './http/protocol.js';
+import { DEFAULT_CLOCK_SKEW_SEC } from './http/protocol.js';
+
+/** Dependencies for {@link authenticateEnvelopeContent}. */
+export interface EnvelopeAuthOptions {
+  /**
+   * Resolve a sender DID to its communication public key (registered peer key,
+   * or a DID-aware resolver such as `resolveBtcr2SenderPk` from
+   * `@did-btcr2/method`).
+   */
+  resolveSenderPk: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
+  /** Require the envelope's `to` field to equal this DID (directed messages). */
+  expectedTo?: string;
+  /** Envelope timestamp tolerance in seconds. Defaults to {@link DEFAULT_CLOCK_SKEW_SEC}. */
+  clockSkewSec?: number;
+  /** Diagnostic logger. Defaults to {@link CONSOLE_LOGGER}. */
+  logger?: Logger;
+}
+
+/** True if `value` is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Merge a message's `body` fields into the top level for handler access. */
+function flattenMessage(msg: Record<string, unknown>): Record<string, unknown> {
+  if(msg.body && typeof msg.body === 'object') {
+    return { ...msg, ...(msg.body as Record<string, unknown>) };
+  }
+  return msg;
+}
+
+/**
+ * Parse, authenticate, and flatten a signed-envelope payload received on any
+ * transport. Returns the flattened message with `from` bound to the verified
+ * envelope sender, or `undefined` when the content must be dropped:
+ * unparseable, unresolvable sender, self-advertised key contradicting the
+ * authenticated key, failed signature verification, stale timestamp, or wrong
+ * recipient.
+ *
+ * The inner message is inspected BEFORE verification only to derive a bootstrap
+ * key candidate (an x1 sender's in-band genesis document); nothing from it is
+ * trusted until the envelope verifies.
+ */
+export function authenticateEnvelopeContent(
+  content: string,
+  options: EnvelopeAuthOptions,
+): Record<string, unknown> | undefined {
+  const logger = options.logger ?? CONSOLE_LOGGER;
+
+  let envelope: SignedEnvelope;
+  try {
+    envelope = JSON.parse(content) as SignedEnvelope;
+  } catch {
+    return undefined;
+  }
+  if(!envelope || typeof envelope !== 'object'
+    || typeof envelope.from !== 'string'
+    || !envelope.message || typeof envelope.message !== 'object') {
+    return undefined;
+  }
+
+  const flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+  const genesisDocument = isRecord(flat.genesisDocument) ? flat.genesisDocument : undefined;
+  const senderPk = options.resolveSenderPk(envelope.from, genesisDocument ? { genesisDocument } : undefined);
+  if(!senderPk) {
+    logger.debug(`Message from unresolvable DID: ${envelope.from}`);
+    return undefined;
+  }
+
+  // A self-advertised communication key must equal the authenticated key: a
+  // sender may not authenticate as one key while advertising another.
+  const advertised = flat.communicationPk;
+  if(advertised !== undefined && (!(advertised instanceof Uint8Array) || !equalBytes(advertised, senderPk.compressed))) {
+    return undefined;
+  }
+
+  try {
+    verifyEnvelope(envelope, senderPk, {
+      clockSkewSec : options.clockSkewSec ?? DEFAULT_CLOCK_SKEW_SEC,
+      ...(options.expectedTo !== undefined ? { expectedTo: options.expectedTo } : {}),
+    });
+  } catch(err) {
+    logger.debug('Envelope verification failed:', err);
+    return undefined;
+  }
+
+  // The dispatched sender is the authenticated envelope sender, never the
+  // (previously untrusted) inner claim.
+  if(flat.from !== undefined && flat.from !== envelope.from) return undefined;
+  return { ...flat, from: envelope.from };
+}

--- a/packages/aggregation/src/core/transport/index.ts
+++ b/packages/aggregation/src/core/transport/index.ts
@@ -8,4 +8,5 @@ export * from './error.js';
 export * from './in-memory.js';
 export * from './nostr.js';
 export * from './didcomm.js';
+export * from './envelope-auth.js';
 export * from './http/index.js';

--- a/packages/aggregation/src/core/transport/nostr.ts
+++ b/packages/aggregation/src/core/transport/nostr.ts
@@ -1,7 +1,7 @@
 import type { Did } from '@did-btcr2/common';
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { bytesToHex } from '@noble/hashes/utils';
 import type { SubCloser } from 'nostr-tools/abstract-pool';
 import type { Event, EventTemplate} from 'nostr-tools';
 import { finalizeEvent, nip44 } from 'nostr-tools';
@@ -13,6 +13,9 @@ import { COHORT_ADVERT } from '../messages/constants.js';
 import { isAggregationMessageType, isKeygenMessageType, isSignMessageType, isUpdateMessageType } from '../messages/guards.js';
 import { TransportAdapterError } from './error.js';
 import type { MessageHandler, Transport } from './transport.js';
+import { signEnvelope } from './http/envelope.js';
+import { DEFAULT_CLOCK_SKEW_SEC } from './http/protocol.js';
+import { authenticateEnvelopeContent } from './envelope-auth.js';
 
 /**
  * Default Nostr relay URLs.
@@ -42,6 +45,27 @@ export interface NostrTransportConfig {
    * {@link DEFAULT_BROADCAST_LOOKBACK_MS} (5 minutes).
    */
   broadcastLookbackMs?: number;
+  /**
+   * Optional DID -> communication-public-key resolver for senders that are not
+   * pre-registered peers (for example `resolveBtcr2SenderPk` from
+   * `@did-btcr2/method`, which decodes KEY identifiers directly and verifies an
+   * in-band genesis document for EXTERNAL identifiers). Without it, only
+   * pre-registered peers can authenticate, and messages from anyone else are
+   * dropped.
+   */
+  resolveSenderPk?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
+  /**
+   * Envelope timestamp tolerance in seconds (both directions). Messages older
+   * than this are dropped, which is also the stale-history replay guard: relays
+   * replay a directed subscription's full event history on reconnect, and the
+   * timestamp check rejects ancient replays before they reach the state
+   * machines. Defaults to {@link DEFAULT_CLOCK_SKEW_SEC} (60s); raise it if
+   * slow relays deliver legitimately delayed traffic.
+   */
+  clockSkewSec?: number;
 }
 
 /** Default `since` lookback for broadcast (COHORT_ADVERT) subscriptions: 5 minutes. */
@@ -63,10 +87,18 @@ interface ActorEntry {
  * {@link registerActor}; the transport resolves the correct identity when
  * sending or receiving.
  *
+ * Sender authentication: every message is wrapped in a signed envelope (the
+ * same SignedEnvelope scheme as the HTTP transport) before publication, and
+ * incoming envelopes are verified against the sender's registered peer key or
+ * the injected `resolveSenderPk` resolver before dispatch. Messages that fail
+ * verification, arrive from unresolvable DIDs, or carry a stale timestamp are
+ * dropped, so `message.from` is always bound to the signing key when a handler
+ * runs.
+ *
  * Message routing:
- * - Keygen messages (COHORT_ADVERT, COHORT_OPT_IN, COHORT_OPT_IN_ACCEPT, COHORT_READY) to kind 1 (plaintext)
- * - Update messages (SUBMIT_UPDATE, DISTRIBUTE_AGGREGATED_DATA, VALIDATION_ACK) to kind 1059 (NIP-44 encrypted)
- * - Sign messages to kind 1059 (NIP-44 encrypted)
+ * - Keygen messages (COHORT_ADVERT, COHORT_OPT_IN, COHORT_OPT_IN_ACCEPT, COHORT_READY) to kind 1 (plaintext envelope)
+ * - Update messages (SUBMIT_UPDATE, DISTRIBUTE_AGGREGATED_DATA, VALIDATION_ACK) to kind 1059 (NIP-44 encrypted envelope)
+ * - Sign messages to kind 1059 (NIP-44 encrypted envelope)
  *
  * @class NostrTransport
  * @implements {Transport}
@@ -81,11 +113,15 @@ export class NostrTransport implements Transport {
   #started = false;
   #logger: Logger;
   #broadcastLookbackMs: number;
+  #resolveSenderPkFn?: NostrTransportConfig['resolveSenderPk'];
+  #clockSkewSec: number;
 
   constructor(config?: NostrTransportConfig) {
     this.#relays = config?.relays ?? DEFAULT_NOSTR_RELAYS;
     this.#logger = config?.logger ?? CONSOLE_LOGGER;
     this.#broadcastLookbackMs = config?.broadcastLookbackMs ?? DEFAULT_BROADCAST_LOOKBACK_MS;
+    this.#resolveSenderPkFn = config?.resolveSenderPk;
+    this.#clockSkewSec = config?.clockSkewSec ?? DEFAULT_CLOCK_SKEW_SEC;
   }
 
   /**
@@ -297,13 +333,18 @@ export class NostrTransport implements Transport {
       }
     }
 
+    // Wrap the message in a signed envelope so receivers can authenticate the
+    // sender DID against the registered/resolved communication key.
+    const envelope = signEnvelope(message, { did: sender, keys: senderKeys }, { ...(to ? { to } : {}) });
+    const envelopeJson = JSON.stringify(envelope);
+
     // Keygen messages: plaintext, kind 1
     if(isKeygenMessageType(type)) {
       const event = finalizeEvent({
         kind       : 1,
         created_at : Math.floor(Date.now() / 1000),
         tags,
-        content    : JSON.stringify(message, NostrTransport.#jsonReplacer),
+        content    : envelopeJson,
       } as EventTemplate, senderKeys.secretKey.bytes);
       this.#logger.debug(`Publishing kind 1 [${type}]`);
       await this.#publishToRelays(event);
@@ -330,7 +371,7 @@ export class NostrTransport implements Transport {
         senderKeys.secretKey.bytes,
         bytesToHex(recipientPk.x)
       );
-      const content = nip44.v2.encrypt(JSON.stringify(message, NostrTransport.#jsonReplacer), conversationKey);
+      const content = nip44.v2.encrypt(envelopeJson, conversationKey);
 
       const event = finalizeEvent({
         kind       : 1059,
@@ -393,9 +434,10 @@ export class NostrTransport implements Transport {
     const pkHex = bytesToHex(entry.keys.publicKey.x);
 
     // No `since` filter: directed messages must be retrievable on reconnect /
-    // crash-recovery. Out-of-phase messages are silently dropped by the state
-    // machines (AggregationService, AggregationParticipant), so replayed stale
-    // messages are harmless.
+    // crash-recovery. Replayed history is filtered two ways: envelope timestamp
+    // verification drops messages older than `clockSkewSec`, and out-of-phase
+    // messages within the window are silently dropped by the state machines
+    // (AggregationService, AggregationParticipant).
     const sub = this.pool.subscribeMany(this.#relays, { kinds: [1, 1059], '#p': [pkHex] }, {
       onclose : (reasons: string[]) => this.#logger.debug(`Nostr directed subscription closed for ${did}`, reasons),
       onevent : this.#makeActorEventHandler(did),
@@ -423,18 +465,17 @@ export class NostrTransport implements Transport {
       // the content was encrypted for the recipient, not self.
       if(event.pubkey === bytesToHex(actor.keys.publicKey.x)) return;
 
-      let message: Record<string, unknown>;
+      let content: string;
 
       try {
         if(event.kind === 1) {
-          message = JSON.parse(event.content, NostrTransport.#jsonReviver);
+          content = event.content;
         } else if(event.kind === 1059) {
           const conversationKey = nip44.v2.utils.getConversationKey(
             actor.keys.secretKey.bytes,
             event.pubkey
           );
-          const plaintext = nip44.v2.decrypt(event.content, conversationKey);
-          message = JSON.parse(plaintext, NostrTransport.#jsonReviver);
+          content = nip44.v2.decrypt(event.content, conversationKey);
         } else {
           return;
         }
@@ -442,6 +483,11 @@ export class NostrTransport implements Transport {
         this.#logger.debug(`Failed to parse event ${event.id} for ${actorDid}:`, err);
         return;
       }
+
+      // Authenticate the envelope; directed messages must also be addressed to
+      // this actor. Unverifiable senders are dropped here, never dispatched.
+      const message = this.#authenticateContent(content, { expectedTo: actorDid });
+      if(!message) return;
 
       this.#dispatchMessage(message, actor);
     };
@@ -460,17 +506,8 @@ export class NostrTransport implements Transport {
   async #handleBroadcastEvent(event: Event): Promise<void> {
     if(event.kind !== 1) return;
 
-    let message: Record<string, unknown>;
-    try {
-      message = JSON.parse(event.content, NostrTransport.#jsonReviver);
-    } catch(err) {
-      this.#logger.debug(`Failed to parse broadcast event ${event.id}:`, err);
-      return;
-    }
-
-    if(message.body && typeof message.body === 'object') {
-      message = { ...message, ...(message.body as Record<string, unknown>) };
-    }
+    const message = this.#authenticateContent(event.content);
+    if(!message) return;
 
     const messageType = message.type as string;
     if(!messageType || !isAggregationMessageType(messageType)) return;
@@ -480,6 +517,41 @@ export class NostrTransport implements Transport {
       const handler = actor.handlers.get(messageType);
       if(handler) await handler(message);
     }
+  }
+
+  /**
+   * Resolve a sender DID to its communication public key: the registered peer
+   * key wins; otherwise the injected `resolveSenderPk` resolver (KEY identifiers
+   * decode directly; EXTERNAL identifiers authenticate via an in-band genesis
+   * document carried on the message).
+   */
+  #resolveSenderPk(did: string, opts?: { genesisDocument?: object }): CompressedSecp256k1PublicKey | undefined {
+    const peerBytes = this.#peerRegistry.get(did);
+    if(peerBytes) {
+      try { return new CompressedSecp256k1PublicKey(peerBytes); }
+      catch { /* fall through to the injected resolver */ }
+    }
+    return this.#resolveSenderPkFn?.(did, opts);
+  }
+
+  /**
+   * Parse, authenticate, and flatten an incoming envelope payload. Returns the
+   * flattened message with `from` bound to the verified envelope sender, or
+   * `undefined` when the content must be dropped: unparseable, unresolvable
+   * sender, self-advertised key that contradicts the authenticated key, failed
+   * signature verification, stale timestamp, or wrong recipient.
+   *
+   * The inner message is inspected BEFORE verification only to derive a
+   * bootstrap key candidate (an x1 sender's in-band genesis document); nothing
+   * from it is trusted until the envelope verifies.
+   */
+  #authenticateContent(content: string, opts?: { expectedTo?: string }): Record<string, unknown> | undefined {
+    return authenticateEnvelopeContent(content, {
+      expectedTo      : opts?.expectedTo,
+      clockSkewSec    : this.#clockSkewSec,
+      logger          : this.#logger,
+      resolveSenderPk : (did, resolveOpts) => this.#resolveSenderPk(did, resolveOpts),
+    });
   }
 
   /**
@@ -534,43 +606,5 @@ export class NostrTransport implements Transport {
         'PUBLISH_ERROR', { adapter: this.name, reasons: rejected.map(r => String((r as PromiseRejectedResult).reason)) }
       );
     }
-  }
-
-  /**
-   * Custom JSON replacer to handle serialization of Uint8Array values as hex strings in message
-   * content. This allows messages containing binary data (e.g. public keys, signatures) to be correctly
-   * serialized to JSON for Nostr event content. The replacer checks if a value is a Uint8Array and, if so,
-   * converts it to a hex string wrapped in an object with a __bytes property. The corresponding reviver
-   * can then convert this back to a Uint8Array when parsing the message content from the event.
-   * @param {string} _key - The key of the property being processed.
-   * @param {unknown} value - The value to check if the message type is valid.
-   * @returns {unknown} The transformed value for JSON serialization. If the value is a Uint8Array,
-   * it returns an object with a __bytes property containing the hex string. Otherwise, it returns
-   * the value unchanged.
-   */
-  static #jsonReplacer(_key: string, value: unknown): unknown {
-    if(value instanceof Uint8Array) {
-      return { __bytes: bytesToHex(value) };
-    }
-    return value;
-  }
-
-  /**
-   * Custom JSON reviver to handle deserialization of hex strings back into Uint8Array values in message
-   * content. This complements the custom replacer used during serialization, allowing messages that contain
-   * binary data (e.g. public keys, signatures) to be correctly reconstructed when parsing JSON from
-   * Nostr event content. The reviver checks if a value is an object with a __bytes property and,
-   * if so, converts the hex string back into a Uint8Array. Otherwise, it returns the value unchanged.
-   * @param {string} _key - The key of the property being processed.
-   * @param {unknown} value - The value to check if it is an object containing a __bytes property for
-   * hex string conversion.
-   * @returns {unknown} The transformed value for JSON deserialization. If the value is an object
-   * with a __bytes property, it returns a Uint8Array. Otherwise, it returns the value unchanged.
-   */
-  static #jsonReviver(_key: string, value: unknown): unknown {
-    if(value && typeof value === 'object' && '__bytes' in (value as Record<string, unknown>)) {
-      return hexToBytes((value as { __bytes: string }).__bytes);
-    }
-    return value;
   }
 }

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -340,6 +340,8 @@ export class AggregationParticipant {
     const state = this.#cohortStates.get(cohortId);
     if(!state || !state.cohort) return;
     if(state.phase !== ParticipantCohortPhase.OptedIn) return;
+    // Only the cohort's service may drive its lifecycle
+    if(message.from !== state.serviceDid) return;
 
     const beaconAddress = message.body?.beaconAddress;
     const cohortKeys = message.body?.cohortKeys;
@@ -438,6 +440,8 @@ export class AggregationParticipant {
     // A submitter is in UpdateSubmitted; a decliner (cooperative non-inclusion)
     // is in NonIncluded. Both validate their own slot in the distributed data.
     if(!state || (state.phase !== ParticipantCohortPhase.UpdateSubmitted && state.phase !== ParticipantCohortPhase.NonIncluded)) return;
+    // Only the cohort's service may distribute aggregated data
+    if(message.from !== state.serviceDid) return;
 
     const declined = state.included === false;
     // A submitter must have its update stored; a decliner has none by design.
@@ -486,10 +490,12 @@ export class AggregationParticipant {
     }
     state.phase = ParticipantCohortPhase.ValidationSent;
     return [createValidationAckMessage({
-      from     : this.did,
-      to       : state.serviceDid,
+      from           : this.did,
+      to             : state.serviceDid,
       cohortId,
-      approved : true,
+      approved       : true,
+      // Bind consent to the exact signal this participant validated
+      signalBytesHex : state.validation!.signalBytesHex,
     })];
   }
 
@@ -506,10 +512,11 @@ export class AggregationParticipant {
     }
     state.phase = ParticipantCohortPhase.Failed;
     return [createValidationAckMessage({
-      from     : this.did,
-      to       : state.serviceDid,
+      from           : this.did,
+      to             : state.serviceDid,
       cohortId,
-      approved : false,
+      approved       : false,
+      signalBytesHex : state.validation!.signalBytesHex,
     })];
   }
 
@@ -531,6 +538,8 @@ export class AggregationParticipant {
     const state = this.#cohortStates.get(cohortId);
     if(!state || !state.cohort) return;
     if(state.phase !== ParticipantCohortPhase.ValidationSent) return;
+    // Only the cohort's service may request signing
+    if(message.from !== state.serviceDid) return;
 
     const sessionId = message.body?.sessionId;
     const pendingTxHex = message.body?.pendingTx;
@@ -636,6 +645,8 @@ export class AggregationParticipant {
     const state = this.#cohortStates.get(cohortId);
     if(!state || !state.signingSession) return;
     if(state.phase !== ParticipantCohortPhase.NonceSent) return;
+    // Only the cohort's service may supply the aggregated nonce
+    if(message.from !== state.serviceDid) return;
 
     const aggregatedNonce = message.body?.aggregatedNonce;
     if(!aggregatedNonce) return;
@@ -712,6 +723,8 @@ export class AggregationParticipant {
       ParticipantCohortPhase.Complete,
     ];
     if(!acceptFrom.includes(state.phase)) return;
+    // Only the cohort's service may initiate a fallback
+    if(message.from !== state.serviceDid) return;
 
     const sessionId = message.body?.sessionId;
     const pendingTxHex = message.body?.pendingTx;
@@ -719,6 +732,12 @@ export class AggregationParticipant {
     const prevOutValue = message.body?.prevOutValue;
     const fallbackLeafScriptHex = message.body?.fallbackLeafScriptHex;
     if(!sessionId || !pendingTxHex || !prevOutScriptHex || !prevOutValue || !fallbackLeafScriptHex) return;
+
+    // The fallback must belong to this member's in-flight signing session (the
+    // service reuses the optimistic session id). When no local session exists yet
+    // (a reordered fallback arriving before the AUTHORIZATION_REQUEST) there is
+    // nothing to compare, so the request is accepted.
+    if(state.signingSession && sessionId !== state.signingSession.id) return;
 
     state.fallbackRequest = { cohortId, sessionId, pendingTxHex, prevOutScriptHex, prevOutValue, fallbackLeafScriptHex };
     // The optimistic path is abandoned; wipe any retained secret nonce for it.

--- a/packages/aggregation/src/service/service.ts
+++ b/packages/aggregation/src/service/service.ts
@@ -677,6 +677,14 @@ export class AggregationService {
     const approved = message.body?.approved;
     if(approved === undefined) return;
 
+    // The ack must commit to the exact signal this service distributed: an ack
+    // naming a different (or no) signal hash is not consent to the current
+    // distribution and is dropped, so a forged or replayed ack cannot drive the
+    // cohort into signing.
+    const signalBytesHex = message.body?.signalBytesHex;
+    const expectedHex = state.cohort.signalBytes ? bytesToHex(state.cohort.signalBytes) : undefined;
+    if(!signalBytesHex || signalBytesHex !== expectedHex) return;
+
     state.cohort.addValidation(message.from, approved);
 
     // Transition to Validated only when all participants approved.

--- a/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
@@ -1,0 +1,433 @@
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { p2tr, Script, Transaction } from '@scure/btc-signer';
+import * as musig2 from '@scure/btc-signer/musig2';
+import { expect } from 'chai';
+
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update, GenesisDocumentLike } from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, resolveBtcr2SenderPk } from '@did-btcr2/method';
+
+import {
+  AggregationParticipant,
+  AggregationService,
+  BaseMessage,
+  KeyPairAggregationSigner,
+  ParticipantCohortPhase,
+  ServiceCohortPhase,
+  SILENT_LOGGER,
+  authenticateEnvelopeContent,
+  createFallbackAuthorizationRequestMessage,
+  createCohortOptInMessage,
+  createValidationAckMessage,
+  signEnvelope,
+} from '../src/index.js';
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+
+function makeIdentity(network = 'mutinynet'): { keys: SchnorrKeyPair; did: string } {
+  const keys = SchnorrKeyPair.generate();
+  const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network });
+  return { keys, did };
+}
+
+/** An x1 identity: signing keypair + self-verifying genesis document. */
+function makeExternalIdentity(network = 'mutinynet'): {
+  keys: SchnorrKeyPair;
+  did: string;
+  genesisDocument: Record<string, unknown>;
+} {
+  const keys = SchnorrKeyPair.generate();
+  const genesisDocument: Record<string, unknown> = {
+    'id'                 : 'did:btcr2:_',
+    '@context'           : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+    'verificationMethod' : [{
+      'id'                 : 'did:btcr2:_#key-0',
+      'type'               : 'Multikey',
+      'controller'         : 'did:btcr2:_',
+      'publicKeyMultibase' : keys.publicKey.multibase.encoded,
+    }],
+    'authentication'       : ['did:btcr2:_#key-0'],
+    'assertionMethod'      : ['did:btcr2:_#key-0'],
+    'capabilityInvocation' : ['did:btcr2:_#key-0'],
+    'capabilityDelegation' : ['did:btcr2:_#key-0'],
+    'service'              : [{
+      'id'              : 'did:btcr2:_#service-0',
+      'type'            : 'SingletonBeacon',
+      'serviceEndpoint' : 'bitcoin:mhME7XiWpho6Ft4pvT3U3h6X8hHtE58ZDJ',
+    }],
+  };
+  const genesisBytes = GenesisDocument.toGenesisBytes(genesisDocument as GenesisDocumentLike);
+  const did = DidBtcr2.create(genesisBytes, { idType: 'EXTERNAL', network });
+  return { keys, did, genesisDocument };
+}
+
+/** Cryptographically valid SignedBTCR2Update for a participant (real BIP-340 proof). */
+function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [
+      { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } },
+    ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : version,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : `${did}#initialKey`,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(`${did}#initialKey`, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+function buildSignalTx(outputScript: Uint8Array, prevOutValue: bigint, signal: Uint8Array): Transaction {
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({
+    txid        : '00'.repeat(32),
+    index       : 0,
+    witnessUtxo : { amount: prevOutValue, script: outputScript },
+  });
+  tx.addOutput({ script: outputScript, amount: prevOutValue - 500n });
+  tx.addOutput({ script: Script.encode(['RETURN', signal]), amount: 0n });
+  return tx;
+}
+
+/** Route outgoing messages to their addressed party; broadcasts (no `to`) go to everyone. */
+function route(msgs: BaseMessage[], parties: Record<string, { receive(m: BaseMessage): void }>): void {
+  for(const m of msgs) {
+    if(m.to === undefined) {
+      for(const target of Object.values(parties)) target.receive(m);
+      continue;
+    }
+    parties[m.to]?.receive(m);
+  }
+}
+
+describe('Aggregation transport + message auth hardening', () => {
+
+  describe('authenticateEnvelopeContent (audit C1)', () => {
+    const service = makeIdentity();
+
+    function optInEnvelope(sender: { keys: SchnorrKeyPair; did: string }, opts?: { fromOverride?: string; communicationPk?: Uint8Array }) {
+      const msg = createCohortOptInMessage({
+        from            : opts?.fromOverride ?? sender.did,
+        to              : service.did,
+        cohortId        : 'cohort-1',
+        participantPk   : sender.keys.publicKey.compressed,
+        communicationPk : opts?.communicationPk ?? sender.keys.publicKey.compressed,
+      });
+      return signEnvelope(msg, { did: sender.did, keys: sender.keys }, { to: service.did });
+    }
+
+    it('accepts a valid envelope from a resolvable (k1) sender', () => {
+      const sender = makeIdentity();
+      const flat = authenticateEnvelopeContent(JSON.stringify(optInEnvelope(sender)), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        expectedTo      : service.did,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat?.from).to.equal(sender.did);
+      expect(flat?.cohortId).to.equal('cohort-1');
+    });
+
+    it('drops a forged envelope (signed by an attacker key, from: victim DID)', () => {
+      const victim = makeIdentity();
+      const attacker = makeIdentity();
+      // Attacker signs but claims the victim's DID as the envelope sender
+      const msg = createCohortOptInMessage({
+        from            : victim.did,
+        to              : service.did,
+        cohortId        : 'cohort-1',
+        participantPk   : attacker.keys.publicKey.compressed,
+        communicationPk : attacker.keys.publicKey.compressed,
+      });
+      const envelope = signEnvelope(msg, { did: victim.did, keys: attacker.keys }, { to: service.did });
+      const flat = authenticateEnvelopeContent(JSON.stringify(envelope), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat).to.be.undefined;
+    });
+
+    it('drops an envelope whose inner message.from disagrees with the authenticated sender', () => {
+      const sender = makeIdentity();
+      const other = makeIdentity();
+      const flat = authenticateEnvelopeContent(JSON.stringify(optInEnvelope(sender, { fromOverride: other.did })), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat).to.be.undefined;
+    });
+
+    it('drops an envelope advertising a communication key that is not the signing key', () => {
+      const sender = makeIdentity();
+      const other = makeIdentity();
+      const flat = authenticateEnvelopeContent(
+        JSON.stringify(optInEnvelope(sender, { communicationPk: other.keys.publicKey.compressed })),
+        { resolveSenderPk: resolveBtcr2SenderPk, logger: SILENT_LOGGER }
+      );
+      expect(flat).to.be.undefined;
+    });
+
+    it('drops a stale envelope (replay beyond the timestamp window)', () => {
+      const sender = makeIdentity();
+      const msg = createCohortOptInMessage({
+        from            : sender.did,
+        to              : service.did,
+        cohortId        : 'cohort-1',
+        participantPk   : sender.keys.publicKey.compressed,
+        communicationPk : sender.keys.publicKey.compressed,
+      });
+      const stale = Math.floor(Date.now() / 1000) - 3600;
+      const envelope = signEnvelope(msg, { did: sender.did, keys: sender.keys }, { timestamp: stale });
+      const flat = authenticateEnvelopeContent(JSON.stringify(envelope), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat).to.be.undefined;
+    });
+
+    it('drops an envelope addressed to a different recipient', () => {
+      const sender = makeIdentity();
+      const flat = authenticateEnvelopeContent(JSON.stringify(optInEnvelope(sender)), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        expectedTo      : makeIdentity().did,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat).to.be.undefined;
+    });
+
+    it('drops a message from an unresolvable DID', () => {
+      const sender = makeIdentity();
+      const msg = createCohortOptInMessage({
+        from            : 'did:example:unresolvable',
+        to              : service.did,
+        cohortId        : 'cohort-1',
+        participantPk   : sender.keys.publicKey.compressed,
+        communicationPk : sender.keys.publicKey.compressed,
+      });
+      const envelope = signEnvelope(msg, { did: 'did:example:unresolvable', keys: sender.keys });
+      const flat = authenticateEnvelopeContent(JSON.stringify(envelope), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat).to.be.undefined;
+    });
+
+    it('accepts an x1 sender bootstrap-authenticated by its in-band genesis document', () => {
+      const sender = makeExternalIdentity();
+      const msg = createCohortOptInMessage({
+        from            : sender.did,
+        to              : service.did,
+        cohortId        : 'cohort-1',
+        participantPk   : sender.keys.publicKey.compressed,
+        communicationPk : sender.keys.publicKey.compressed,
+        genesisDocument : sender.genesisDocument,
+      });
+      const envelope = signEnvelope(msg, { did: sender.did, keys: sender.keys }, { to: service.did });
+      const flat = authenticateEnvelopeContent(JSON.stringify(envelope), {
+        resolveSenderPk : resolveBtcr2SenderPk,
+        expectedTo      : service.did,
+        logger          : SILENT_LOGGER,
+      });
+      expect(flat?.from).to.equal(sender.did);
+    });
+  });
+
+  describe('participant service-identity guards (audit H7, L21)', () => {
+    function setup() {
+      const svc = makeIdentity();
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      const service = new AggregationService({ did: svc.did, publicKey: svc.keys.publicKey });
+      const aliceP = new AggregationParticipant({ did: alice.did, signer: new KeyPairAggregationSigner(alice.keys) });
+      const bobP = new AggregationParticipant({ did: bob.did, signer: new KeyPairAggregationSigner(bob.keys) });
+      return { svc, alice, bob, service, aliceP, bobP };
+    }
+
+    /** Drive both participants to OptedIn; returns the cohortId. */
+    function driveToOptedIn(ctx: ReturnType<typeof setup>): string {
+      const { service, aliceP, bobP, alice, bob, svc } = ctx;
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      route(service.advertise(cohortId), { [alice.did]: aliceP, [bob.did]: bobP });
+      route(aliceP.joinCohort(cohortId), { [svc.did]: service });
+      route(bobP.joinCohort(cohortId), { [svc.did]: service });
+      route(service.acceptParticipant(cohortId, alice.did), { [alice.did]: aliceP });
+      route(service.acceptParticipant(cohortId, bob.did), { [bob.did]: bobP });
+      return cohortId;
+    }
+
+    /** Continue from OptedIn to CohortReady for both participants. */
+    function driveToReady(ctx: ReturnType<typeof setup>, cohortId: string): void {
+      const { service, aliceP, bobP, alice, bob } = ctx;
+      route(service.finalizeKeygen(cohortId), { [alice.did]: aliceP, [bob.did]: bobP });
+    }
+
+    /** Continue through update submission and distribution to AwaitingValidation. */
+    function driveToValidation(ctx: ReturnType<typeof setup>, cohortId: string): void {
+      const { service, aliceP, bobP, alice, bob } = ctx;
+      driveToReady(ctx, cohortId);
+      route(aliceP.submitUpdate(cohortId, createSignedUpdate(alice.did, alice.keys)), { [ctx.svc.did]: service });
+      route(bobP.submitUpdate(cohortId, createSignedUpdate(bob.did, bob.keys)), { [ctx.svc.did]: service });
+      route(service.buildAndDistribute(cohortId), { [alice.did]: aliceP, [bob.did]: bobP });
+    }
+
+    it('H7: ignores a COHORT_READY from a sender that is not the service', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      const readyMsgs = ctx.service.finalizeKeygen(cohortId);
+      const forAlice = readyMsgs.find(m => m.to === ctx.alice.did)!;
+
+      const attacker = makeIdentity();
+      ctx.aliceP.receive(new BaseMessage({ type: forAlice.type, from: attacker.did, to: forAlice.to, body: forAlice.body }));
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.OptedIn);
+
+      // Control: the genuine service message advances the phase
+      ctx.aliceP.receive(forAlice);
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.CohortReady);
+    });
+
+    it('H7: ignores a DISTRIBUTE_AGGREGATED_DATA from a sender that is not the service', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToReady(ctx, cohortId);
+      route(ctx.aliceP.submitUpdate(cohortId, createSignedUpdate(ctx.alice.did, ctx.alice.keys)), { [ctx.svc.did]: ctx.service });
+      route(ctx.bobP.submitUpdate(cohortId, createSignedUpdate(ctx.bob.did, ctx.bob.keys)), { [ctx.svc.did]: ctx.service });
+      const distMsgs = ctx.service.buildAndDistribute(cohortId);
+      const forAlice = distMsgs.find(m => m.to === ctx.alice.did)!;
+
+      const attacker = makeIdentity();
+      ctx.aliceP.receive(new BaseMessage({ type: forAlice.type, from: attacker.did, to: forAlice.to, body: forAlice.body }));
+      expect(ctx.aliceP.pendingValidations.has(cohortId)).to.be.false;
+
+      ctx.aliceP.receive(forAlice);
+      expect(ctx.aliceP.pendingValidations.has(cohortId)).to.be.true;
+    });
+
+    it('H7: ignores a FALLBACK_AUTHORIZATION_REQUEST from a sender that is not the service', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToValidation(ctx, cohortId);
+      route(ctx.aliceP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+
+      const attacker = makeIdentity();
+      ctx.aliceP.receive(createFallbackAuthorizationRequestMessage({
+        from                  : attacker.did,
+        to                    : ctx.alice.did,
+        cohortId,
+        sessionId             : 'attacker-session',
+        pendingTx             : 'aa',
+        prevOutScriptHex      : 'bb',
+        prevOutValue          : '1000',
+        fallbackLeafScriptHex : 'cc',
+      }));
+      expect(ctx.aliceP.pendingFallbackRequests.has(cohortId)).to.be.false;
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+    });
+
+    it('L21: ignores a fallback request naming a foreign session id when a session exists', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToValidation(ctx, cohortId);
+      route(ctx.aliceP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+      route(ctx.bobP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+
+      const cohort = ctx.service.getCohort(cohortId)!;
+      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
+      const payment = p2tr(aggPk);
+      const tx = buildSignalTx(payment.script, 100000n, cohort.signalBytes!);
+      route(ctx.service.startSigning(cohortId, {
+        tx,
+        prevOutScripts : [payment.script],
+        prevOutValues  : [100000n],
+      }), { [ctx.alice.did]: ctx.aliceP, [ctx.bob.did]: ctx.bobP });
+
+      // Alice creates her signing session
+      route(ctx.aliceP.approveNonce(cohortId), { [ctx.svc.did]: ctx.service });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      // A fallback request from the real service but naming a different session
+      // must not abandon the in-flight optimistic session.
+      ctx.aliceP.receive(createFallbackAuthorizationRequestMessage({
+        from                  : ctx.svc.did,
+        to                    : ctx.alice.did,
+        cohortId,
+        sessionId             : 'foreign-session',
+        pendingTx             : 'aa',
+        prevOutScriptHex      : 'bb',
+        prevOutValue          : '1000',
+        fallbackLeafScriptHex : 'cc',
+      }));
+      expect(ctx.aliceP.pendingFallbackRequests.has(cohortId)).to.be.false;
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      // Control: the service's genuine fallback reuses the session id and is accepted
+      route(ctx.service.startFallbackSigning(cohortId), { [ctx.alice.did]: ctx.aliceP });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+    });
+  });
+
+  describe('validation ack signal binding (audit H8)', () => {
+    it('service drops an ack that does not commit to the distributed signal', () => {
+      const svc = makeIdentity();
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      const service = new AggregationService({ did: svc.did, publicKey: svc.keys.publicKey });
+      const aliceP = new AggregationParticipant({ did: alice.did, signer: new KeyPairAggregationSigner(alice.keys) });
+      const bobP = new AggregationParticipant({ did: bob.did, signer: new KeyPairAggregationSigner(bob.keys) });
+      const parties = { [svc.did]: service, [alice.did]: aliceP, [bob.did]: bobP };
+
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      route(service.advertise(cohortId), parties);
+      route(aliceP.joinCohort(cohortId), parties);
+      route(bobP.joinCohort(cohortId), parties);
+      route(service.acceptParticipant(cohortId, alice.did), parties);
+      route(service.acceptParticipant(cohortId, bob.did), parties);
+      route(service.finalizeKeygen(cohortId), parties);
+      route(aliceP.submitUpdate(cohortId, createSignedUpdate(alice.did, alice.keys)), parties);
+      route(bobP.submitUpdate(cohortId, createSignedUpdate(bob.did, bob.keys)), parties);
+      route(service.buildAndDistribute(cohortId), parties);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      // A forged ack approving a DIFFERENT signal must not count as consent
+      service.receive(createValidationAckMessage({
+        from           : alice.did,
+        to             : svc.did,
+        cohortId,
+        approved       : true,
+        signalBytesHex : 'ab'.repeat(32),
+      }));
+      expect(service.validationProgress(cohortId).approved.size).to.equal(0);
+
+      // Genuine acks commit to the distributed signal and drive the phase forward
+      route(aliceP.approveValidation(cohortId), parties);
+      route(bobP.approveValidation(cohortId), parties);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
+    });
+  });
+});


### PR DESCRIPTION
* fix(aggregation-transport): authenticate Nostr senders with signed envelopes and drop stale replays (audit C1, L20)
* fix(aggregation-participant): verify service identity on cohort-driving handlers and bind fallback requests to the in-flight session (audit H7, L21)
* fix(aggregation-service): bind VALIDATION_ACK consent to the distributed signal hash (audit H8)
* test(aggregation): regression coverage for envelope auth, service-identity guards, ack signal binding (13 tests)