### PR TITLE
harden credential handling across bitcoin, cli, and lib tooling

### DIFF
--- a/packages/bitcoin/src/client/rest/index.ts
+++ b/packages/bitcoin/src/client/rest/index.ts
@@ -6,6 +6,7 @@ import { EsploraProtocol } from './protocol.js';
 import type { RestConfig } from '../../types.js';
 import type { HttpExecutor, HttpRequest} from '../http.js';
 import { defaultHttpExecutor } from '../http.js';
+import { redactUrlCredentials } from '../utils.js';
 
 /**
  * Esplora REST API client for Bitcoin.
@@ -56,19 +57,28 @@ export class BitcoinRestClient {
   private async executeRequest(request: HttpRequest): Promise<any> {
     const response = await this.executor(request);
 
-    const contentType = response.headers.get('Content-Type') ?? '';
-    const data = contentType.includes('text/plain')
-      ? await response.text()
-      : await response.json();
-
+    // Check the status BEFORE parsing: an error page (proxy HTML, empty body) is
+    // often not JSON, and a raw parse throw would mask the HTTP failure
+    // entirely (audit L11). The URL is redacted so embedded userinfo
+    // credentials never land in an error message.
     if (!response.ok) {
+      let data: unknown;
+      try {
+        const errorContentType = response.headers.get('Content-Type') ?? '';
+        data = errorContentType.includes('text/plain') ? await response.text() : await response.json();
+      } catch {
+        data = undefined;
+      }
       throw new MethodError(
-        `Request to ${request.url} failed: ${response.status} - ${response.statusText}`,
+        `Request to ${redactUrlCredentials(request.url)} failed: ${response.status} - ${response.statusText}`,
         'FAILED_HTTP_REQUEST',
         { data }
       );
     }
 
-    return data;
+    const contentType = response.headers.get('Content-Type') ?? '';
+    return contentType.includes('text/plain')
+      ? await response.text()
+      : await response.json();
   }
 }

--- a/packages/bitcoin/src/client/rpc/protocol.ts
+++ b/packages/bitcoin/src/client/rpc/protocol.ts
@@ -1,7 +1,7 @@
 import { BitcoinRpcError } from '../../errors.js';
 import type { RpcConfig } from '../../types.js';
 import type { HttpRequest } from '../http.js';
-import { toBase64 } from '../utils.js';
+import { isInsecureRemoteHttp, redactUrlCredentials, toBase64 } from '../utils.js';
 
 /**
  * Sans-I/O JSON-RPC protocol for Bitcoin Core.
@@ -56,7 +56,8 @@ export class JsonRpcProtocol {
           url = u.toString().replace(/\/+$/, '');
         }
       } catch (error: unknown) {
-        console.error(`Invalid URL in Bitcoin RPC config: ${url}`, error);
+        // The raw URL may carry userinfo credentials; log only the redacted form (audit L11).
+        console.error(`Invalid URL in Bitcoin RPC config: ${redactUrlCredentials(url)}`, error);
       }
     }
 
@@ -76,6 +77,18 @@ export class JsonRpcProtocol {
       'Content-Type' : 'application/json',
       ...(authHeader ? { Authorization: authHeader } : {}),
     };
+
+    // Warn when credentials (basic auth or a caller-supplied Authorization
+    // header) will be sent over cleartext HTTP to a non-loopback host: anyone on
+    // the path can read them (audit M7).
+    const sendsCredentials = authHeader !== undefined
+      || Object.keys(cfg.headers ?? {}).some(h => h.toLowerCase() === 'authorization');
+    if (sendsCredentials && isInsecureRemoteHttp(url)) {
+      console.warn(
+        `WARNING: Bitcoin RPC credentials will be sent over cleartext HTTP to ${new URL(url).host}. `
+        + 'Use HTTPS, an SSH tunnel, or a loopback bind instead.',
+      );
+    }
   }
 
   /**

--- a/packages/bitcoin/src/client/utils.ts
+++ b/packages/bitcoin/src/client/utils.ts
@@ -19,3 +19,38 @@ export function toBase64(s: string): string {
 export async function safeText(res: Response): Promise<string> {
   try { return await res.text(); } catch { return ''; }
 }
+
+/**
+ * Strip any userinfo (credentials) from a URL string so it is safe to log or
+ * embed in an error message (audit L11). Handles both parseable URLs (via the
+ * URL API) and unparseable ones (defensive regex over the authority segment).
+ */
+export function redactUrlCredentials(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.username || u.password) {
+      u.username = '';
+      u.password = '';
+    }
+    return u.toString();
+  } catch {
+    return url.replace(/(\/\/)[^/@]*@/, '$1[REDACTED]@');
+  }
+}
+
+/** Hosts considered local: cleartext HTTP to these does not leak credentials off-box. */
+const LOOPBACK_HOSTNAMES = new Set([ 'localhost', '127.0.0.1', '::1', '[::1]' ]);
+
+/**
+ * True if `url` is cleartext HTTP to a non-loopback host: sending credentials
+ * to such an endpoint exposes them on the network (audit M7).
+ */
+export function isInsecureRemoteHttp(url: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  return u.protocol === 'http:' && !LOOPBACK_HOSTNAMES.has(u.hostname);
+}

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -30,7 +30,7 @@ export type { FeeEstimator } from './fee-estimator.js';
 // Helpers
 export { getNetwork } from './network.js';
 export type { BTCNetwork } from './network.js';
-export { toBase64, safeText } from './client/utils.js';
+export { toBase64, safeText, redactUrlCredentials, isInsecureRemoteHttp } from './client/utils.js';
 
 // Constants
 export {

--- a/packages/bitcoin/tests/credential-hygiene.spec.ts
+++ b/packages/bitcoin/tests/credential-hygiene.spec.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import { BitcoinRestClient } from '../src/client/rest/index.js';
+import { JsonRpcProtocol } from '../src/client/rpc/protocol.js';
+import type { HttpExecutor, HttpRequest } from '../src/client/http.js';
+import { isInsecureRemoteHttp, redactUrlCredentials } from '../src/client/utils.js';
+
+/** Capture console.warn calls for the duration of fn. */
+function captureWarn(fn: () => void): string[] {
+  const original = console.warn;
+  const messages: string[] = [];
+  console.warn = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+  try { fn(); } finally { console.warn = original; }
+  return messages;
+}
+
+describe('credential hygiene (audit M7, L11)', () => {
+
+  describe('JsonRpcProtocol cleartext-credential warning (M7)', () => {
+    it('warns when basic auth is sent over cleartext HTTP to a remote host', () => {
+      const warnings = captureWarn(() => {
+        new JsonRpcProtocol({ host: 'http://node.example.com:8332', username: 'u', password: 'p' });
+      });
+      expect(warnings).to.have.lengthOf(1);
+      expect(warnings[0]).to.match(/cleartext HTTP/);
+      expect(warnings[0]).to.not.match(/\bp\b/);
+    });
+
+    it('warns when a configured Authorization header goes to a remote cleartext host', () => {
+      const warnings = captureWarn(() => {
+        new JsonRpcProtocol({ host: 'http://node.example.com:8332', headers: { Authorization: 'Basic xyz' } });
+      });
+      expect(warnings).to.have.lengthOf(1);
+    });
+
+    it('stays quiet for loopback cleartext hosts', () => {
+      for (const host of [ 'http://localhost:18443', 'http://127.0.0.1:18443', 'http://[::1]:18443' ]) {
+        const warnings = captureWarn(() => {
+          new JsonRpcProtocol({ host, username: 'u', password: 'p' });
+        });
+        expect(warnings, host).to.have.lengthOf(0);
+      }
+    });
+
+    it('stays quiet for HTTPS and for credential-free HTTP', () => {
+      let warnings = captureWarn(() => {
+        new JsonRpcProtocol({ host: 'https://node.example.com:8332', username: 'u', password: 'p' });
+      });
+      expect(warnings).to.have.lengthOf(0);
+      warnings = captureWarn(() => {
+        new JsonRpcProtocol({ host: 'http://node.example.com:8332' });
+      });
+      expect(warnings).to.have.lengthOf(0);
+    });
+
+    it('warns for credentials embedded in the URL userinfo', () => {
+      const warnings = captureWarn(() => {
+        new JsonRpcProtocol({ host: 'http://user:pass@node.example.com:8332' });
+      });
+      expect(warnings).to.have.lengthOf(1);
+    });
+  });
+
+  describe('redactUrlCredentials (L11)', () => {
+    it('strips userinfo from a parseable URL', () => {
+      expect(redactUrlCredentials('http://user:pass@node.example.com:8332/'))
+        .to.equal('http://node.example.com:8332/');
+    });
+
+    it('masks the authority segment of an unparseable URL', () => {
+      const redacted = redactUrlCredentials('http://user:pass@not a url');
+      expect(redacted).to.not.contain('pass');
+    });
+
+    it('leaves credential-free URLs untouched', () => {
+      expect(redactUrlCredentials('http://node.example.com:8332')).to.equal('http://node.example.com:8332/');
+    });
+  });
+
+  describe('isInsecureRemoteHttp (M7 helper)', () => {
+    it('classifies hosts correctly', () => {
+      expect(isInsecureRemoteHttp('http://node.example.com')).to.be.true;
+      expect(isInsecureRemoteHttp('http://localhost:8332')).to.be.false;
+      expect(isInsecureRemoteHttp('https://node.example.com')).to.be.false;
+      expect(isInsecureRemoteHttp('not a url')).to.be.false;
+    });
+  });
+
+  describe('invalid RPC URL logging (L11)', () => {
+    it('logs the redacted URL, never the credentials', () => {
+      const original = console.error;
+      const messages: string[] = [];
+      console.error = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+      try {
+        new JsonRpcProtocol({ host: 'http://user:supersecret@:' });
+      } finally {
+        console.error = original;
+      }
+      expect(messages).to.have.lengthOf(1);
+      expect(messages[0]).to.not.contain('supersecret');
+    });
+  });
+
+  describe('BitcoinRestClient error handling (L11)', () => {
+    function mockExecutor(response: { status: number; body: string; contentType?: string }): { executor: HttpExecutor; seen: HttpRequest[] } {
+      const seen: HttpRequest[] = [];
+      const executor: HttpExecutor = async (req) => {
+        seen.push(req);
+        return new Response(response.body, {
+          status     : response.status,
+          statusText : 'Error',
+          headers    : { 'Content-Type': response.contentType ?? 'application/json' },
+        });
+      };
+      return { executor, seen };
+    }
+
+    it('throws a typed MethodError (not a raw parse error) for a non-JSON error body', async () => {
+      const { executor } = mockExecutor({ status: 502, body: '<html>Bad Gateway</html>', contentType: 'text/html' });
+      const rest = new BitcoinRestClient({ host: 'http://example.com' }, executor);
+      try {
+        await rest.block.count();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('FAILED_HTTP_REQUEST');
+        expect(err.message).to.include('502');
+      }
+    });
+
+    it('redacts userinfo credentials from the failing request URL in the error message', async () => {
+      const { executor } = mockExecutor({ status: 500, body: '{}' });
+      const rest = new BitcoinRestClient({ host: 'http://user:supersecret@example.com' }, executor);
+      try {
+        await rest.block.count();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.not.contain('supersecret');
+      }
+    });
+  });
+});

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -287,7 +287,6 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `--btc-rest <url>` | Override Bitcoin REST endpoint (Esplora API) |
 | `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
 | `--btc-rpc-user <user>` | Bitcoin Core RPC username |
-| `--btc-rpc-pass <pass>` | Bitcoin Core RPC password (accepts an `env:<VAR>` or `file:<path>` secret reference) |
 | `--btc-rpc-wallet <name>` | Bitcoin Core wallet name for wallet-scoped RPCs (`/wallet/<name>`) |
 | `--btc-rpc-header <header>` | Extra Bitcoin Core RPC header `"Key: Value"` (repeatable) |
 | `--btc-rest-header <header>` | Extra Bitcoin REST header `"Key: Value"` (repeatable), e.g. an API key |
@@ -306,7 +305,7 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` |
+| `BTCR2_BTC_RPC_PASS` | (env only; no flag - a password on argv is exposed via `ps`/shell history) |
 | `BTCR2_BTC_RPC_PASS_FILE` | file whose contents are the RPC password |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -53,7 +53,9 @@ export class DidBtcr2Cli {
       .option('--btc-rest <url>', 'Override Bitcoin REST endpoint (Esplora API)')
       .option('--btc-rpc-url <url>', 'Override Bitcoin Core RPC endpoint')
       .option('--btc-rpc-user <user>', 'Bitcoin Core RPC username')
-      .option('--btc-rpc-pass <pass>', 'Bitcoin Core RPC password')
+      // No --btc-rpc-pass flag: a password on argv is visible in ps, /proc/<pid>/cmdline,
+      // shell history, and CI logs (audit H4). Use BTCR2_BTC_RPC_PASS,
+      // BTCR2_BTC_RPC_PASS_FILE, or an `env:`/`file:` secret reference instead.
       .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads (read-only)')
       .option('--cas-rpc-url <url>', 'IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables --publish-to-cas)')
       .option('--btc-timeout <ms>', 'Bitcoin REST/RPC request timeout in milliseconds (default: unbounded)')

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -63,6 +63,15 @@ export function registerConfigCommand(program: Command, globals: () => GlobalOpt
       if (unknownPath && !globals().quiet) {
         console.error(`Warning: "${dotted}" is not a known config path; writing it anyway.`);
       }
+      // A plaintext RPC password lands on disk in cleartext (file 0600, but at
+      // rest). Nudge toward an env:/file: secret reference instead (audit L15).
+      if (dotted.endsWith('.btc.rpcPass') && typeof parsed === 'string'
+        && !parsed.startsWith('env:') && !parsed.startsWith('file:') && !globals().quiet) {
+        console.error(
+          'Warning: storing a plaintext RPC password in the config file. '
+          + 'Prefer an "env:<VAR>" or "file:<path>" secret reference, or BTCR2_BTC_RPC_PASS.',
+        );
+      }
       writeConfigFile(path(), raw => setConfigPath(raw, dotted, parsed));
       print({ action: 'config-set', data: { path: dotted } });
     });

--- a/packages/cli/src/commands/key.ts
+++ b/packages/cli/src/commands/key.ts
@@ -2,7 +2,7 @@ import type { KeyManager } from '@did-btcr2/key-manager';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import type { Command } from 'commander';
-import { closeSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { closeSync, openSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import type { ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
@@ -162,8 +162,23 @@ function parseHex(hex: string, expectedBytes: number, label: string): Uint8Array
 function readHexFile(path: string, expectedBytes: number, label: string): Uint8Array {
   let content: string;
   try {
+    // The file holds raw secret key material: refuse to read it when group or
+    // other users have any permission bits (0600/0400 only), matching the
+    // keystore's permission policy (audit L13). Not enforceable on Windows.
+    if (process.platform !== 'win32') {
+      const mode = statSync(path).mode & 0o777;
+      if ((mode & 0o077) !== 0) {
+        throw new CLIError(
+          `Refusing to read ${label} at ${path}: permissions 0${mode.toString(8)} are too open; expected 0600. `
+          + `Fix with: chmod 600 ${path}`,
+          'INVALID_ARGUMENT_ERROR',
+          { label, path, mode: `0${mode.toString(8)}` },
+        );
+      }
+    }
     content = readFileSync(path, 'utf-8');
-  } catch {
+  } catch (error) {
+    if (error instanceof CLIError) throw error;
     throw new CLIError(`Cannot read ${label} at ${path}.`, 'INVALID_ARGUMENT_ERROR', { label, path });
   }
   return parseHex(content, expectedBytes, label);

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import { defaultConfigPath, readConfigFile, writeConfigFile } from '../config.js';
+import { assertSafeProfileName, defaultConfigPath, readConfigFile, writeConfigFile } from '../config.js';
 import { CLIError } from '../error.js';
 import { formatResult, redactSecrets } from '../output.js';
 import type { CommandResult, GlobalOptions } from '../types.js';
@@ -14,6 +14,7 @@ export function registerProfileCommand(program: Command, globals: () => GlobalOp
     .command('add <name>')
     .description('Add an empty profile.')
     .action((name: string) => {
+      assertSafeProfileName(name);
       writeConfigFile(path(), raw => {
         if (raw.profiles === undefined || raw.profiles === null) raw.profiles = {};
         const profiles = raw.profiles as Record<string, unknown>;
@@ -27,6 +28,7 @@ export function registerProfileCommand(program: Command, globals: () => GlobalOp
     .command('use <name>')
     .description('Set the active profile (writes defaults.profile).')
     .action((name: string) => {
+      assertSafeProfileName(name);
       writeConfigFile(path(), raw => {
         if (raw.defaults === undefined || raw.defaults === null) raw.defaults = {};
         (raw.defaults as Record<string, unknown>).profile = name;
@@ -57,6 +59,7 @@ export function registerProfileCommand(program: Command, globals: () => GlobalOp
     .alias('rm')
     .description('Remove a profile.')
     .action((name: string) => {
+      assertSafeProfileName(name);
       writeConfigFile(path(), raw => {
         const profiles = raw.profiles as Record<string, unknown> | undefined;
         if (!profiles?.[name]) throw new CLIError(`Profile "${name}" not found.`, 'INVALID_ARGUMENT_ERROR', { name });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -184,6 +184,17 @@ function assertSafeKey(key: string, path: string): void {
   }
 }
 
+/**
+ * Rejects a profile name that would reach the prototype chain when used as an
+ * object key (`profile add __proto__` would otherwise invoke the __proto__
+ * setter and mutate the profiles object's prototype; audit L12).
+ */
+export function assertSafeProfileName(name: string): void {
+  if (UNSAFE_KEYS.has(name)) {
+    throw new CLIError(`Illegal profile name "${name}".`, 'INVALID_ARGUMENT_ERROR', { name });
+  }
+}
+
 /** Sets the value at a dotted path, creating intermediate objects. */
 export function setConfigPath(config: Record<string, unknown>, path: string, value: unknown): void {
   const keys = path.split('.');
@@ -231,7 +242,7 @@ export type ApiFactory = (network?: NetworkOption, overrides?: ConnectionOverrid
  * | `BTCR2_BTC_REST`      | `--btc-rest`       |
  * | `BTCR2_BTC_RPC_URL`   | `--btc-rpc-url`    |
  * | `BTCR2_BTC_RPC_USER`  | `--btc-rpc-user`   |
- * | `BTCR2_BTC_RPC_PASS`  | `--btc-rpc-pass`   |
+ * | `BTCR2_BTC_RPC_PASS`  | (env only; no flag - audit H4) |
  * | `BTCR2_CAS_GATEWAY`   | `--cas-gateway`    |
  * | `BTCR2_CAS_RPC_URL`   | `--cas-rpc-url`    |
  * | `BTCR2_BTC_TIMEOUT`   | `--btc-timeout`    |
@@ -752,12 +763,26 @@ function readSecretFile(path: string, source: string): string {
  * reads the named environment variable, `file:<path>` reads the file, and any
  * other value is returned as-is. A trailing newline is trimmed from file/env
  * sources so a secret written by `echo` matches an inline value (ADR 077).
+ *
+ * Prefix semantics are exact: any value starting with `env:` or `file:` is
+ * ALWAYS treated as a reference, so a literal password cannot begin with those
+ * prefixes (audit L15). An `env:` reference naming an unset variable throws
+ * rather than silently resolving to undefined, so a typo'd variable name
+ * surfaces here instead of as a downstream RPC auth failure.
  */
 export function resolveSecretRef(value?: string): string | undefined {
   if (value === undefined) return undefined;
   if (value.startsWith('env:')) {
-    const fromEnv = process.env[value.slice(4)];
-    return fromEnv === undefined ? undefined : trimTrailingNewline(fromEnv);
+    const varName = value.slice(4);
+    const fromEnv = process.env[varName];
+    if (fromEnv === undefined) {
+      throw new CLIError(
+        `Secret reference env:${varName} names an environment variable that is not set.`,
+        'CONFIG_READ_ERROR',
+        { variable: varName },
+      );
+    }
+    return trimTrailingNewline(fromEnv);
   }
   if (value.startsWith('file:')) {
     return readSecretFile(value.slice(5), 'file reference');

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -97,7 +97,8 @@ export interface GlobalOptions {
   btcRest?       : string;
   btcRpcUrl?     : string;
   btcRpcUser?    : string;
-  btcRpcPass?    : string;
+  // No btcRpcPass: an RPC password is never accepted as a CLI flag (audit H4);
+  // it reaches the connection via env var, pass file, or secret reference.
   casGateway?    : string;
   casRpcUrl?     : string;
   btcTimeout?    : string;

--- a/packages/cli/tests/cli-helpers.spec.ts
+++ b/packages/cli/tests/cli-helpers.spec.ts
@@ -107,7 +107,7 @@ describe('CLI Helpers', () => {
     expect(capturedOverrides?.btcRest).to.equal('http://custom:3000');
   });
 
-  it('passes --btc-rpc-* overrides to factory on resolve', async () => {
+  it('passes --btc-rpc-url/--btc-rpc-user overrides to factory on resolve', async () => {
     let capturedOverrides: ConnectionOverrides | undefined;
     const spy: ApiFactory = (_network, overrides) => {
       capturedOverrides = overrides;
@@ -121,12 +121,24 @@ describe('CLI Helpers', () => {
       'node', 'btcr2',
       '--btc-rpc-url', 'http://node:18443',
       '--btc-rpc-user', 'alice',
-      '--btc-rpc-pass', 'secret',
       'resolve', '-i', validDid,
     ]);
 
     expect(capturedOverrides?.btcRpcUrl).to.equal('http://node:18443');
     expect(capturedOverrides?.btcRpcUser).to.equal('alice');
-    expect(capturedOverrides?.btcRpcPass).to.equal('secret');
+  });
+
+  it('rejects the removed --btc-rpc-pass flag (audit H4)', async () => {
+    const spy: ApiFactory = () => createApi();
+    const cli = new DidBtcr2Cli(spy);
+    cli.program.exitOverride();
+    cli.program.configureOutput({ writeErr: () => {} });
+    console.error = () => {};
+    await cli.run([
+      'node', 'btcr2',
+      '--btc-rpc-pass', 'secret',
+      'resolve', '-i', 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47',
+    ]);
+    expect(process.exitCode).to.equal(1);
   });
 });

--- a/packages/cli/tests/config-commands.spec.ts
+++ b/packages/cli/tests/config-commands.spec.ts
@@ -89,6 +89,34 @@ describe('config and profile commands', () => {
     expect(readCfg().profiles).to.not.have.property('signet');
   });
 
+  it('profile add rejects prototype-chain names (audit L12)', async () => {
+    await run('config', 'init');
+    await run('profile', 'add', '__proto__');
+    expect(err.join(' ')).to.match(/Illegal profile name/);
+    expect(Object.hasOwn(readCfg().profiles, '__proto__')).to.be.false;
+    expect(Object.getPrototypeOf(readCfg().profiles as object)).to.equal(Object.prototype);
+  });
+
+  it('profile use rejects prototype-chain names (audit L12)', async () => {
+    await run('config', 'init');
+    err = [];
+    await run('profile', 'use', 'constructor');
+    expect(err.join(' ')).to.match(/Illegal profile name/);
+  });
+
+  it('config set warns when storing a plaintext RPC password (audit L15)', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'hunter2');
+    expect(err.join(' ')).to.match(/plaintext RPC password/);
+    expect(readCfg().profiles.regtest.btc.rpcPass).to.equal('hunter2');
+  });
+
+  it('config set does not warn for env:/file: password references', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'env:MY_RPC_PASS');
+    expect(err.join(' ')).to.not.match(/plaintext RPC password/);
+  });
+
   it('config set stores a known scalar path as a string (no JSON coercion)', async () => {
     await run('config', 'init');
     await run('config', 'set', 'profiles.regtest.btc.rpcUrl', '8080');

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -852,6 +852,11 @@ describe('resolveSecretRef and RPC password sources', () => {
     expect(resolveSecretRef('env:MY_RPC_PASS')).to.equal('from-env');
   });
 
+  it('throws a CLIError naming the variable for an env: reference that is not set (audit L15)', () => {
+    expect(() => resolveSecretRef('env:BTCR2_DEFINITELY_UNSET_VAR'))
+      .to.throw(CLIError, /BTCR2_DEFINITELY_UNSET_VAR/);
+  });
+
   it('reads a file: reference and trims a trailing newline', () => {
     const file = join(tempDir, 'pass.txt');
     writeFileSync(file, 'from-file\n');

--- a/packages/cli/tests/key-commands.spec.ts
+++ b/packages/cli/tests/key-commands.spec.ts
@@ -1,7 +1,7 @@
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import type { Command } from 'commander';
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
@@ -89,6 +89,29 @@ describe('key commands', () => {
     const list = JSON.parse(out[0]);
     expect(list).to.have.length(1);
     expect(list[0].name).to.equal('a');
+  });
+
+  it('import --secret-file reads a 0600 secret file', async () => {
+    const secretFile = join(dir, 'secret.hex');
+    writeFileSync(secretFile, bytesToHex(SchnorrKeyPair.generate().secretKey.bytes));
+    chmodSync(secretFile, 0o600);
+    await runKey('import', '--secret-file', secretFile, '--name', 'imported');
+    const result = JSON.parse(out[0]);
+    expect(result.keyId).to.match(/^urn:kms:secp256k1:/);
+  });
+
+  it('import --secret-file refuses a group/world-readable secret file (audit L13)', async () => {
+    if (process.platform === 'win32') return; // perms not enforceable there
+    const secretFile = join(dir, 'loose.hex');
+    writeFileSync(secretFile, bytesToHex(SchnorrKeyPair.generate().secretKey.bytes));
+    chmodSync(secretFile, 0o644);
+    let threw = false;
+    await runKey('import', '--secret-file', secretFile).catch((err) => {
+      threw = true;
+      expect(err).to.be.instanceOf(CLIError);
+      expect((err as Error).message).to.match(/permissions/);
+    });
+    expect(threw, 'expected a permission refusal').to.be.true;
   });
 
   it('import --public adds a watch-only key', async () => {

--- a/packages/method/lib/bitcoin-endpoints.ts
+++ b/packages/method/lib/bitcoin-endpoints.ts
@@ -32,6 +32,13 @@ export function connectBitcoin(
   if (!host) {
     throw new Error(`No default REST endpoint for network "${network}". Pass options.restHost explicitly.`);
   }
+  // The default RPC host is the local Polar regtest node; it only makes sense
+  // for regtest. For any other network an RPC attachment must name its host
+  // explicitly, so dev credentials are never sent to an unintended host
+  // (audit N6).
+  if (options.rpc && network !== 'regtest' && !options.rpc.host) {
+    throw new Error(`No default RPC endpoint for network "${network}". Pass options.rpc.host explicitly.`);
+  }
   const rpc = options.rpc
     ? { host: REGTEST_RPC_HOST, ...options.rpc } as RpcConfig
     : undefined;

--- a/packages/method/lib/generate-vector.ts
+++ b/packages/method/lib/generate-vector.ts
@@ -264,7 +264,12 @@ function loadVectorContext(hash: string): VectorContext {
  */
 function requireBitcoinConnection(net: string): BitcoinConnection {
   try {
-    return connectBitcoin(net, { rpc: { username: 'polaruser', password: 'polarpass' } });
+    // The hardcoded Polar credentials are the local regtest node's defaults
+    // only; attaching them to any other network would send them to that
+    // network's RPC host (audit N6).
+    return net === 'regtest'
+      ? connectBitcoin(net, { rpc: { username: 'polaruser', password: 'polarpass' } })
+      : connectBitcoin(net);
   } catch (err: any) {
     console.error(`Error: Failed to connect to Bitcoin network "${net}".`);
     console.error(`  ${err.message}`);


### PR DESCRIPTION
* fix(bitcoin): warn on cleartext-HTTP credentials and redact userinfo from logged and error URLs (audit M7, L11)
* fix(cli): drop --btc-rpc-pass, guard profile names and secret-file perms, warn on plaintext passwords (audit H4, L12, L13, L15)
* fix(method): scope Polar dev credentials to regtest in lib endpoint helpers (audit N6)
* test(bitcoin): cover cleartext warnings, URL redaction, and error-path status handling
* test(cli): cover flag removal, profile guards, secret-file perms, and secret-ref failures