### PR TITLE
fix full-node signal discovery; harden resolver input handling

### DIFF
--- a/packages/common/src/json-patch.ts
+++ b/packages/common/src/json-patch.ts
@@ -6,6 +6,14 @@ import type { JSONObject } from './types.js';
 const { applyPatch, compare, deepClone } = jsonPatch;
 
 export type PatchOpCode = 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
+
+/** Maximum operations in a single JSON Patch (audit L10). */
+export const MAX_PATCH_OPERATIONS = 1024;
+/** Maximum length of an operation's JSON Pointer path (audit L10). */
+export const MAX_PATCH_PATH_LENGTH = 2048;
+/** Maximum JSON-serialized size of an operation's value, in bytes (audit L10). */
+export const MAX_PATCH_VALUE_BYTES = 256 * 1024;
+
 /**
  * A JSON Patch operation, as defined in {@link https://datatracker.ietf.org/doc/html/rfc6902 | RFC 6902}.
  */
@@ -95,18 +103,40 @@ export class JSONPatch {
   }
 
   /**
- * Validate JSON Patch operations.
- * @param {PatchOperation[]} operations - The operations to validate.
- * @returns {MethodError | null} A MethodError if validation fails, otherwise null.
- */
+   * Validate JSON Patch operations.
+   *
+   * Beyond shape checks, patches carried by untrusted DID updates are bounded
+   * in count, path length, and value size so a hostile update cannot force
+   * unbounded patch work (audit L10).
+   *
+   * @param {PatchOperation[]} operations - The operations to validate.
+   * @returns {MethodError | null} A MethodError if validation fails, otherwise null.
+   */
   static validateOperations(operations: PatchOperation[]): MethodError | null {
     if (!Array.isArray(operations)) return new MethodError('Operations must be an array', 'JSON_PATCH_VALIDATION_ERROR');
+    if (operations.length > MAX_PATCH_OPERATIONS) {
+      return new MethodError(`Too many operations: ${operations.length} > ${MAX_PATCH_OPERATIONS}`, 'JSON_PATCH_VALIDATION_ERROR');
+    }
     for (const op of operations) {
       if (!op || typeof op !== 'object') return new MethodError('Operation must be an object', 'JSON_PATCH_VALIDATION_ERROR');
       if (typeof op.op !== 'string') return new MethodError('Operation.op must be a string', 'JSON_PATCH_VALIDATION_ERROR');
       if (typeof op.path !== 'string') return new MethodError('Operation.path must be a string', 'JSON_PATCH_VALIDATION_ERROR');
+      if (op.path.length > MAX_PATCH_PATH_LENGTH) {
+        return new MethodError(`Operation.path too long: ${op.path.length} > ${MAX_PATCH_PATH_LENGTH}`, 'JSON_PATCH_VALIDATION_ERROR');
+      }
       if ((op.op === 'move' || op.op === 'copy') && typeof op.from !== 'string') {
         return new MethodError(`Operation.from must be a string for op=${op.op}`, 'JSON_PATCH_VALIDATION_ERROR');
+      }
+      if (op.value !== undefined) {
+        let valueSize: number;
+        try {
+          valueSize = JSON.stringify(op.value).length;
+        } catch {
+          return new MethodError('Operation.value is not JSON-serializable', 'JSON_PATCH_VALIDATION_ERROR');
+        }
+        if (valueSize > MAX_PATCH_VALUE_BYTES) {
+          return new MethodError(`Operation.value too large: ${valueSize} > ${MAX_PATCH_VALUE_BYTES} bytes`, 'JSON_PATCH_VALIDATION_ERROR');
+        }
       }
     }
     return null;

--- a/packages/common/tests/json-patch.spec.ts
+++ b/packages/common/tests/json-patch.spec.ts
@@ -28,6 +28,27 @@ describe('JSONPatch', () => {
     expect(() => JSONPatch.apply(source, ops)).to.throw(MethodError, 'Invalid JSON Patch operations');
   });
 
+  it('rejects a patch with too many operations (audit L10)', () => {
+    const ops = Array.from({ length: 1025 }, () => ({ op: 'add', path: '/x', value: 1 }) as any);
+    expect(() => JSONPatch.apply({ a: 1 }, ops)).to.throw(MethodError, 'Invalid JSON Patch operations');
+    expect(JSONPatch.validateOperations(ops)?.message).to.match(/Too many operations/);
+  });
+
+  it('rejects an operation with an over-long path (audit L10)', () => {
+    const ops = [{ op: 'add', path: `/${'a'.repeat(2048)}`, value: 1 } as any];
+    expect(JSONPatch.validateOperations(ops)?.message).to.match(/path too long/);
+  });
+
+  it('rejects an operation with an oversized value (audit L10)', () => {
+    const ops = [{ op: 'add', path: '/x', value: 'x'.repeat(300 * 1024) } as any];
+    expect(JSONPatch.validateOperations(ops)?.message).to.match(/value too large/);
+  });
+
+  it('accepts a patch within the bounds', () => {
+    const ops = [{ op: 'add', path: '/x', value: 'y' } as any];
+    expect(JSONPatch.validateOperations(ops)).to.be.null;
+  });
+
   it('computes diffs and prefixes paths with escaping', () => {
     const source = { 'a/b': 1 };
     const target = { 'a/b': 2, c: 3 };

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -6,6 +6,7 @@ import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
 import type { BroadcastOptions, BroadcastResult } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
+import { CASBeaconError } from './error.js';
 import type { BeaconService, BeaconSignal, BlockMetadata, CasPublishFn } from './interfaces.js';
 
 /**
@@ -111,7 +112,17 @@ export class CASBeacon extends SinglePartyBeacon {
         continue;
       }
 
-      const updateHash = encode(decode(updateHashEncoded, 'base64urlnopad'), 'hex');
+      // A malformed announcement entry must surface as a typed error, not a raw
+      // decode throw escaping resolution (audit L7).
+      let updateHash: string;
+      try {
+        updateHash = encode(decode(updateHashEncoded, 'base64urlnopad'), 'hex');
+      } catch {
+        throw new CASBeaconError(
+          'Malformed update hash in CAS announcement',
+          'INVALID_CAS_ANNOUNCEMENT', { did, updateHashEncoded }
+        );
+      }
 
       // Look up the signed update in sidecar updateMap
       const signedUpdate = sidecar.updateMap.get(updateHash);

--- a/packages/method/src/core/beacon/signal-discovery.ts
+++ b/packages/method/src/core/beacon/signal-discovery.ts
@@ -224,11 +224,12 @@ export class BeaconSignalDiscovery {
             continue;
           }
 
-          // A beacon signal output must be exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
-          // Reject any other shape so a malformed on-chain output cannot masquerade as a
-          // phantom signal downstream.
-          const txVoutScriptPubkeyAsm = prevout.vout[vin.vout].scriptPubKey.asm;
-          const updateHash = extractOpReturnSignal(txVoutScriptPubkeyAsm);
+          // The signal is carried by the SPENDING transaction's last output (an
+          // OP_RETURN), never by the spent prevout: the prevout is the beacon
+          // address's payment script, so reading it here always yielded null and
+          // full-node discovery silently reported zero signals (audit H5).
+          const signalVout = tx.vout.slice(-1)[0];
+          const updateHash = extractOpReturnSignal(signalVout?.scriptPubKey?.asm);
           if(!updateHash) {
             continue;
           }

--- a/packages/method/src/core/beacon/smt-beacon.ts
+++ b/packages/method/src/core/beacon/smt-beacon.ts
@@ -81,12 +81,22 @@ export class SMTBeacon extends SinglePartyBeacon {
       // inclusion = hash(hash(nonce) || updateId); non-inclusion = hash(hash(nonce)).
       // Hash fields are base64url (no padding) per the SMT Proof spec. A
       // non-inclusion proof (absent updateId) is verified too, not trusted.
-      const index = didToIndex(did);
-      const nonceHash = base64UrlToHash(smtProof.nonce);
-      const candidateHash = smtProof.updateId
-        ? blockHash(blockHash(nonceHash), base64UrlToHash(smtProof.updateId))
-        : blockHash(blockHash(nonceHash));
-      const valid = verifySerializedProof(smtProof, index, candidateHash);
+      // Malformed base64url fields must surface as a typed error, not a raw
+      // decode throw escaping resolution (audit L7).
+      let valid: boolean;
+      try {
+        const index = didToIndex(did);
+        const nonceHash = base64UrlToHash(smtProof.nonce);
+        const candidateHash = smtProof.updateId
+          ? blockHash(blockHash(nonceHash), base64UrlToHash(smtProof.updateId))
+          : blockHash(blockHash(nonceHash));
+        valid = verifySerializedProof(smtProof, index, candidateHash);
+      } catch {
+        throw new SMTBeaconError(
+          'Malformed SMT proof fields.',
+          'INVALID_SMT_PROOF', { smtProof, did }
+        );
+      }
 
       if(!valid) {
         throw new SMTBeaconError(

--- a/packages/method/src/core/beacon/utils.ts
+++ b/packages/method/src/core/beacon/utils.ts
@@ -174,14 +174,20 @@ export class BeaconUtils {
 
   /**
    * Create a map of address => beaconService with address field.
+   *
+   * Values are the ORIGINAL service objects (not re-parsed copies) so callers
+   * can look a service up by address and then use identity-based collections
+   * keyed by the service itself (e.g. the fullnode discovery result map).
+   *
    * @param {Array<BeaconService>} beacons The list of beacon services.
    * @returns {Map<string, BeaconService>} A map of address => beaconService.
    */
   static getBeaconServicesMap(beacons: Array<BeaconService>): Map<string, BeaconService> {
     return new Map<string, BeaconService>(
-      beacons
-        .map(this.parseBeaconServiceEndpoint)
-        .map((beacon) => ([beacon.serviceEndpoint as string, beacon]))
+      beacons.map((beacon) => ([
+        this.parseBitcoinAddress(beacon.serviceEndpoint as string),
+        beacon
+      ]))
     );
   }
 

--- a/packages/method/src/core/identifier.ts
+++ b/packages/method/src/core/identifier.ts
@@ -28,6 +28,14 @@ export interface IdentifierComponents {
     network: string;
     genesisBytes: Bytes;
 }
+
+/**
+ * Upper bound on the bech32m method-specific-id length accepted by
+ * {@link Identifier.decode}. A conformant id is 55-57 characters (1-char hrp,
+ * separator, and 53-55 data chars for a 33- or 34-byte payload).
+ */
+export const MAX_METHOD_SPECIFIC_ID_LENGTH = 96;
+
 /**
  * Implements {@link https://dcdpr.github.io/did-btcr2/#syntax | 3 Syntax}.
  * A did:btcr2 DID consists of a did:btcr2 prefix, followed by an id-bech32 value, which is a Bech32m encoding of:
@@ -143,8 +151,21 @@ export class Identifier {
       throw new IdentifierError(`Invalid method-specific id: ${identifier}`, INVALID_DID, { identifier });
     }
 
-    // 6. Bech32m-decode the id into its hrp and dataBytes.
-    const { prefix: hrp, bytes: dataBytes } = bech32m.decodeToBytes(encoded);
+    // 6. Bech32m-decode the id into its hrp and dataBytes. Cap the length first
+    //    so an over-long input is rejected with a typed error before any decode
+    //    work (audit I1), and convert the library's raw throw on malformed
+    //    bech32m into a typed error (audit L7). A conformant id is 55-57 chars;
+    //    96 leaves generous headroom while bounding decode work.
+    if (encoded.length > MAX_METHOD_SPECIFIC_ID_LENGTH) {
+      throw new IdentifierError(`Method-specific id too long: ${encoded.length} chars`, INVALID_DID, { identifier });
+    }
+    let hrp: string;
+    let dataBytes: Uint8Array;
+    try {
+      ({ prefix: hrp, bytes: dataBytes } = bech32m.decodeToBytes(encoded));
+    } catch {
+      throw new IdentifierError(`Failed to bech32m-decode id: ${encoded}`, INVALID_DID, { identifier });
+    }
 
     // 7. The hrp MUST be "k" (KEY) or "x" (EXTERNAL).
     if (!['x', 'k'].includes(hrp)) {

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -9,6 +9,7 @@ import {
   INTERNAL_ERROR,
   INVALID_DID_DOCUMENT,
   INVALID_DID_UPDATE,
+  INVALID_SIDECAR_DATA,
   JSONPatch,
   JSONUtils,
   LATE_PUBLISHING_ERROR,
@@ -368,7 +369,18 @@ export class Resolver {
     const smtMap = new Map<string, SMTProof>();
     if(sidecar.smtProofs?.length)
       for(const proof of sidecar.smtProofs) {
-        smtMap.set(encodeHash(decodeHash(proof.id, 'base64urlnopad'), 'hex'), proof);
+        // A malformed proof id must surface as a typed error, not a raw decode
+        // throw escaping resolution (audit L7).
+        let rootHashHex: string;
+        try {
+          rootHashHex = encodeHash(decodeHash(proof.id, 'base64urlnopad'), 'hex');
+        } catch {
+          throw new ResolveError(
+            'Malformed SMT proof id in sidecar data',
+            INVALID_SIDECAR_DATA, { proofId: proof?.id }
+          );
+        }
+        smtMap.set(rootHashHex, proof);
       }
 
     return { updateMap, casMap, smtMap };
@@ -415,7 +427,7 @@ export class Resolver {
         versionId     : `${currentVersionId}`,
         confirmations : 0,
         updated       : '',
-        deactivated   : currentDocument.deactivated || false
+        deactivated   : currentDocument.deactivated === true
       }
     };
 
@@ -443,12 +455,6 @@ export class Resolver {
       // tuple that chains to a skipped update then correctly surfaces as a
       // late-publishing error.
       if(block.confirmations < minConf) continue;
-
-      // Set the updated field to the blocktime of the current update
-      response.metadata.updated = DateUtils.toISOStringNonFractional(blocktime);
-
-      // Set confirmations to the block confirmations
-      response.metadata.confirmations = block.confirmations;
 
       // Check update.targetVersionId against currentVersionId.
       // If update.targetVersionId <= currentVersionId, this update re-announces a version
@@ -483,8 +489,18 @@ export class Resolver {
 
       // If update.targetVersionId == currentVersionId + 1, apply the update
       if (update.targetVersionId === currentVersionId + 1) {
-        // Check if update.sourceHash !== currentDocumentHash (byte comparison)
-        const sourceHashBytes = decodeHash(update.sourceHash, 'base64urlnopad');
+        // Check if update.sourceHash !== currentDocumentHash (byte comparison).
+        // A malformed sourceHash must surface as a typed error, not a raw decode
+        // throw escaping resolution (audit L7).
+        let sourceHashBytes: HashBytes;
+        try {
+          sourceHashBytes = decodeHash(update.sourceHash, 'base64urlnopad');
+        } catch {
+          throw new ResolveError(
+            'Malformed update.sourceHash',
+            INVALID_DID_UPDATE, { sourceHash: update.sourceHash }
+          );
+        }
         if (!equalBytes(sourceHashBytes, currentDocumentHash)) {
           throw new ResolveError(
             `Hash mismatch: update.sourceHash !== currentDocumentHash`,
@@ -496,6 +512,12 @@ export class Resolver {
         }
         // Apply the update to the currentDocument and set it in the response
         response.didDocument = this.applyUpdate(response.didDocument, update);
+
+        // Resolution metadata reflects APPLIED updates only. A duplicate
+        // re-announcement (handled above) must not clobber confirmations/updated
+        // with its own later, shallower block data (audit L8).
+        response.metadata.updated = DateUtils.toISOStringNonFractional(blocktime);
+        response.metadata.confirmations = block.confirmations;
 
         // Create unsigned_update by removing the proof property from update.
         const unsignedUpdate = JSONUtils.deleteKeys(update, ['proof']) as UnsignedBTCR2Update;
@@ -521,10 +543,12 @@ export class Resolver {
       // Set response.versionId to be the new currentVersionId
       response.metadata.versionId = `${currentVersionId}`;
 
-      // Check if the current document is deactivated before further processing
-      if(response.didDocument.deactivated) {
+      // Check if the current document is deactivated before further processing.
+      // Strict boolean: a truthy non-boolean (a string, an object) is not a
+      // deactivation (audit I6).
+      if(response.didDocument.deactivated === true) {
         // Set the response deactivated flag to true
-        response.metadata.deactivated = response.didDocument.deactivated;
+        response.metadata.deactivated = true;
         // If deactivated, stop processing further updates and return the response
         return response;
       }
@@ -621,6 +645,17 @@ export class Resolver {
       );
     }
 
+    // The write path signs capabilityAction 'Write'; the resolve path must
+    // enforce it, or a proof carrying any other (or no) action would authorize
+    // a DID update it never intended (audit I4).
+    const capabilityAction = update.proof?.capabilityAction;
+    if(capabilityAction !== 'Write') {
+      throw new ResolveError(
+        'Invalid update: capabilityAction must be "Write"',
+        INVALID_DID_UPDATE, { capabilityAction }
+      );
+    }
+
     // Get the verificationMethod field from the update proof as verificationMethodId.
     const verificationMethodId = update.proof?.verificationMethod;
     // Since this field is optional, check that it exists
@@ -689,7 +724,16 @@ export class Resolver {
     const currentDocumentHash = canonicalHashBytes(updatedDocument);
 
     // Prepare the update targetHash for comparison with currentDocumentHash.
-    const updateTargetHash = decodeHash(update.targetHash);
+    // Typed error on malformed input, not a raw decode throw (audit L7).
+    let updateTargetHash: HashBytes;
+    try {
+      updateTargetHash = decodeHash(update.targetHash);
+    } catch {
+      throw new ResolveError(
+        'Malformed update.targetHash',
+        INVALID_DID_UPDATE, { targetHash: update.targetHash }
+      );
+    }
 
     // Make sure the update.targetHash equals currentDocumentHash.
     if (!equalBytes(updateTargetHash, currentDocumentHash)) {
@@ -864,8 +908,12 @@ export class Resolver {
             result : this.#resolvedResponse ?? {
               didDocument : this.#currentDocument!,
               metadata    : {
-                versionId   : this.#versionId ?? '1',
-                deactivated : this.#currentDocument!.deactivated || false
+                // No updates were applied: the current version is the counter the
+                // resolution actually reached, not the caller's requested
+                // versionId (which may name a version that does not exist)
+                // (audit I2).
+                versionId   : String(this.#currentVersionId),
+                deactivated : this.#currentDocument!.deactivated === true
               }
             }
           };

--- a/packages/method/src/utils/appendix.ts
+++ b/packages/method/src/utils/appendix.ts
@@ -161,13 +161,17 @@ export class Appendix {
     const rootCapability = {} as RootCapability;
 
     // 2. Set components to the result of capabilityId.split(":").
-    const [urn, zcap, root, did] = capabilityId.split(':') ?? [];
+    const components = capabilityId.split(':');
 
     // 3. Validate components:
-    //    1. Assert length of components is 4.
-    if ([urn, zcap, root, did].length !== 4) {
+    //    1. Assert length of components is 4. Split first, then count: the
+    //    previous destructuring form always produced exactly four slots, so the
+    //    check could never fire and trailing segments were silently ignored
+    //    (audit L9).
+    if (components.length !== 4) {
       throw new DidError(DidErrorCode.InvalidDid, `Invalid capabilityId: ${capabilityId}`);
     }
+    const [urn, zcap, root, did] = components;
 
     //    2. components[0] == urn.
     if (!urn || urn !== 'urn') {
@@ -187,8 +191,15 @@ export class Appendix {
     // 4. Set uriEncodedId to components[3].
     const uriEncodedId = did;
 
-    // 5. Set Identifier the result of decodeURIComponent(uriEncodedId).
-    const Identifier = decodeURIComponent(uriEncodedId);
+    // 5. Set Identifier the result of decodeURIComponent(uriEncodedId). A
+    //    malformed percent-escape throws a raw URIError; surface it as a typed
+    //    error instead.
+    let Identifier: string;
+    try {
+      Identifier = decodeURIComponent(uriEncodedId);
+    } catch {
+      throw new DidError(DidErrorCode.InvalidDid, `Invalid capabilityId encoding: ${capabilityId}`);
+    }
 
     // 6. Set rootCapability.id to capabilityId.
     rootCapability.id = capabilityId;

--- a/packages/method/tests/appendix.spec.ts
+++ b/packages/method/tests/appendix.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { Appendix } from '../src/utils/appendix.js';
+
+const VALID_CAP_ID = 'urn:zcap:root:did%3Abtcr2%3Ak1q0rnnwf657vuu8trztlczvlmphjgc6q598h79cm6sp7c4fgqh0fkc0vzd9u';
+
+describe('Appendix.dereferenceZcapId', () => {
+  it('dereferences a well-formed root capability id', () => {
+    const cap = Appendix.dereferenceZcapId(VALID_CAP_ID);
+    expect(cap.controller).to.equal('did:btcr2:k1q0rnnwf657vuu8trztlczvlmphjgc6q598h79cm6sp7c4fgqh0fkc0vzd9u');
+    expect(cap.invocationTarget).to.equal('did:btcr2:k1q0rnnwf657vuu8trztlczvlmphjgc6q598h79cm6sp7c4fgqh0fkc0vzd9u');
+  });
+
+  it('rejects a capability id with trailing segments (audit L9)', () => {
+    expect(() => Appendix.dereferenceZcapId(`${VALID_CAP_ID}:extra`)).to.throw(/Invalid capabilityId/);
+  });
+
+  it('rejects a capability id with too few segments', () => {
+    expect(() => Appendix.dereferenceZcapId('urn:zcap:root')).to.throw(/Invalid capabilityId/);
+  });
+
+  it('rejects a capability id with a wrong scheme or type segment', () => {
+    expect(() => Appendix.dereferenceZcapId('http:zcap:root:did%3Abtcr2%3Ak1x')).to.throw(/Invalid capabilityId/);
+    expect(() => Appendix.dereferenceZcapId('urn:foo:root:did%3Abtcr2%3Ak1x')).to.throw(/Invalid capabilityId/);
+  });
+
+  it('rejects a malformed percent-encoding with a typed error, not a raw URIError', () => {
+    expect(() => Appendix.dereferenceZcapId('urn:zcap:root:did%E0%A4%A')).to.throw(/Invalid capabilityId/);
+  });
+});

--- a/packages/method/tests/decode-identifier.spec.ts
+++ b/packages/method/tests/decode-identifier.spec.ts
@@ -50,6 +50,14 @@ describe('Decode Identifier', () => {
     it('rejects malformed bech32m payloads', () => {
       expect(() => Identifier.decode('did:btcr2:k1notavalidbech32m')).to.throw();
     });
+
+    it('rejects malformed bech32m payloads with a typed IdentifierError (audit L7)', () => {
+      expect(() => Identifier.decode('did:btcr2:k1notavalidbech32m')).to.throw(/bech32m/i);
+    });
+
+    it('rejects over-long method-specific ids before decoding (audit I1)', () => {
+      expect(() => Identifier.decode(`did:btcr2:k1${'q'.repeat(200)}`)).to.throw(/too long/i);
+    });
   });
 
   describe('hrp validation', () => {

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1764,3 +1764,92 @@ describe('Resolver security regressions (audit batch 1)', () => {
     expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length + 1);
   });
 });
+
+describe('Resolver security regressions (audit: discovery hardening)', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+  const vmOf = (doc: DidDocument) => doc.verificationMethod![0]!;
+
+  it('L7: malformed sidecar SMT proof id throws a typed ResolveError', () => {
+    expect(() => Resolver.sidecarData({
+      smtProofs : [{ id: '!!!not-base64url!!!', collapsed: '', hashes: [] }] as any
+    })).to.throw(/Malformed SMT proof id/);
+  });
+
+  it('L7: a malformed update.sourceHash throws a typed ResolveError, not a raw decode error', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+    const u2 = Updater.sign(fixture.did, Updater.construct(sourceDocument, benignPatch(fixture.did), 1), vmOf(sourceDocument), signer1);
+    // A controller signs an update whose sourceHash is not valid base64url: the
+    // proof stays valid (it covers the malformed string), so the decode is reached.
+    const { proof: _p1, ...unsignedSource } = u2 as Record<string, unknown>;
+    const resigned = Updater.sign(fixture.did, { ...unsignedSource, sourceHash: '!!!not-base64!!!' } as any, vmOf(sourceDocument), signer1);
+
+    expect(() => driveSingleBeacon(fixture.did, [resigned])).to.throw(/Malformed update\.sourceHash/);
+  });
+
+  it('L7: a malformed update.targetHash throws a typed ResolveError, not a raw decode error', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+    const u2 = Updater.sign(fixture.did, Updater.construct(sourceDocument, benignPatch(fixture.did), 1), vmOf(sourceDocument), signer1);
+    // The targetHash decode runs after proof verification, so the malformed
+    // value must itself be validly signed: strip the old proof and re-sign.
+    const { proof: _p2, ...unsignedTarget } = u2 as Record<string, unknown>;
+    const resigned = Updater.sign(fixture.did, { ...unsignedTarget, targetHash: '!!!not-base64!!!' } as any, vmOf(sourceDocument), signer1);
+
+    expect(() => driveSingleBeacon(fixture.did, [resigned])).to.throw(/Malformed update\.targetHash/);
+  });
+
+  it('L8: a duplicate re-announcement does not clobber confirmations/updated metadata', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const [u2] = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did)]);
+
+    // The same update announced twice: the apply at height 100 (10 confs), the
+    // duplicate at height 105 (5 confs, later time).
+    const resolved = driveSignalSequence(fixture.did, [u2], [u2, u2], [
+      { height: 100, time: 1700000000, confirmations: 10 },
+      { height: 105, time: 1700001000, confirmations: 5 },
+    ]);
+
+    expect(resolved.metadata.versionId).to.equal('2');
+    expect(resolved.metadata.confirmations).to.equal(10);
+    expect(resolved.metadata.updated).to.equal('2023-11-14T22:13:20Z');
+  });
+
+  it('I2: complete-phase metadata reports the actual version, not the requested versionId', () => {
+    // No updates exist; the caller asks for version 5. The resolved document is
+    // version 1 and the metadata must say so.
+    const resolver = DidBtcr2.resolve(fixture.did, { versionId: '5' });
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+    resolver.provide(state.needs[0] as NeedBeaconSignals, new Map<BeaconService, Array<BeaconSignal>>());
+    state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected resolved');
+    expect(state.result.metadata.versionId).to.equal('1');
+  });
+
+  it('I4: rejects an update whose proof capabilityAction is not "Write"', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const signer1 = new LocalSigner(hexToBytes(fixture.secretKey));
+    const u2 = Updater.sign(fixture.did, Updater.construct(sourceDocument, benignPatch(fixture.did), 1), vmOf(sourceDocument), signer1);
+
+    // Tamper the action post-signing: the check runs before proof verification,
+    // so the refusal must name the capabilityAction.
+    const tampered = JSON.parse(JSON.stringify(u2));
+    tampered.proof.capabilityAction = 'Read';
+    expect(() => driveSingleBeacon(fixture.did, [tampered])).to.throw(/capabilityAction/);
+  });
+
+  it('I6: a truthy non-boolean deactivated value is not treated as deactivated', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    (sourceDocument as any).deactivated = 'yes';
+    const response = Resolver.updates(sourceDocument, []);
+    expect(response.metadata.deactivated).to.be.false;
+  });
+
+  it('I6: a boolean deactivated: true is honored', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    (sourceDocument as any).deactivated = true;
+    const response = Resolver.updates(sourceDocument, []);
+    expect(response.metadata.deactivated).to.be.true;
+  });
+});

--- a/packages/method/tests/signal-discovery.spec.ts
+++ b/packages/method/tests/signal-discovery.spec.ts
@@ -121,3 +121,69 @@ describe('BeaconSignalDiscovery.indexer', () => {
     expect(found[0].blockMetadata.height).to.equal(100);
   });
 });
+
+describe('BeaconSignalDiscovery.fullnode', () => {
+  const SIGNAL_HEX = 'cd'.repeat(32);
+  const SIGNAL_ASM = `OP_RETURN OP_PUSHBYTES_32 ${SIGNAL_HEX}`;
+
+  const secret = new Uint8Array(32);
+  secret[31] = 9;
+  const address = p2wpkh(secp256k1.getPublicKey(secret, true), getNetwork('regtest')).address!;
+  const PAYMENT_ASM = 'OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6';
+
+  const service: BeaconService = {
+    id              : 'did:btcr2:x#beacon-0',
+    type            : 'SingletonBeacon',
+    serviceEndpoint : `bitcoin:${address}`
+  };
+
+  /**
+   * Minimal RPC stub: two blocks. Block 1 contains `spendTx`, a transaction
+   * whose input spends a prevout paying the beacon address. The prevout lookup
+   * returns the funding tx (its output script is the beacon PAYMENT script,
+   * never an OP_RETURN).
+   */
+  function mockFullnode(spendTx: unknown): BitcoinConnection {
+    const fundingTx = {
+      txid  : 'ef'.repeat(32),
+      vout  : [{ scriptPubKey: { asm: PAYMENT_ASM, address } }]
+    };
+    const blocks: Record<number, unknown> = {
+      0 : { hash: '00'.repeat(32), height: 0, time: 1700000000, confirmations: 2, tx: [] },
+      1 : { hash: '11'.repeat(32), height: 1, time: 1700000600, confirmations: 1, tx: [spendTx] },
+    };
+    return {
+      rpc : {
+        getBlockCount     : async () => 1,
+        getBlock          : async ({ height }: { height: number }) => blocks[height],
+        getRawTransaction : async () => fundingTx,
+      }
+    } as unknown as BitcoinConnection;
+  }
+
+  it('discovers the signal on the spending transaction, not the spent prevout (audit H5)', async () => {
+    const spendTx = {
+      txid  : 'ab'.repeat(32),
+      vin   : [{ txid: 'ef'.repeat(32), vout: 0 }],
+      vout  : [
+        { scriptPubKey: { asm: PAYMENT_ASM, address } },  // self-change
+        { scriptPubKey: { asm: SIGNAL_ASM } },            // the beacon signal
+      ],
+    };
+    const signals = await BeaconSignalDiscovery.fullnode([service], mockFullnode(spendTx));
+    const found = signals.get(service)!;
+    expect(found).to.have.lengthOf(1);
+    expect(found[0].signalBytes).to.equal(SIGNAL_HEX);
+    expect(found[0].blockMetadata.height).to.equal(1);
+  });
+
+  it('finds no signal when the spending transaction carries no OP_RETURN', async () => {
+    const spendTx = {
+      txid  : 'ab'.repeat(32),
+      vin   : [{ txid: 'ef'.repeat(32), vout: 0 }],
+      vout  : [{ scriptPubKey: { asm: PAYMENT_ASM, address } }],
+    };
+    const signals = await BeaconSignalDiscovery.fullnode([service], mockFullnode(spendTx));
+    expect(signals.get(service)).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
* fix(method): full-node signals from the spending tx; typed malformed-input throws (audit H5, L7-L9, I1, I2, I4, I6)
* fix(common): bound JSON patch operation count, path length, and value size (audit L10)
* test(method): cover fullnode discovery, typed-error paths, duplicate metadata, and capability checks
* test(common): cover patch bound rejection and acceptance