### PR TITLE
validate participant-signed beacon txs against cohort state

### DIFF
--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -1,9 +1,10 @@
 import { canonicalHash } from '@did-btcr2/common';
+import { getNetwork } from '@did-btcr2/bitcoin';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof} from '@did-btcr2/smt';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-import { Script, Transaction } from '@scure/btc-signer';
+import { Address, OutScript, Script, Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from '../core/beacon-strategy.js';
 import { AggregationCohort } from '../core/cohort.js';
 import type { CohortConditions } from '../core/conditions.js';
@@ -59,6 +60,35 @@ function txEmbedsSignal(tx: Transaction, signalHex: string): boolean {
   }
   return false;
 }
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
+/**
+ * The scriptPubKey of the cohort's beacon UTXO, decoded from the beacon address
+ * the member independently recomputed and verified at cohort-ready time
+ * ({@link AggregationCohort.validateMembership}). Used to check that a
+ * service-supplied spend really targets the cohort's beacon output (audit M5).
+ */
+function beaconOutputScript(cohort: AggregationCohort): Uint8Array {
+  return OutScript.encode(Address(getNetwork(cohort.network)).decode(cohort.beaconAddress));
+}
+
+/**
+ * Conservative dust floor for the beacon self-change output (satoshis), matching
+ * the floor used by the recovery spend builder.
+ */
+const SELF_CHANGE_DUST_LIMIT_SATS = 546n;
+
+/**
+ * Default absolute fee ceiling (satoshis) a member will sign for a beacon
+ * announcement. The coordinator builds the tx and the member never sees the fee
+ * rate, only the absolute fee implied by the outputs; the ceiling stops a
+ * malicious or buggy coordinator from burning the beacon UTXO as fee (audit
+ * M5). Typical announcement txs cost a few hundred sats.
+ */
+export const DEFAULT_MAX_FEE_SATS = 100_000n;
 
 /**
  * Cohort advert as discovered by the participant (UI: list of joinable cohorts).
@@ -157,6 +187,14 @@ export interface AggregationParticipantParams {
    */
   maxCohorts?: number;
   /**
+   * Absolute fee ceiling (satoshis) applied to every beacon transaction this
+   * member is asked to sign, on both the optimistic and fallback paths. The
+   * member's signature commits to all outputs, so an uncapped fee lets a
+   * malicious coordinator burn the cohort's beacon UTXO (audit M5). Defaults
+   * to {@link DEFAULT_MAX_FEE_SATS}.
+   */
+  maxFeeSats?: bigint | number;
+  /**
    * The joining identity's genesis DID document. Required for an EXTERNAL (x1) did:btcr2
    * identifier, whose key is not in the DID string: it is attached to every cohort opt-in
    * this participant sends so the service can bootstrap-authenticate the participant from
@@ -194,14 +232,18 @@ export class AggregationParticipant {
   /** Cap on retained cohort states (audit M6). */
   readonly #maxCohorts: number;
 
+  /** Absolute fee ceiling applied to every beacon tx this member signs (audit M5). */
+  readonly #maxFeeSats: bigint;
+
   /** Per-cohort state, keyed by cohortId. */
   #cohortStates: Map<string, ParticipantCohortState> = new Map();
 
-  constructor({ did, signer, genesisDocument, maxCohorts }: AggregationParticipantParams) {
+  constructor({ did, signer, genesisDocument, maxCohorts, maxFeeSats }: AggregationParticipantParams) {
     this.did = did;
     this.#signer = signer;
     this.#genesisDocument = genesisDocument;
     this.#maxCohorts = maxCohorts ?? DEFAULT_MAX_PARTICIPANT_COHORTS;
+    this.#maxFeeSats = maxFeeSats !== undefined ? BigInt(maxFeeSats) : DEFAULT_MAX_FEE_SATS;
   }
 
   /** The participant's compressed (33-byte) MuSig2 public key. Not secret. */
@@ -601,7 +643,111 @@ export class AggregationParticipant {
   }
 
   /**
-   * User action: approve signing and generate nonce contribution.
+   * Refuse to sign unless the service-supplied spend is shaped like a genuine
+   * beacon announcement of THIS cohort (audit M5). The member's signature
+   * (SIGHASH_DEFAULT) commits to every input and output, so a coordinator that
+   * controls the tx could otherwise point change at itself or burn the beacon
+   * UTXO as fee. Checks, all against the member's own verified cohort state:
+   *
+   * 1. `prevOutScript` must equal the beacon output script decoded from the
+   *    cohort's beacon address, so the sighash only validates for spending the
+   *    cohort's actual beacon UTXO.
+   * 2. Exactly one input: the beacon spend. Extra inputs would be silently
+   *    committed to the signature.
+   * 3. Every output is either a zero-value OP_RETURN (the signal) or self-change
+   *    paying the beacon script at or above the dust floor; at least one
+   *    self-change output must exist so the UTXO cannot be burned outright.
+   * 4. The implied absolute fee is capped at {@link #maxFeeSats}.
+   */
+  #assertBeaconTxShape(
+    cohortId: string,
+    state: ParticipantCohortState,
+    tx: Transaction,
+    prevOutScript: Uint8Array,
+    prevOutValue: bigint,
+  ): void {
+    const cohort = state.cohort!;
+    const expectedScript = beaconOutputScript(cohort);
+    if(!bytesEqual(prevOutScript, expectedScript)) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} does not spend the cohort's beacon UTXO (prevOutScript mismatch).`,
+        'PREVOUT_SCRIPT_MISMATCH', { cohortId }
+      );
+    }
+    if(tx.inputsLength !== 1) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} has ${tx.inputsLength} inputs; a beacon spend must have exactly one.`,
+        'UNEXPECTED_INPUT_COUNT', { cohortId, inputs: tx.inputsLength }
+      );
+    }
+
+    let outputTotal = 0n;
+    let selfChangeCount = 0;
+    for(let i = 0; i < tx.outputsLength; i++) {
+      const out = tx.getOutput(i);
+      if(!out?.script || out.amount === undefined) {
+        throw new AggregationParticipantError(
+          `Transaction for cohort ${cohortId} has a malformed output at index ${i}.`,
+          'TX_OUTPUT_MALFORMED', { cohortId, index: i }
+        );
+      }
+      outputTotal += out.amount;
+
+      let decoded: Array<string | Uint8Array> | undefined;
+      try { decoded = Script.decode(out.script) as Array<string | Uint8Array>; } catch { decoded = undefined; }
+      if(decoded && decoded[0] === 'RETURN') {
+        // The signal output must carry no value; a non-zero OP_RETURN burns sats.
+        if(out.amount !== 0n) {
+          throw new AggregationParticipantError(
+            `OP_RETURN output ${i} for cohort ${cohortId} carries ${out.amount} sats; signal outputs must be zero-value.`,
+            'SIGNAL_OUTPUT_CARRIES_VALUE', { cohortId, index: i }
+          );
+        }
+        continue;
+      }
+      if(!bytesEqual(out.script, expectedScript)) {
+        throw new AggregationParticipantError(
+          `Output ${i} for cohort ${cohortId} pays a script other than the cohort beacon address; change must return to the beacon.`,
+          'FOREIGN_OUTPUT', { cohortId, index: i }
+        );
+      }
+      if(out.amount < SELF_CHANGE_DUST_LIMIT_SATS) {
+        throw new AggregationParticipantError(
+          `Self-change output ${i} for cohort ${cohortId} is ${out.amount} sats, below the ${SELF_CHANGE_DUST_LIMIT_SATS}-sat dust floor.`,
+          'DUST_SELF_CHANGE', { cohortId, index: i }
+        );
+      }
+      selfChangeCount += 1;
+    }
+    if(selfChangeCount === 0) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} has no self-change output; the beacon UTXO must be carried forward, not burned.`,
+        'MISSING_SELF_CHANGE', { cohortId }
+      );
+    }
+
+    const fee = prevOutValue - outputTotal;
+    if(fee < 0n) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} spends ${outputTotal} sats from a ${prevOutValue}-sat UTXO.`,
+        'NEGATIVE_FEE', { cohortId }
+      );
+    }
+    if(fee > this.#maxFeeSats) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} implies a ${fee}-sat fee, above this member's ${this.#maxFeeSats}-sat ceiling.`,
+        'FEE_TOO_HIGH', { cohortId, fee: fee.toString(), maxFeeSats: this.#maxFeeSats.toString() }
+      );
+    }
+  }
+
+  /**
+   * User action: approve signing and generate nonce contribution. Refuses
+   * (throws) unless the service-supplied transaction anchors the validated
+   * signal AND is shaped like a genuine spend of this cohort's beacon UTXO:
+   * prevOut script bound to the beacon address, single input, zero-value
+   * OP_RETURN, self-change back to the beacon script above dust, and an
+   * absolute fee at or under `maxFeeSats` (audit M5).
    */
   public approveNonce(cohortId: string): BaseMessage[] {
     const state = this.#cohortStates.get(cohortId);
@@ -633,6 +779,11 @@ export class AggregationParticipant {
     // change script.
     const prevOutScripts = [hexToBytes(state.signingRequest.prevOutScriptHex)];
     const prevOutValues = [BigInt(state.signingRequest.prevOutValue)];
+
+    // Refuse to sign a spend that is not shaped like a genuine announcement of
+    // this cohort's beacon UTXO (prevOut binding, single input, self-change
+    // only, capped fee; audit M5).
+    this.#assertBeaconTxShape(cohortId, state, tx, prevOutScripts[0], prevOutValues[0]);
 
     const session = new BeaconSigningSession({
       id        : state.signingRequest.sessionId,
@@ -794,6 +945,10 @@ export class AggregationParticipant {
     // Refuse to sign unless the fallback tx anchors the signal this member
     // validated (the coordinator drives output selection on the fallback path).
     this.#assertTxAnchorsValidatedSignal(cohortId, state, tx);
+
+    // The fallback signs the SAME beacon tx with SIGHASH_DEFAULT, so the full
+    // output/fee sanity check applies identically (audit M5).
+    this.#assertBeaconTxShape(cohortId, state, tx, prevOutScript, prevOutValue);
 
     // Recompute the fallback leaf from our own cohort keys so a malicious service
     // cannot induce a signature over a different leaf than the one the funded

--- a/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
@@ -1,7 +1,6 @@
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
-import { p2tr, Script, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Script, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update, GenesisDocumentLike } from '@did-btcr2/method';
@@ -21,6 +20,7 @@ import {
   createValidationAckMessage,
   signEnvelope,
 } from '../src/index.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -352,12 +352,11 @@ describe('Aggregation transport + message auth hardening', () => {
       route(ctx.bobP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
 
       const cohort = ctx.service.getCohort(cohortId)!;
-      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-      const payment = p2tr(aggPk);
-      const tx = buildSignalTx(payment.script, 100000n, cohort.signalBytes!);
+      const script = beaconOutputScript(cohort);
+      const tx = buildSignalTx(script, 100000n, cohort.signalBytes!);
       route(ctx.service.startSigning(cohortId, {
         tx,
-        prevOutScripts : [payment.script],
+        prevOutScripts : [script],
         prevOutValues  : [100000n],
       }), { [ctx.alice.did]: ctx.aliceP, [ctx.bob.did]: ctx.bobP });
 

--- a/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
+++ b/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
@@ -34,8 +34,9 @@ import {
   createFallbackSignatureMessage,
 } from '../src/index.js';
 import { DidBtcr2 } from '@did-btcr2/method';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { bytesToHex } from '@noble/hashes/utils';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -154,6 +155,9 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
   function beaconTx(script: Uint8Array, internalKey: Uint8Array, value: bigint, signal: Uint8Array): Transaction {
     const tx = new Transaction({ version: 2, allowUnknownInputs: true, allowUnknownOutputs: true });
     tx.addInput({ txid: '22'.repeat(32), index: 0, witnessUtxo: { script, amount: value }, tapInternalKey: internalKey });
+    // Self-change back to the beacon script: members reject any spend whose
+    // change goes elsewhere (and any spend with no change at all) (audit M5).
+    tx.addOutput({ script, amount: value - 500n });
     tx.addOutput({ script: Script.encode([ 'RETURN', signal ]), amount: 0n });
     return tx;
   }
@@ -293,19 +297,21 @@ describe('Aggregate beacon fallback runner: latch safety (ADR 042)', () => {
     transport.registerPeer(svcDid, svcKeys.publicKey.compressed);
     transport.start();
 
-    const dummyScript = p2tr(schnorr.getPublicKey(hexToBytes('77'.repeat(32))), undefined, getNetwork('mutinynet')).script;
     const svc = new AggregationServiceRunner({
       transport,
       did             : svcDid,
       keys            : svcKeys,
-      onProvideTxData : async ({ signalBytes }) => {
+      onProvideTxData : async ({ cohortId, signalBytes }) => {
+        // The well-formed beacon shape: spend the cohort's beacon UTXO, return
+        // self-change to the beacon script, anchor the signal in an OP_RETURN.
+        const script = beaconOutputScript(svc.session.getCohort(cohortId)!);
         const value = 100000n;
         const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
-        tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: value, script: dummyScript } });
-        tx.addOutput({ script: dummyScript, amount: value - 500n });
+        tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: value, script } });
+        tx.addOutput({ script, amount: value - 500n });
         // Members bind their nonce approval to the validated signal.
         tx.addOutput({ script: Script.encode([ 'RETURN', signalBytes ]), amount: 0n });
-        return { tx, prevOutScripts: [ dummyScript ], prevOutValues: [ value ] };
+        return { tx, prevOutScripts: [ script ], prevOutValues: [ value ] };
       },
     });
     const participants = pKeys.map((k, i) => new AggregationParticipantRunner({

--- a/packages/aggregation/tests/aggregation-multi-cohort.spec.ts
+++ b/packages/aggregation/tests/aggregation-multi-cohort.spec.ts
@@ -1,8 +1,7 @@
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
-import { p2tr, Script, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Script, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 import {
   AggregationParticipantRunner,
@@ -12,6 +11,7 @@ import {
 } from '../src/index.js';
 import { DidBtcr2 } from '@did-btcr2/method';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -57,15 +57,14 @@ function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): Sig
 
 /** A dummy P2TR signing payload over the cohort's aggregate key (matches the solo/e2e demos). */
 function dummyTxData(cohort: AggregationCohort) {
-  const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-  const payment = p2tr(aggPk);
+  const script = beaconOutputScript(cohort);
   const prevOutValue = 100000n;
   const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
-  tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: prevOutValue, script: payment.script } });
-  tx.addOutput({ script: payment.script, amount: prevOutValue - 500n });
+  tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: prevOutValue, script } });
+  tx.addOutput({ script, amount: prevOutValue - 500n });
   // Members bind their nonce approval to the validated signal: anchor it in an OP_RETURN.
   if(cohort.signalBytes) tx.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes ]), amount: 0n });
-  return { tx, prevOutScripts: [ payment.script ], prevOutValues: [ prevOutValue ] };
+  return { tx, prevOutScripts: [ script ], prevOutValues: [ prevOutValue ] };
 }
 
 const CAS = (minParticipants = 1): CohortConfig => ({ minParticipants, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: TEST_RECOVERY_KEY, recoverySequence: TEST_RECOVERY_SEQUENCE });

--- a/packages/aggregation/tests/aggregation-noninclusion.spec.ts
+++ b/packages/aggregation/tests/aggregation-noninclusion.spec.ts
@@ -3,8 +3,7 @@ import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { base64UrlToHash, blockHash, didToIndex, verifySerializedProof } from '@did-btcr2/smt';
 import { hexToBytes } from '@noble/hashes/utils';
-import { p2tr, Script, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Script, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 import {
   AggregationCohort,
@@ -31,6 +30,7 @@ import {
 } from '../src/index.js';
 import { DidBtcr2 } from '@did-btcr2/method';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -241,11 +241,10 @@ describe('Aggregate beacon cooperative non-inclusion', () => {
 
     async function driveSigningToComplete(cohortId: string): Promise<void> {
       const cohort = service.getCohort(cohortId)!;
-      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-      const payment = p2tr(aggPk);
+      const script = beaconOutputScript(cohort);
       const prevOutValue = 100000n;
-      const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
-      await send(serviceTransport, serviceDid, service.startSigning(cohortId, { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] }));
+      const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
+      await send(serviceTransport, serviceDid, service.startSigning(cohortId, { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] }));
       await send(aliceTransport, aliceDid, alice.approveNonce(cohortId));
       await send(bobTransport, bobDid, bob.approveNonce(cohortId));
       await send(serviceTransport, serviceDid, service.sendAggregatedNonce(cohortId));

--- a/packages/aggregation/tests/aggregation-participant-tx-checks.spec.ts
+++ b/packages/aggregation/tests/aggregation-participant-tx-checks.spec.ts
@@ -1,0 +1,235 @@
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { getNetwork } from '@did-btcr2/bitcoin';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
+import { DidBtcr2 } from '@did-btcr2/method';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { p2tr, Script, Transaction } from '@scure/btc-signer';
+import { expect } from 'chai';
+
+import type {
+  BaseMessage} from '../src/index.js';
+import {
+  AggregationParticipant,
+  AggregationService,
+  KeyPairAggregationSigner,
+  ParticipantCohortPhase,
+  ServiceCohortPhase,
+  buildFallbackLeaf,
+  createFallbackAuthorizationRequestMessage,
+} from '../src/index.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+
+function makeIdentity(network = 'mutinynet'): { keys: SchnorrKeyPair; did: string } {
+  const keys = SchnorrKeyPair.generate();
+  const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network });
+  return { keys, did };
+}
+
+function createSignedUpdate(did: string, keys: SchnorrKeyPair): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [
+      { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } },
+    ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : 2,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : `${did}#initialKey`,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(`${did}#initialKey`, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+/** A script that is NOT the cohort beacon output (a foreign taproot key). */
+function foreignScript(): Uint8Array {
+  return p2tr(schnorr.getPublicKey(hexToBytes('77'.repeat(32))), undefined, getNetwork('mutinynet')).script;
+}
+
+/** How the signing tx handed to the participant should be shaped. */
+interface TxSpec {
+  /** Input 0 prevout script; defaults to the cohort beacon script. */
+  prevOutScript?: Uint8Array;
+  prevOutValue?: bigint;
+  /** Add a second (foreign) input. */
+  extraInput?: boolean;
+  /** Self-change amount back to the beacon script; omit for no change output. */
+  selfChange?: bigint;
+  /** Attach the validated signal as a zero-value OP_RETURN. Defaults to true. */
+  withSignal?: boolean;
+  /** Sats carried by the OP_RETURN output (must be 0 for a well-formed tx). */
+  signalAmount?: bigint;
+  /** Change output paying a foreign script. */
+  foreignChange?: bigint;
+}
+
+interface Drive {
+  service: AggregationService;
+  participant: AggregationParticipant;
+  cohortId: string;
+  serviceDid: string;
+  memberDid: string;
+  script: Uint8Array;
+  value: bigint;
+}
+
+/**
+ * Drive a 1-member cohort to the member's AwaitingSigning phase with a signing
+ * tx built from `spec`. All protocol messages are cryptographically real; only
+ * the final tx shape varies.
+ */
+function driveToAwaitingSigning(spec: TxSpec, participantOpts?: { maxFeeSats?: bigint | number }): Drive {
+  const serviceId = makeIdentity();
+  const member = makeIdentity();
+  const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
+  const participant = new AggregationParticipant({
+    did    : member.did,
+    signer : new KeyPairAggregationSigner(member.keys),
+    ...participantOpts,
+  });
+  const route = (msgs: BaseMessage[]): void => {
+    for(const m of msgs) {
+      // Broadcasts (the cohort advert) reach the listening member; addressed
+      // messages reach their named recipient.
+      if(m.to === undefined) { participant.receive(m); continue; }
+      (m.to === member.did ? participant : service).receive(m);
+    }
+  };
+
+  const cohortId = service.createCohort({
+    minParticipants  : 1,
+    network          : 'mutinynet',
+    beaconType       : 'CASBeacon',
+    recoveryKey      : TEST_RECOVERY_KEY,
+    recoverySequence : TEST_RECOVERY_SEQUENCE,
+  });
+  route(service.advertise(cohortId));
+  route(participant.joinCohort(cohortId));
+  route(service.acceptParticipant(cohortId, member.did));
+  route(service.finalizeKeygen(cohortId));
+  route(participant.submitUpdate(cohortId, createSignedUpdate(member.did, member.keys)));
+  route(service.buildAndDistribute(cohortId));
+  route(participant.approveValidation(cohortId));
+  expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
+
+  const cohort = service.getCohort(cohortId)!;
+  const script = beaconOutputScript(cohort);
+  const value = spec.prevOutValue ?? 100000n;
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({
+    txid        : '00'.repeat(32),
+    index       : 0,
+    witnessUtxo : { amount: value, script: spec.prevOutScript ?? script },
+  });
+  if(spec.extraInput) {
+    tx.addInput({ txid: '11'.repeat(32), index: 1, witnessUtxo: { amount: 1000n, script: foreignScript() } });
+  }
+  if(spec.selfChange !== undefined) tx.addOutput({ script, amount: spec.selfChange });
+  if(spec.foreignChange !== undefined) tx.addOutput({ script: foreignScript(), amount: spec.foreignChange });
+  if(spec.withSignal !== false) {
+    tx.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes! ]), amount: spec.signalAmount ?? 0n });
+  }
+
+  const prevOutScript = spec.prevOutScript ?? script;
+  route(service.startSigning(cohortId, { tx, prevOutScripts: [ prevOutScript ], prevOutValues: [ value ] }));
+  expect(participant.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingSigning);
+  return { service, participant, cohortId, serviceDid: serviceId.did, memberDid: member.did, script, value };
+}
+
+describe('Participant beacon-tx validation (audit M5)', () => {
+
+  it('accepts a well-formed beacon spend (control)', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
+    const msgs = d.participant.approveNonce(d.cohortId);
+    expect(msgs).to.have.lengthOf(1);
+    expect(d.participant.getCohortPhase(d.cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+  });
+
+  it('refuses a prevOutScript that is not the cohort beacon script', () => {
+    const d = driveToAwaitingSigning({ prevOutScript: foreignScript(), selfChange: 100000n - 500n });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/PREVOUT_SCRIPT_MISMATCH|beacon UTXO/);
+  });
+
+  it('refuses a spend with more than one input', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n, extraInput: true });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/UNEXPECTED_INPUT_COUNT|exactly one/);
+  });
+
+  it('refuses change paid to a foreign script', () => {
+    const d = driveToAwaitingSigning({ foreignChange: 100000n - 500n });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FOREIGN_OUTPUT|beacon address/);
+  });
+
+  it('refuses a spend with no self-change output (whole UTXO burned)', () => {
+    const d = driveToAwaitingSigning({});
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/MISSING_SELF_CHANGE|carried forward/);
+  });
+
+  it('refuses a dust self-change output', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100n });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/DUST_SELF_CHANGE|dust/);
+  });
+
+  it('refuses a value-carrying OP_RETURN output', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 1500n, signalAmount: 1000n });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/SIGNAL_OUTPUT_CARRIES_VALUE|zero-value/);
+  });
+
+  it('refuses a fee above the default ceiling', () => {
+    const d = driveToAwaitingSigning({ prevOutValue: 300000n, selfChange: 150000n });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FEE_TOO_HIGH|ceiling/);
+  });
+
+  it('honors a custom maxFeeSats ceiling', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n }, { maxFeeSats: 400 });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FEE_TOO_HIGH|ceiling/);
+  });
+
+  it('refuses a fallback spend whose change pays a foreign script', () => {
+    // The optimistic request is well-formed; the tampered tx arrives on the
+    // fallback authorization request.
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
+    const cohort = d.service.getCohort(d.cohortId)!;
+    const sessionId = d.service.getSigningSessionId(d.cohortId)!;
+
+    const tampered = new Transaction({ version: 2, allowUnknownOutputs: true });
+    tampered.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: d.value, script: d.script } });
+    tampered.addOutput({ script: foreignScript(), amount: d.value - 500n });
+    tampered.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes! ]), amount: 0n });
+
+    const leaf = buildFallbackLeaf({
+      cohortKeys        : cohort.cohortKeys,
+      fallbackThreshold : cohort.effectiveFallbackThreshold,
+    });
+    d.participant.receive(createFallbackAuthorizationRequestMessage({
+      from                  : d.serviceDid,
+      to                    : d.memberDid,
+      cohortId              : d.cohortId,
+      sessionId,
+      pendingTx             : tampered.hex,
+      prevOutScriptHex      : bytesToHex(d.script),
+      prevOutValue          : d.value.toString(),
+      fallbackLeafScriptHex : bytesToHex(leaf),
+    }));
+    expect(d.participant.getCohortPhase(d.cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+    expect(() => d.participant.approveFallback(d.cohortId)).to.throw(/FOREIGN_OUTPUT|beacon address/);
+  });
+});

--- a/packages/aggregation/tests/aggregation-x1-transport-auth.spec.ts
+++ b/packages/aggregation/tests/aggregation-x1-transport-auth.spec.ts
@@ -1,8 +1,7 @@
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils';
-import { p2tr, Script, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Script, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update, GenesisDocumentLike } from '@did-btcr2/method';
@@ -24,6 +23,7 @@ import {
   type HttpRequestLike,
 } from '../src/index.js';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 /**
  * Trustless transport authentication for EXTERNAL (x1) did:btcr2 identifiers (ADR 066).
@@ -398,11 +398,10 @@ describe('x1 transport authentication (ADR 066)', () => {
         config          : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: TEST_RECOVERY_KEY, recoverySequence: TEST_RECOVERY_SEQUENCE },
         onProvideTxData : async () => {
           const cohort = service.session.cohorts[0];
-          const aggPk  = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-          const payment = p2tr(aggPk);
+          const script = beaconOutputScript(cohort);
           const prevOutValue = 100000n;
-          const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
-          return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+          const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
+          return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
         },
       });
 

--- a/packages/aggregation/tests/aggregation.spec.ts
+++ b/packages/aggregation/tests/aggregation.spec.ts
@@ -23,6 +23,7 @@ import {
 } from '../src/index.js';
 import { DidBtcr2 } from '@did-btcr2/method';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -437,14 +438,13 @@ describe('Aggregation', () => {
 
       // ── Step 4: Sign ──
       const cohort = service.getCohort(cohortId)!;
-      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-      const payment = p2tr(aggPk);
+      const script = beaconOutputScript(cohort);
       const prevOutValue = 100000n;
-      const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
+      const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
 
       await send(serviceTransport, serviceDid, service.startSigning(cohortId, {
         tx,
-        prevOutScripts : [payment.script],
+        prevOutScripts : [script],
         prevOutValues  : [prevOutValue],
       }));
       expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.SigningStarted);
@@ -510,14 +510,13 @@ describe('Aggregation', () => {
       expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
 
       // ── Step 4: Sign ──
-      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-      const payment = p2tr(aggPk);
+      const script = beaconOutputScript(cohort);
       const prevOutValue = 100000n;
-      const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
+      const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
 
       await send(serviceTransport, serviceDid, service.startSigning(cohortId, {
         tx,
-        prevOutScripts : [payment.script],
+        prevOutScripts : [script],
         prevOutValues  : [prevOutValue],
       }));
 
@@ -655,11 +654,10 @@ describe('Aggregation', () => {
         config          : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: TEST_RECOVERY_KEY, recoverySequence: TEST_RECOVERY_SEQUENCE },
         onProvideTxData : async () => {
           const cohort = service.session.cohorts[0];
-          const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-          const payment = p2tr(aggPk);
+          const script = beaconOutputScript(cohort);
           const prevOutValue = 100000n;
-          const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
-          return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+          const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
+          return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
         },
       });
 
@@ -791,11 +789,10 @@ describe('Aggregation', () => {
         config          : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: TEST_RECOVERY_KEY, recoverySequence: TEST_RECOVERY_SEQUENCE },
         onProvideTxData : async () => {
           const cohort = service.session.cohorts[0];
-          const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-          const payment = p2tr(aggPk);
+          const script = beaconOutputScript(cohort);
           const prevOutValue = 100000n;
-          const tx = buildDummyTx(payment.script, prevOutValue, cohort.signalBytes!);
-          return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+          const tx = buildDummyTx(script, prevOutValue, cohort.signalBytes!);
+          return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
         },
       });
 

--- a/packages/aggregation/tests/helpers/beacon-script.ts
+++ b/packages/aggregation/tests/helpers/beacon-script.ts
@@ -1,0 +1,14 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { Address, OutScript } from '@scure/btc-signer';
+import type { AggregationCohort } from '../../src/index.js';
+
+/**
+ * The scriptPubKey of the cohort's funded beacon UTXO, decoded from the beacon
+ * address computed at keygen (internal MuSig2 key + recovery script tree). Test
+ * txs that stand in for the operator-built beacon spend must use this script as
+ * both prevout and self-change script: participants reject any other shape
+ * (audit M5).
+ */
+export function beaconOutputScript(cohort: AggregationCohort): Uint8Array {
+  return OutScript.encode(Address(getNetwork(cohort.network)).decode(cohort.beaconAddress));
+}


### PR DESCRIPTION
* fix(aggregation): participants refuse to sign spends that do not target the beacon UTXO, carry foreign change, lack self-change, or exceed a fee ceiling (audit M5)
* test(aggregation): cover tx-shape refusals and align existing specs with the legitimate beacon shape