### PR TITLE
harden bitcoin clients against hostile endpoints and batch id drift

### DIFF
--- a/packages/api/tests/bitcoin-api.spec.ts
+++ b/packages/api/tests/bitcoin-api.spec.ts
@@ -140,7 +140,7 @@ describe('BitcoinApi', () => {
 
   it('getTransaction() sends request to correct URL via injected executor', async () => {
     const txid = 'a'.repeat(64);
-    const { executor, requests } = mockExecutor(200, { txid });
+    const { executor, requests } = mockExecutor(200, { txid, vin: [], vout: [], status: { confirmed: false } });
     const btc = new BitcoinApi({ network: 'regtest', executor });
     await btc.getTransaction(txid);
     expect(requests).to.have.lengthOf(1);

--- a/packages/bitcoin/src/client/rest/address.ts
+++ b/packages/bitcoin/src/client/rest/address.ts
@@ -1,6 +1,25 @@
+import { BitcoinRestError } from '../../errors.js';
 import type { AddressInfo, AddressUtxo, RawTransactionRest } from '../../types.js';
 import type { HttpRequest } from '../http.js';
+import { checkAddressInfo, checkAddressUtxo, checkRawTransactionRest } from '../validate.js';
 import type { EsploraProtocol } from './protocol.js';
+
+/**
+ * Validate a list of Esplora transaction objects (audit M11).
+ * @throws {BitcoinRestError} If the response is not an array of transactions.
+ */
+function assertTxList(value: unknown, context: string): Array<RawTransactionRest> {
+  if (!Array.isArray(value)) {
+    throw new BitcoinRestError(`Invalid ${context} response: expected an array of transactions`);
+  }
+  for (const [i, tx] of value.entries()) {
+    const reason = checkRawTransactionRest(tx);
+    if (reason) {
+      throw new BitcoinRestError(`Invalid ${context} response: tx[${i}]: ${reason}`);
+    }
+  }
+  return value as Array<RawTransactionRest>;
+}
 
 /**
  * Address-related Esplora REST API operations.
@@ -22,7 +41,7 @@ export class BitcoinAddress {
    * @returns {Promise<Array<RawTransactionRest>>} Transaction history.
    */
   public async getTxs(addressOrScripthash: string): Promise<Array<RawTransactionRest>> {
-    return await this.exec(this.protocol.getAddressTxs(addressOrScripthash));
+    return assertTxList(await this.exec(this.protocol.getAddressTxs(addressOrScripthash)), 'address txs');
   }
 
   /**
@@ -43,7 +62,7 @@ export class BitcoinAddress {
    * @returns {Promise<Array<RawTransactionRest>>} Unconfirmed transactions.
    */
   public async getTxsMempool(addressOrScripthash: string): Promise<Array<RawTransactionRest>> {
-    return await this.exec(this.protocol.getAddressTxsMempool(addressOrScripthash));
+    return assertTxList(await this.exec(this.protocol.getAddressTxsMempool(addressOrScripthash)), 'address mempool txs');
   }
 
   /**
@@ -52,7 +71,12 @@ export class BitcoinAddress {
    * @returns {Promise<AddressInfo>} Address information.
    */
   public async getInfo(addressOrScripthash: string): Promise<AddressInfo> {
-    return await this.exec(this.protocol.getAddressInfo(addressOrScripthash));
+    const info = await this.exec(this.protocol.getAddressInfo(addressOrScripthash));
+    const reason = checkAddressInfo(info);
+    if (reason) {
+      throw new BitcoinRestError(`Invalid address info response: ${reason}`);
+    }
+    return info as AddressInfo;
   }
 
   /**
@@ -63,7 +87,10 @@ export class BitcoinAddress {
    * @returns {Promise<Array<RawTransactionRest>>} Confirmed transactions.
    */
   public async getConfirmedTxs(addressOrScripthash: string, lastSeenTxId?: string): Promise<Array<RawTransactionRest>> {
-    return await this.exec(this.protocol.getAddressTxsChain(addressOrScripthash, lastSeenTxId));
+    return assertTxList(
+      await this.exec(this.protocol.getAddressTxsChain(addressOrScripthash, lastSeenTxId)),
+      'address confirmed txs'
+    );
   }
 
   /**
@@ -73,6 +100,16 @@ export class BitcoinAddress {
    * @returns {Promise<Array<AddressUtxo>>} Unspent transaction outputs.
    */
   public async getUtxos(addressOrScripthash: string): Promise<Array<AddressUtxo>> {
-    return await this.exec(this.protocol.getAddressUtxos(addressOrScripthash));
+    const utxos = await this.exec(this.protocol.getAddressUtxos(addressOrScripthash));
+    if (!Array.isArray(utxos)) {
+      throw new BitcoinRestError('Invalid address utxo response: expected an array');
+    }
+    for (const [i, utxo] of utxos.entries()) {
+      const reason = checkAddressUtxo(utxo);
+      if (reason) {
+        throw new BitcoinRestError(`Invalid address utxo response: utxo[${i}]: ${reason}`);
+      }
+    }
+    return utxos as Array<AddressUtxo>;
   }
 }

--- a/packages/bitcoin/src/client/rest/block.ts
+++ b/packages/bitcoin/src/client/rest/block.ts
@@ -1,6 +1,7 @@
 import { BitcoinRestError } from '../../errors.js';
 import type { EsploraBlock } from '../../types.js';
 import type { HttpRequest } from '../http.js';
+import { checkEsploraBlock } from '../validate.js';
 import type { EsploraProtocol } from './protocol.js';
 
 /**
@@ -21,10 +22,19 @@ export class BitcoinBlock {
 
   /**
    * Returns the blockheight of the most-work fully-validated chain.
+   * Esplora answers with a `text/plain` number; the value is coerced and
+   * validated so a hostile endpoint cannot feed a non-number into the
+   * confirmation arithmetic of downstream callers (audit M11).
    * @returns {Promise<number>} The current block height.
+   * @throws {BitcoinRestError} If the response is not a non-negative integer.
    */
   public async count(): Promise<number> {
-    return await this.exec(this.protocol.getBlockTipHeight());
+    const raw = await this.exec(this.protocol.getBlockTipHeight());
+    const height = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw.trim()) : NaN;
+    if (!Number.isInteger(height) || height < 0) {
+      throw new BitcoinRestError(`Invalid tip height response: ${JSON.stringify(raw)}`);
+    }
+    return height;
   }
 
   /**
@@ -45,7 +55,12 @@ export class BitcoinBlock {
       return undefined;
     }
 
-    return await this.exec(this.protocol.getBlock(blockhash)) as EsploraBlock;
+    const block = await this.exec(this.protocol.getBlock(blockhash));
+    const reason = checkEsploraBlock(block);
+    if (reason) {
+      throw new BitcoinRestError(`Invalid block response for ${blockhash}: ${reason}`, { blockhash });
+    }
+    return block as EsploraBlock;
   }
 
   /**
@@ -53,8 +68,13 @@ export class BitcoinBlock {
    * See {@link https://github.com/blockstream/esplora/blob/master/API.md#get-block-heightheight | Esplora GET /block-height/:height } for details.
    * @param {number} height The block height (required).
    * @returns {Promise<string>} The hash of the block at the given height.
+   * @throws {BitcoinRestError} If the response is not a 64-character hex string (audit M11).
    */
   public async getHash(height: number): Promise<string> {
-    return await this.exec(this.protocol.getBlockHeight(height));
+    const hash = await this.exec(this.protocol.getBlockHeight(height));
+    if (typeof hash !== 'string' || !/^[0-9a-fA-F]{64}$/.test(hash)) {
+      throw new BitcoinRestError(`Invalid block hash response for height ${height}`, { height });
+    }
+    return hash;
   }
 }

--- a/packages/bitcoin/src/client/rest/index.ts
+++ b/packages/bitcoin/src/client/rest/index.ts
@@ -6,7 +6,7 @@ import { EsploraProtocol } from './protocol.js';
 import type { RestConfig } from '../../types.js';
 import type { HttpExecutor, HttpRequest} from '../http.js';
 import { defaultHttpExecutor } from '../http.js';
-import { redactUrlCredentials } from '../utils.js';
+import { DEFAULT_MAX_RESPONSE_BYTES, readJsonWithLimit, readTextWithLimit, redactUrlCredentials } from '../utils.js';
 
 /**
  * Esplora REST API client for Bitcoin.
@@ -56,6 +56,7 @@ export class BitcoinRestClient {
    */
   private async executeRequest(request: HttpRequest): Promise<any> {
     const response = await this.executor(request);
+    const maxBytes = this._config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
 
     // Check the status BEFORE parsing: an error page (proxy HTML, empty body) is
     // often not JSON, and a raw parse throw would mask the HTTP failure
@@ -65,7 +66,9 @@ export class BitcoinRestClient {
       let data: unknown;
       try {
         const errorContentType = response.headers.get('Content-Type') ?? '';
-        data = errorContentType.includes('text/plain') ? await response.text() : await response.json();
+        data = errorContentType.includes('text/plain')
+          ? await readTextWithLimit(response, maxBytes)
+          : await readJsonWithLimit(response, maxBytes);
       } catch {
         data = undefined;
       }
@@ -76,9 +79,20 @@ export class BitcoinRestClient {
       );
     }
 
+    // Cap the body size before parsing: unbounded response.json() on a hostile
+    // endpoint is a memory-DoS, and a raw SyntaxError from a non-JSON body
+    // would escape as an untyped error (audit M11).
     const contentType = response.headers.get('Content-Type') ?? '';
-    return contentType.includes('text/plain')
-      ? await response.text()
-      : await response.json();
+    try {
+      return contentType.includes('text/plain')
+        ? await readTextWithLimit(response, maxBytes)
+        : await readJsonWithLimit(response, maxBytes);
+    } catch (error: unknown) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new MethodError(
+        `Unreadable response from ${redactUrlCredentials(request.url)}: ${cause}`,
+        'INVALID_RESPONSE_BODY',
+      );
+    }
   }
 }

--- a/packages/bitcoin/src/client/rest/transaction.ts
+++ b/packages/bitcoin/src/client/rest/transaction.ts
@@ -1,6 +1,8 @@
 import type { Bytes } from '@did-btcr2/common';
+import { BitcoinRestError } from '../../errors.js';
 import type { RawTransactionRest } from '../../types.js';
 import type { HttpRequest } from '../http.js';
+import { checkRawTransactionRest } from '../validate.js';
 import type { EsploraProtocol } from './protocol.js';
 
 export class BitcoinTransaction {
@@ -17,9 +19,15 @@ export class BitcoinTransaction {
    * See {@link https://github.com/blockstream/esplora/blob/master/API.md#get-txtxid | Esplora GET /tx/:txid } for details.
    * @param {string} txid The transaction id (required).
    * @returns {Promise<RawTransactionRest>} A promise resolving to data about a transaction.
+   * @throws {BitcoinRestError} If the response does not have the expected shape (audit M11).
    */
   public async get(txid: string): Promise<RawTransactionRest> {
-    return await this.exec(this.protocol.getTx(txid));
+    const tx = await this.exec(this.protocol.getTx(txid));
+    const reason = checkRawTransactionRest(tx);
+    if (reason) {
+      throw new BitcoinRestError(`Invalid transaction response for ${txid}: ${reason}`, { txid });
+    }
+    return tx as RawTransactionRest;
   }
 
   /**
@@ -37,9 +45,14 @@ export class BitcoinTransaction {
    * See {@link https://github.com/blockstream/esplora/blob/master/API.md#get-txtxidhex | Esplora GET /tx/:txid/hex } for details.
    * @param {string} txid The transaction id (required).
    * @returns {Promise<string>} A promise resolving to the raw transaction hex.
+   * @throws {BitcoinRestError} If the response is not a hex string (audit M11).
    */
   public async getHex(txid: string): Promise<string> {
-    return await this.exec(this.protocol.getTxHex(txid));
+    const hex = await this.exec(this.protocol.getTxHex(txid));
+    if (typeof hex !== 'string' || hex.length === 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+      throw new BitcoinRestError(`Invalid transaction hex response for ${txid}`, { txid });
+    }
+    return hex;
   }
 
   /**
@@ -57,8 +70,13 @@ export class BitcoinTransaction {
    * See {@link https://github.com/blockstream/esplora/blob/master/API.md#post-tx | Esplora POST /tx } for details.
    * @param {string} tx The raw transaction in hex format (required).
    * @returns {Promise<string>} The transaction id of the broadcasted transaction.
+   * @throws {BitcoinRestError} If the response is not a non-empty string (audit M11).
    */
   public async send(tx: string): Promise<string> {
-    return await this.exec(this.protocol.postTx(tx));
+    const txid = await this.exec(this.protocol.postTx(tx));
+    if (typeof txid !== 'string' || txid.length === 0) {
+      throw new BitcoinRestError('Invalid broadcast response: expected a txid string');
+    }
+    return txid;
   }
 }

--- a/packages/bitcoin/src/client/rpc/index.ts
+++ b/packages/bitcoin/src/client/rpc/index.ts
@@ -24,6 +24,7 @@ import type {
   WalletTransaction
 } from '../../types.js';
 import type { HttpExecutor } from '../http.js';
+import { checkRpcResult } from '../validate.js';
 import type { BitcoinRpcClient } from './interface.js';
 import { JsonRpcTransport } from './json-rpc.js';
 
@@ -79,6 +80,10 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
 
   /**
    * Executes a typed JSON-RPC command on the bitcoind node.
+   *
+   * Results are structurally validated before being trusted: amounts, UTXO
+   * sets, and confirmation status from the node flow into resolution and
+   * funding decisions (audit M11).
    */
   private async executeRpc<M extends TypedRpcMethod>(
     method: M,
@@ -87,6 +92,10 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
     try {
       const raw = await this.#transport.call(method, parameters as unknown[]);
       const normalized = JSONUtils.isUnprototyped(raw) ? JSONUtils.normalize(raw) : raw;
+      const reason = checkRpcResult(method, normalized);
+      if (reason) {
+        throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Invalid ${method} response: ${reason}`, { method });
+      }
       return normalized as RpcMethodMap[M]['result'];
     } catch (err: unknown) {
       if (err instanceof BitcoinRpcError) throw err;
@@ -272,6 +281,10 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
     );
     return results.map(raw => {
       const normalized = JSONUtils.isUnprototyped(raw) ? JSONUtils.normalize(raw) : raw;
+      const reason = checkRpcResult('getrawtransaction', normalized);
+      if (reason) {
+        throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Invalid getrawtransaction response: ${reason}`, { method: 'getrawtransaction' });
+      }
       switch (v) {
         case 0:  return normalized as RawTransactionV0;
         case 1:  return normalized as RawTransactionV1;

--- a/packages/bitcoin/src/client/rpc/json-rpc.ts
+++ b/packages/bitcoin/src/client/rpc/json-rpc.ts
@@ -2,7 +2,7 @@ import { BitcoinRpcError } from '../../errors.js';
 import type { RpcConfig } from '../../types.js';
 import type { HttpExecutor} from '../http.js';
 import { defaultHttpExecutor } from '../http.js';
-import { safeText } from '../utils.js';
+import { DEFAULT_MAX_RESPONSE_BYTES, readJsonWithLimit, safeText } from '../utils.js';
 import { JsonRpcProtocol } from './protocol.js';
 
 export class JsonRpcTransport {
@@ -13,15 +13,30 @@ export class JsonRpcTransport {
   readonly protocol: JsonRpcProtocol;
 
   private readonly execute: HttpExecutor;
+  private readonly maxResponseBytes: number;
 
   constructor(cfg: RpcConfig, executor?: HttpExecutor) {
     this.protocol = new JsonRpcProtocol(cfg);
     this.execute = executor ?? defaultHttpExecutor;
+    this.maxResponseBytes = cfg.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
   }
 
   /** @internal Expose URL for tests that inspect transport state. */
   get url(): string {
     return this.protocol.url;
+  }
+
+  /**
+   * Read a JSON-RPC response body with a size cap (audit M11), wrapping parse
+   * and size failures in a typed {@link BitcoinRpcError}.
+   */
+  private async readBody<T>(res: Response, context: Record<string, unknown>): Promise<T> {
+    try {
+      return await readJsonWithLimit(res, this.maxResponseBytes) as T;
+    } catch (error: unknown) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Unreadable RPC response: ${cause}`, context);
+    }
   }
 
   /**
@@ -41,7 +56,7 @@ export class JsonRpcTransport {
       );
     }
 
-    const payload = await res.json() as { result?: unknown; error?: { code: number; message: string } };
+    const payload = await this.readBody<{ result?: unknown; error?: { code: number; message: string } }>(res, { method });
     return this.protocol.parseResponse(payload, method);
   }
 
@@ -69,7 +84,10 @@ export class JsonRpcTransport {
       );
     }
 
-    const payloads = await res.json() as Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>;
-    return this.protocol.parseBatchResponse(payloads, calls);
+    const payloads = await this.readBody<Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>>(
+      res,
+      { methods: calls.map(c => c.method) }
+    );
+    return this.protocol.parseBatchResponse(payloads, calls, request.ids);
   }
 }

--- a/packages/bitcoin/src/client/rpc/protocol.ts
+++ b/packages/bitcoin/src/client/rpc/protocol.ts
@@ -4,6 +4,18 @@ import type { HttpRequest } from '../http.js';
 import { isInsecureRemoteHttp, redactUrlCredentials, toBase64 } from '../utils.js';
 
 /**
+ * An {@link HttpRequest} for a JSON-RPC batch call, carrying the request IDs
+ * assigned to each call at build time.  {@link JsonRpcProtocol.parseBatchResponse}
+ * requires these exact IDs so results are matched to calls by the identity
+ * assigned when the batch was built, never by reconstructing IDs from mutable
+ * protocol state at parse time (audit M9).
+ */
+export interface BatchHttpRequest extends HttpRequest {
+  /** The JSON-RPC ID assigned to each call, in call order. */
+  readonly ids: number[];
+}
+
+/**
  * Sans-I/O JSON-RPC protocol for Bitcoin Core.
  *
  * Builds {@link HttpRequest} descriptors for JSON-RPC method calls and
@@ -107,11 +119,17 @@ export class JsonRpcProtocol {
   /**
    * Build an {@link HttpRequest} for a JSON-RPC batch call.
    * Sends all calls in a single HTTP request per the JSON-RPC 2.0 spec.
+   *
+   * The assigned request IDs are captured on the returned descriptor so the
+   * caller can pass them back to {@link parseBatchResponse}: interleaved
+   * `buildRequest`/`buildBatchRequest` calls between build and parse must not
+   * shift the ID mapping (audit M9).
    */
-  buildBatchRequest(calls: Array<{ method: string; params: unknown[] }>): HttpRequest {
-    const body = calls.map(c => ({
+  buildBatchRequest(calls: Array<{ method: string; params: unknown[] }>): BatchHttpRequest {
+    const ids = calls.map(() => ++this._id);
+    const body = calls.map((c, i) => ({
       jsonrpc : '2.0',
-      id      : ++this._id,
+      id      : ids[i],
       method  : c.method,
       params  : c.params,
     }));
@@ -120,6 +138,7 @@ export class JsonRpcProtocol {
       method  : 'POST',
       headers : { ...this._headers },
       body    : JSON.stringify(body),
+      ids,
     };
   }
 
@@ -145,23 +164,32 @@ export class JsonRpcProtocol {
   /**
    * Parse a JSON-RPC batch response payload.
    * Returns results in the same order as the original calls.
+   *
+   * @param payloads The response payloads from the server (may be out of order).
+   * @param calls The original batch calls.
+   * @param ids The IDs captured on the {@link BatchHttpRequest} at build time.
    */
   parseBatchResponse(
     payloads: Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>,
     calls: Array<{ method: string; params: unknown[] }>,
+    ids: readonly number[],
   ): unknown[] {
+    if (ids.length !== calls.length) {
+      throw new BitcoinRpcError(
+        'RPC_ERROR',
+        -1,
+        `Batch id count (${ids.length}) does not match call count (${calls.length})`,
+      );
+    }
     const byId = new Map(payloads.map(p => [p.id, p]));
-    // Batch responses may arrive out of order; re-sort by sequential id.
-    // IDs were assigned as (_id - calls.length + 1) .. _id
-    const startId = this._id - calls.length + 1;
 
     return calls.map((call, i) => {
-      const payload = byId.get(startId + i);
+      const payload = byId.get(ids[i]);
       if (!payload) {
         throw new BitcoinRpcError(
           'RPC_ERROR',
           -1,
-          `Missing response for batch call ${call.method} (id ${startId + i})`,
+          `Missing response for batch call ${call.method} (id ${ids[i]})`,
           { method: call.method }
         );
       }

--- a/packages/bitcoin/src/client/utils.ts
+++ b/packages/bitcoin/src/client/utils.ts
@@ -21,6 +21,76 @@ export async function safeText(res: Response): Promise<string> {
 }
 
 /**
+ * Default maximum accepted response body size (32 MiB). Unbounded
+ * `response.json()` on a hostile endpoint is a memory-DoS (audit M11); both
+ * client transports cap bodies at this size unless configured otherwise via
+ * `maxResponseBytes` on the REST/RPC config.
+ */
+export const DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Read a response body as text, rejecting bodies larger than `maxBytes`.
+ * Streams the body when possible so an over-limit body is rejected before it
+ * is fully buffered; falls back to a post-hoc length check for Response-like
+ * objects without a readable stream (audit M11).
+ *
+ * @throws {Error} If the body exceeds `maxBytes`.
+ */
+export async function readTextWithLimit(res: Response, maxBytes: number = DEFAULT_MAX_RESPONSE_BYTES): Promise<string> {
+  const contentLength = res.headers.get('Content-Length');
+  if (contentLength !== null) {
+    const declared = Number(contentLength);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error(`Response body exceeds ${maxBytes}-byte limit (declared Content-Length: ${declared})`);
+    }
+  }
+
+  const body = res.body;
+  if (body && typeof body.getReader === 'function') {
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value?.byteLength ?? 0;
+        if (total > maxBytes) {
+          try { await reader.cancel(); } catch { /* best effort */ }
+          throw new Error(`Response body exceeds ${maxBytes}-byte limit`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes);
+  }
+
+  const text = await res.text();
+  if (new TextEncoder().encode(text).byteLength > maxBytes) {
+    throw new Error(`Response body exceeds ${maxBytes}-byte limit`);
+  }
+  return text;
+}
+
+/**
+ * Read a response body as JSON, rejecting bodies larger than `maxBytes`
+ * (audit M11).
+ *
+ * @throws {Error} If the body exceeds `maxBytes` or is not valid JSON.
+ */
+export async function readJsonWithLimit(res: Response, maxBytes: number = DEFAULT_MAX_RESPONSE_BYTES): Promise<unknown> {
+  return JSON.parse(await readTextWithLimit(res, maxBytes));
+}
+
+/**
  * Strip any userinfo (credentials) from a URL string so it is safe to log or
  * embed in an error message (audit L11). Handles both parseable URLs (via the
  * URL API) and unparseable ones (defensive regex over the authority segment).

--- a/packages/bitcoin/src/client/validate.ts
+++ b/packages/bitcoin/src/client/validate.ts
@@ -1,0 +1,182 @@
+/**
+ * Structural validation for untrusted Bitcoin endpoint responses (audit M11).
+ *
+ * Amounts, UTXO sets, and confirmation status returned by an Esplora or
+ * Bitcoin Core endpoint flow directly into resolution and funding decisions.
+ * Each `check*` function returns `null` when the value has the expected
+ * shape, otherwise a short human-readable reason. Callers turn a non-null
+ * reason into the client-appropriate typed error (`BitcoinRestError` for
+ * REST, `BitcoinRpcError` for RPC).
+ */
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** Esplora/RPC transaction status object: `{ confirmed, block_height?, ... }`. */
+export function checkTransactionStatus(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'status is not an object';
+  if (typeof value.confirmed !== 'boolean') return 'status.confirmed is not a boolean';
+  // A confirmed tx must report the block it was mined in; confirmation counts
+  // are derived from this height downstream.
+  if (value.confirmed === true && !isNonNegativeInteger(value.block_height)) {
+    return 'status.block_height is not a non-negative integer for a confirmed transaction';
+  }
+  return null;
+}
+
+/** Esplora `/tx` transaction object. */
+export function checkRawTransactionRest(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'transaction is not an object';
+  if (!isNonEmptyString(value.txid)) return 'txid is not a non-empty string';
+  if (!Array.isArray(value.vin)) return 'vin is not an array';
+  if (!Array.isArray(value.vout)) return 'vout is not an array';
+  const statusReason = checkTransactionStatus(value.status);
+  if (statusReason) return statusReason;
+  for (const [i, vout] of (value.vout as unknown[]).entries()) {
+    if (!isPlainObject(vout)) return `vout[${i}] is not an object`;
+    if (typeof vout.scriptpubkey !== 'string') return `vout[${i}].scriptpubkey is not a string`;
+    if (!isNonNegativeNumber(vout.value)) return `vout[${i}].value is not a non-negative number`;
+  }
+  return null;
+}
+
+/** Esplora `/address/:address/utxo` entry. `value` must be integer sats: it is fed to `BigInt()`. */
+export function checkAddressUtxo(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'utxo is not an object';
+  if (typeof value.txid !== 'string' || !/^[0-9a-fA-F]{64}$/.test(value.txid)) {
+    return 'utxo.txid is not a 64-character hex string';
+  }
+  if (!isNonNegativeInteger(value.vout)) return 'utxo.vout is not a non-negative integer';
+  if (!isNonNegativeInteger(value.value)) return 'utxo.value is not a non-negative integer (sats)';
+  return checkTransactionStatus(value.status);
+}
+
+/** Esplora `/block/:hash` object. */
+export function checkEsploraBlock(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'block is not an object';
+  if (!isNonEmptyString(value.id)) return 'block.id is not a non-empty string';
+  if (!isNonNegativeInteger(value.height)) return 'block.height is not a non-negative integer';
+  if (!isNonNegativeInteger(value.tx_count)) return 'block.tx_count is not a non-negative integer';
+  return null;
+}
+
+/** Esplora `/address/:address` info object. */
+export function checkAddressInfo(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'address info is not an object';
+  if (!isPlainObject(value.chain_stats)) return 'chain_stats is not an object';
+  if (!isPlainObject(value.mempool_stats)) return 'mempool_stats is not an object';
+  return null;
+}
+
+/** Verbose (`getrawtransaction` v1/v2) transaction from Bitcoin Core. */
+function checkRawTransactionRpc(value: unknown): string | null {
+  // Verbosity 0 returns a bare hex string.
+  if (typeof value === 'string') return value.length > 0 ? null : 'result is an empty string';
+  if (!isPlainObject(value)) return 'transaction is not an object';
+  if (!isNonEmptyString(value.txid)) return 'txid is not a non-empty string';
+  if (!Array.isArray(value.vin)) return 'vin is not an array';
+  if (!Array.isArray(value.vout)) return 'vout is not an array';
+  for (const [i, vout] of (value.vout as unknown[]).entries()) {
+    if (!isPlainObject(vout)) return `vout[${i}] is not an object`;
+    if (!isNonNegativeNumber(vout.value)) return `vout[${i}].value is not a non-negative number`;
+    if (!isPlainObject(vout.scriptPubKey)) return `vout[${i}].scriptPubKey is not an object`;
+  }
+  return null;
+}
+
+/** `getblock` result: hex string at verbosity 0, decoded object otherwise. */
+function checkBlockRpc(value: unknown): string | null {
+  if (typeof value === 'string') return value.length > 0 ? null : 'result is an empty string';
+  if (!isPlainObject(value)) return 'block is not an object';
+  if (!isNonEmptyString(value.hash)) return 'block.hash is not a non-empty string';
+  if (!isNonNegativeInteger(value.height)) return 'block.height is not a non-negative integer';
+  return null;
+}
+
+/** `listunspent` entry. `amount` is a BTC float and feeds funding decisions. */
+function checkUnspentTxInfo(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'utxo is not an object';
+  if (!isNonEmptyString(value.txid)) return 'utxo.txid is not a non-empty string';
+  if (!isNonNegativeInteger(value.vout)) return 'utxo.vout is not a non-negative integer';
+  if (!isNonNegativeNumber(value.amount)) return 'utxo.amount is not a non-negative number';
+  return null;
+}
+
+function checkStringArray(value: unknown): string | null {
+  if (!Array.isArray(value)) return 'result is not an array';
+  for (const [i, entry] of value.entries()) {
+    if (typeof entry !== 'string') return `result[${i}] is not a string`;
+  }
+  return null;
+}
+
+/**
+ * Structural check on a Bitcoin Core RPC result for the given method.
+ * Methods without an entry pass through unchecked (`null`).
+ */
+export function checkRpcResult(method: string, result: unknown): string | null {
+  switch (method) {
+    case 'getblockcount':
+      return isNonNegativeInteger(result) ? null : 'result is not a non-negative integer';
+    case 'getbalance':
+      return typeof result === 'number' && Number.isFinite(result) ? null : 'result is not a finite number';
+    case 'getbestblockhash':
+    case 'getblockhash':
+    case 'getnewaddress':
+    case 'createrawtransaction':
+    case 'sendrawtransaction':
+    case 'sendtoaddress':
+    case 'signmessage':
+      return isNonEmptyString(result) ? null : 'result is not a non-empty string';
+    case 'verifymessage':
+      return typeof result === 'boolean' ? null : 'result is not a boolean';
+    case 'getblockchaininfo':
+      if (!isPlainObject(result)) return 'result is not an object';
+      if (!isNonNegativeInteger(result.blocks)) return 'result.blocks is not a non-negative integer';
+      if (typeof result.chain !== 'string') return 'result.chain is not a string';
+      return null;
+    case 'getblock':
+      return checkBlockRpc(result);
+    case 'getrawtransaction':
+      return checkRawTransactionRpc(result);
+    case 'gettransaction':
+      if (!isPlainObject(result)) return 'result is not an object';
+      if (!isNonEmptyString(result.txid)) return 'result.txid is not a non-empty string';
+      if (typeof result.amount !== 'number' || !Number.isFinite(result.amount)) {
+        return 'result.amount is not a finite number';
+      }
+      return null;
+    case 'signrawtransactionwithwallet':
+      if (!isPlainObject(result)) return 'result is not an object';
+      if (typeof result.hex !== 'string') return 'result.hex is not a string';
+      if (typeof result.complete !== 'boolean') return 'result.complete is not a boolean';
+      return null;
+    case 'listunspent':
+      if (!Array.isArray(result)) return 'result is not an array';
+      for (const [i, entry] of result.entries()) {
+        const reason = checkUnspentTxInfo(entry);
+        if (reason) return `result[${i}]: ${reason}`;
+      }
+      return null;
+    case 'listtransactions':
+      return Array.isArray(result) ? null : 'result is not an array';
+    case 'deriveaddresses':
+    case 'generatetoaddress':
+      return checkStringArray(result);
+    default:
+      return null;
+  }
+}

--- a/packages/bitcoin/src/connection.ts
+++ b/packages/bitcoin/src/connection.ts
@@ -74,16 +74,36 @@ export class BitcoinConnection {
   /**
    * Converts Bitcoin (BTC) to satoshis.
    * Uses string-based arithmetic to avoid floating-point precision errors.
-   * @throws {RangeError} If the value has more than 8 decimal places.
+   * @throws {RangeError} If the value is not finite, is out of range, or has
+   * more than 8 decimal places of precision.
    */
   static btcToSats(btc: number): number {
-    const str = btc.toFixed(8);
+    if (!Number.isFinite(btc)) {
+      throw new RangeError(`BTC value ${btc} is not finite`);
+    }
+    // Number.toFixed switches to exponential notation at |x| >= 1e21, which
+    // would silently corrupt the string parsing below (audit L14).
+    if (Math.abs(btc) >= 1e21) {
+      throw new RangeError(`BTC value ${btc} is out of range`);
+    }
+    // Handle the sign separately: for -1 < btc < 0 the whole part stringifies
+    // to "-0" and Number("-0") === -0, which would drop the sign of the
+    // fractional part (audit L14).
+    const negative = btc < 0;
+    const abs = Math.abs(btc);
+    const str = abs.toFixed(8);
     const [whole, frac] = str.split('.');
-    // Verify no precision beyond 8 decimals was lost
-    if (Math.abs(btc - Number(str)) > Number.EPSILON) {
+    // Verify no precision beyond 8 decimals was lost. The tolerance scales
+    // with magnitude: a double cannot represent 8 exact decimal places at
+    // large values, so a fixed Number.EPSILON threshold would reject
+    // legitimate values whose representation error alone exceeds it
+    // (audit L14).
+    const tolerance = 4 * Number.EPSILON * Math.max(1, abs);
+    if (Math.abs(abs - Number(str)) > tolerance) {
       throw new RangeError(`BTC value ${btc} exceeds 8 decimal places of precision`);
     }
-    return Number(whole) * 1e8 + Number(frac);
+    const sats = Number(whole) * 1e8 + Number(frac);
+    return negative ? -sats : sats;
   }
 
   /**

--- a/packages/bitcoin/src/errors.ts
+++ b/packages/bitcoin/src/errors.ts
@@ -2,6 +2,7 @@ export type RpcErrorType =
   | 'HTTP_ERROR'
   | 'RPC_ERROR'
   | 'INVALID_PARAMS_GET_BLOCK'
+  | 'INVALID_RESPONSE'
   | 'SIGNING_INCOMPLETE'
   | 'UNKNOWN_ERROR';
 

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -6,6 +6,7 @@ export type { HttpRequest, HttpExecutor } from './client/http.js';
 export { defaultHttpExecutor } from './client/http.js';
 export { EsploraProtocol } from './client/rest/protocol.js';
 export { JsonRpcProtocol } from './client/rpc/protocol.js';
+export type { BatchHttpRequest } from './client/rpc/protocol.js';
 
 // Clients (convenience wrappers around the protocol layer)
 export { BitcoinRestClient } from './client/rest/index.js';
@@ -31,6 +32,21 @@ export type { FeeEstimator } from './fee-estimator.js';
 export { getNetwork } from './network.js';
 export type { BTCNetwork } from './network.js';
 export { toBase64, safeText, redactUrlCredentials, isInsecureRemoteHttp } from './client/utils.js';
+export {
+  DEFAULT_MAX_RESPONSE_BYTES,
+  readJsonWithLimit,
+  readTextWithLimit,
+} from './client/utils.js';
+
+// Untrusted-response structural validation (audit M11)
+export {
+  checkAddressInfo,
+  checkAddressUtxo,
+  checkEsploraBlock,
+  checkRawTransactionRest,
+  checkRpcResult,
+  checkTransactionStatus,
+} from './client/validate.js';
 
 // Constants
 export {

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -96,6 +96,8 @@ export interface EsploraBlock {
 export interface RestConfig {
   host: string;
   headers?: Record<string, string>;
+  /** Maximum accepted response body size in bytes (audit M11). Defaults to 32 MiB. */
+  maxResponseBytes?: number;
 }
 
 export interface RestApiCallParams {
@@ -111,6 +113,8 @@ export type RestResponse = Response;
 export interface RpcConfig {
   headers?: Record<string, string>;
   host?: string;
+  /** Maximum accepted response body size in bytes (audit M11). Defaults to 32 MiB. */
+  maxResponseBytes?: number;
   password?: string;
   username?: string;
   wallet?: string;

--- a/packages/bitcoin/tests/bitcoin.spec.ts
+++ b/packages/bitcoin/tests/bitcoin.spec.ts
@@ -112,9 +112,10 @@ describe('BitcoinConnection', () => {
   describe('end-to-end with custom executor', () => {
     it('routes REST calls through the injected executor', async () => {
       const seen: HttpRequest[] = [];
+      const mockTx = { txid: 'mock-txid', vin: [], vout: [], status: { confirmed: false } };
       const executor: HttpExecutor = async (req) => {
         seen.push(req);
-        return new Response(JSON.stringify({ txid: 'mock-txid' }), {
+        return new Response(JSON.stringify(mockTx), {
           status  : 200,
           headers : { 'Content-Type': 'application/json' },
         });
@@ -123,7 +124,7 @@ describe('BitcoinConnection', () => {
       const txid = 'a'.repeat(64);
       const btc = regtest({ executor });
       const tx = await btc.rest.transaction.get(txid);
-      expect(tx).to.deep.equal({ txid: 'mock-txid' });
+      expect(tx).to.deep.equal(mockTx);
       expect(seen).to.have.length(1);
       expect(seen[0].url).to.include(`/tx/${txid}`);
     });

--- a/packages/bitcoin/tests/client-robustness.spec.ts
+++ b/packages/bitcoin/tests/client-robustness.spec.ts
@@ -1,0 +1,342 @@
+import { expect } from 'chai';
+import { BitcoinRestClient } from '../src/client/rest/index.js';
+import { BitcoinCoreRpcClient } from '../src/client/rpc/index.js';
+import { BitcoinConnection } from '../src/connection.js';
+import { BitcoinRpcError, BitcoinRestError } from '../src/errors.js';
+import type { HttpExecutor } from '../src/client/http.js';
+import { DEFAULT_MAX_RESPONSE_BYTES } from '../src/client/utils.js';
+
+const VALID_TXID = 'a'.repeat(64);
+
+/** Minimal Esplora tx fixture accepted by the response validators. */
+function restTx(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false }, ...overrides };
+}
+
+/** Executor returning a JSON body with a 200 status. */
+function jsonExecutor(body: unknown): HttpExecutor {
+  return async () => new Response(JSON.stringify(body), {
+    status  : 200,
+    headers : { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('client robustness (audit M9, M11, L14)', () => {
+  describe('response size cap (M11)', () => {
+    it('REST rejects a body whose declared Content-Length exceeds the cap', async () => {
+      const executor: HttpExecutor = async () => new Response('{}', {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json', 'Content-Length': String(DEFAULT_MAX_RESPONSE_BYTES + 1) },
+      });
+      const rest = new BitcoinRestClient({ host: 'http://node' }, executor);
+      try {
+        await rest.transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('exceeds');
+        expect(err.type).to.equal('INVALID_RESPONSE_BODY');
+      }
+    });
+
+    it('REST rejects a streamed body that grows past the cap without a Content-Length', async () => {
+      const chunk = new Uint8Array(64);
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          // Push well past the small configured cap in repeated chunks.
+          for (let i = 0; i < 100; i++) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      const executor: HttpExecutor = async () => new Response(stream, {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json' },
+      });
+      const rest = new BitcoinRestClient({ host: 'http://node', maxResponseBytes: 1024 }, executor);
+      try {
+        await rest.transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('exceeds');
+        expect(err.type).to.equal('INVALID_RESPONSE_BODY');
+      }
+    });
+
+    it('REST accepts a body within a custom maxResponseBytes', async () => {
+      const rest = new BitcoinRestClient(
+        { host: 'http://node', maxResponseBytes: 1024 * 1024 },
+        jsonExecutor(restTx())
+      );
+      const tx = await rest.transaction.get(VALID_TXID);
+      expect(tx.txid).to.equal(VALID_TXID);
+    });
+
+    it('RPC rejects an oversized body with a typed error', async () => {
+      const executor: HttpExecutor = async () => new Response('{}', {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json', 'Content-Length': String(DEFAULT_MAX_RESPONSE_BYTES + 1) },
+      });
+      const rpc = new BitcoinCoreRpcClient({ host: 'http://node' }, executor);
+      try {
+        await rpc.getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('exceeds');
+      }
+    });
+
+    it('RPC wraps an invalid JSON body in a typed error instead of a raw SyntaxError', async () => {
+      const executor: HttpExecutor = async () => new Response('not json', {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json' },
+      });
+      const rpc = new BitcoinCoreRpcClient({ host: 'http://node' }, executor);
+      try {
+        await rpc.getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
+  });
+
+  describe('REST structural validation (M11)', () => {
+    const rest = (body: unknown) => new BitcoinRestClient({ host: 'http://node' }, jsonExecutor(body));
+
+    it('rejects a transaction missing vin/vout arrays', async () => {
+      try {
+        await rest({ txid: VALID_TXID, status: { confirmed: false } }).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRestError);
+        expect(err.message).to.include('vin is not an array');
+      }
+    });
+
+    it('rejects a transaction with a non-boolean status.confirmed', async () => {
+      try {
+        await rest(restTx({ status: { confirmed: 'yes' } })).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('status.confirmed is not a boolean');
+      }
+    });
+
+    it('rejects a confirmed transaction without a block height', async () => {
+      try {
+        await rest(restTx({ status: { confirmed: true } })).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('block_height');
+      }
+    });
+
+    it('rejects a vout entry with a negative value', async () => {
+      const tx = restTx({ vout: [{ scriptpubkey: '6a', value: -5 }] });
+      try {
+        await rest(tx).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('vout[0].value');
+      }
+    });
+
+    it('rejects utxos with a fractional satoshi value', async () => {
+      const utxos = [{ txid: VALID_TXID, vout: 0, value: 5000.5, status: { confirmed: false } }];
+      try {
+        await rest(utxos).address.getUtxos('addr');
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('utxo.value');
+      }
+    });
+
+    it('rejects utxos with a malformed txid', async () => {
+      const utxos = [{ txid: 'short', vout: 0, value: 5000, status: { confirmed: false } }];
+      try {
+        await rest(utxos).address.getUtxos('addr');
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('utxo.txid');
+      }
+    });
+
+    it('rejects a non-array address txs response', async () => {
+      try {
+        await rest({ not: 'an array' }).address.getTxs('addr');
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('expected an array');
+      }
+    });
+
+    it('rejects a garbage tip height', async () => {
+      const executor: HttpExecutor = async () => new Response('tip height unavailable', {
+        status  : 200,
+        headers : { 'Content-Type': 'text/plain' },
+      });
+      const client = new BitcoinRestClient({ host: 'http://node' }, executor);
+      try {
+        await client.block.count();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRestError);
+        expect(err.message).to.include('tip height');
+      }
+    });
+
+    it('rejects a malformed block hash for a height lookup', async () => {
+      const executor: HttpExecutor = async () => new Response('../../etc/passwd', {
+        status  : 200,
+        headers : { 'Content-Type': 'text/plain' },
+      });
+      const client = new BitcoinRestClient({ host: 'http://node' }, executor);
+      try {
+        await client.block.getHash(100);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRestError);
+      }
+    });
+
+    it('rejects a block response missing its id', async () => {
+      try {
+        await rest({ height: 100, tx_count: 1 }).block.get({ blockhash: VALID_TXID });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('block.id');
+      }
+    });
+
+    it('rejects a non-hex transaction hex response', async () => {
+      const executor: HttpExecutor = async () => new Response('<html>error</html>', {
+        status  : 200,
+        headers : { 'Content-Type': 'text/plain' },
+      });
+      const client = new BitcoinRestClient({ host: 'http://node' }, executor);
+      try {
+        await client.transaction.getHex(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRestError);
+      }
+    });
+  });
+
+  describe('RPC structural validation (M11)', () => {
+    const rpc = (result: unknown) => new BitcoinCoreRpcClient({ host: 'http://node' }, jsonExecutor({ result }));
+
+    it('rejects a non-integer getblockcount result', async () => {
+      try {
+        await rpc('eight hundred').getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
+
+    it('rejects a negative getblockcount result', async () => {
+      try {
+        await rpc(-5).getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
+
+    it('rejects a listunspent entry with a negative amount', async () => {
+      const utxos = [{ txid: VALID_TXID, vout: 0, amount: -1.5 }];
+      try {
+        await rpc(utxos).listUnspent({});
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('amount');
+      }
+    });
+
+    it('rejects a verbose getrawtransaction without a vin array', async () => {
+      try {
+        await rpc({ txid: VALID_TXID, vout: [] }).getRawTransaction(VALID_TXID, 2);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('vin');
+      }
+    });
+
+    it('rejects a signrawtransactionwithwallet result missing complete', async () => {
+      try {
+        await rpc({ hex: 'aa' }).signRawTransaction('aa');
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('complete');
+      }
+    });
+
+    it('rejects a malformed getrawtransaction element in a batch', async () => {
+      const executor: HttpExecutor = async (req) => {
+        const reqBody = JSON.parse(req.body!);
+        const responses = reqBody.map((item: any, i: number) => ({
+          jsonrpc : '2.0',
+          id      : item.id,
+          result  : i === 0 ? { txid: VALID_TXID, vin: [], vout: [] } : { corrupted: true },
+        }));
+        return new Response(JSON.stringify(responses), {
+          status  : 200,
+          headers : { 'Content-Type': 'application/json' },
+        });
+      };
+      const client = new BitcoinCoreRpcClient({ host: 'http://node' }, executor);
+      try {
+        await client.getRawTransactions(['a'.repeat(64), 'b'.repeat(64)], 2);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
+
+    it('accepts well-formed results', async () => {
+      expect(await rpc(808080).getBlockCount()).to.equal(808080);
+      expect(await rpc('ab'.repeat(32)).getBlockHash(1)).to.equal('ab'.repeat(32));
+      expect(await rpc(true).verifyMessage('a', 's', 'm')).to.equal(true);
+      const tx = { txid: VALID_TXID, vin: [], vout: [{ value: 0.5, scriptPubKey: { hex: '6a' } }] };
+      const verbose = await rpc(tx).getRawTransaction(VALID_TXID, 2);
+      expect(verbose).to.have.property('txid', VALID_TXID);
+    });
+  });
+
+  describe('btcToSats edge cases (L14)', () => {
+    it('preserves the sign of negative fractional values', () => {
+      expect(BitcoinConnection.btcToSats(-0.5)).to.equal(-50_000_000);
+      expect(BitcoinConnection.btcToSats(-0.00000001)).to.equal(-1);
+      expect(BitcoinConnection.btcToSats(-1.5)).to.equal(-150_000_000);
+    });
+
+    it('rejects non-finite values', () => {
+      expect(() => BitcoinConnection.btcToSats(Infinity)).to.throw(RangeError);
+      expect(() => BitcoinConnection.btcToSats(-Infinity)).to.throw(RangeError);
+      expect(() => BitcoinConnection.btcToSats(NaN)).to.throw(RangeError);
+    });
+
+    it('rejects values in the exponential-notation range of toFixed', () => {
+      expect(() => BitcoinConnection.btcToSats(1e21)).to.throw(RangeError);
+      expect(() => BitcoinConnection.btcToSats(-1e21)).to.throw(RangeError);
+    });
+
+    it('rejects sub-satoshi precision', () => {
+      expect(() => BitcoinConnection.btcToSats(0.000000009)).to.throw(RangeError);
+      expect(() => BitcoinConnection.btcToSats(1.000000005)).to.throw(RangeError);
+    });
+
+    it('does not false-positive on large values within double representation error', () => {
+      expect(BitcoinConnection.btcToSats(21000000.99999999)).to.equal(2100000099999999);
+      expect(BitcoinConnection.btcToSats(99999999.99999999)).to.equal(10000000000000000);
+      expect(BitcoinConnection.btcToSats(123456789.12345678)).to.equal(12345678912345678);
+    });
+  });
+});

--- a/packages/bitcoin/tests/json-rpc.spec.ts
+++ b/packages/bitcoin/tests/json-rpc.spec.ts
@@ -123,6 +123,16 @@ describe('JsonRpcProtocol', () => {
       expect(body[1].params).to.deep.equal([100]);
       expect(body[0].id).to.not.equal(body[1].id);
     });
+
+    it('captures the assigned IDs on the request descriptor', () => {
+      const protocol = new JsonRpcProtocol({ host: 'http://localhost:18443' });
+      const req = protocol.buildBatchRequest([
+        { method: 'getblockcount', params: [] },
+        { method: 'getblockhash', params: [100] },
+      ]);
+      const body = JSON.parse(req.body!);
+      expect(req.ids).to.deep.equal([body[0].id, body[1].id]);
+    });
   });
 
   describe('authentication', () => {
@@ -195,16 +205,39 @@ describe('JsonRpcProtocol', () => {
         { method: 'getblockcount', params: [] as unknown[] },
         { method: 'getblockhash', params: [100] as unknown[] },
       ];
-      // Build batch to assign IDs
-      protocol.buildBatchRequest(calls);
-      // IDs are now (id-1) and (id)
-      const id = (protocol as any)._id;
+      const req = protocol.buildBatchRequest(calls);
+      const [id1, id2] = req.ids;
       const results = protocol.parseBatchResponse(
         [
-          { id: id, result: 'hash100' },
-          { id: id - 1, result: 12345 },
+          { id: id2, result: 'hash100' },
+          { id: id1, result: 12345 },
         ],
         calls,
+        req.ids,
+      );
+      expect(results).to.deep.equal([12345, 'hash100']);
+    });
+
+    it('is not confused by requests interleaved between build and parse (audit M9)', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = [
+        { method: 'getblockcount', params: [] as unknown[] },
+        { method: 'getblockhash', params: [100] as unknown[] },
+      ];
+      const req = protocol.buildBatchRequest(calls);
+      // Interleave other request builds before the batch response is parsed:
+      // these advance the protocol's internal counter and previously shifted
+      // the reconstructed startId, mapping every result to the wrong call.
+      protocol.buildRequest('getbalance', []);
+      protocol.buildBatchRequest([{ method: 'getblockcount', params: [] }]);
+      const [id1, id2] = req.ids;
+      const results = protocol.parseBatchResponse(
+        [
+          { id: id2, result: 'hash100' },
+          { id: id1, result: 12345 },
+        ],
+        calls,
+        req.ids,
       );
       expect(results).to.deep.equal([12345, 'hash100']);
     });
@@ -212,13 +245,25 @@ describe('JsonRpcProtocol', () => {
     it('throws on missing response', () => {
       const protocol = new JsonRpcProtocol({});
       const calls = [{ method: 'getblockcount', params: [] as unknown[] }];
-      protocol.buildBatchRequest(calls);
+      const req = protocol.buildBatchRequest(calls);
       try {
-        protocol.parseBatchResponse([], calls);
+        protocol.parseBatchResponse([], calls, req.ids);
         expect.fail('Expected to throw');
       } catch (err: any) {
         expect(err).to.be.instanceOf(BitcoinRpcError);
         expect(err.message).to.include('Missing response');
+      }
+    });
+
+    it('throws when id count does not match call count', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = [{ method: 'getblockcount', params: [] as unknown[] }];
+      try {
+        protocol.parseBatchResponse([], calls, []);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.message).to.include('does not match call count');
       }
     });
   });

--- a/packages/bitcoin/tests/rest-client.spec.ts
+++ b/packages/bitcoin/tests/rest-client.spec.ts
@@ -42,16 +42,22 @@ function createMockSubClient() {
     // Return a response that lets us inspect what was requested
     if (req.url.includes('/blocks/tip/height')) return 12345;
     if (req.url.includes('/block-height/')) return VALID_HASH;
-    if (req.url.includes('/block/')) return { hash: VALID_HASH };
+    if (req.url.includes('/block/')) return { id: VALID_HASH, height: 100, tx_count: 1 };
     if (req.url.includes('/tx/') && req.url.endsWith('/hex')) return 'deadbeef';
     if (req.url.includes('/tx/') && req.url.endsWith('/raw')) return new Uint8Array([0xde, 0xad]);
     if (req.url.includes('/tx') && req.method === 'POST') return VALID_TXID;
-    if (req.url.includes('/tx/')) return { txid: VALID_TXID, status: { confirmed: false } };
-    if (req.url.includes('/utxo')) return [{ txid: VALID_TXID, vout: 0, value: 5000 }];
-    if (req.url.includes('/address/') && req.url.endsWith('/txs/chain')) return [{ status: { confirmed: true } }];
+    if (req.url.includes('/tx/')) return { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } };
+    if (req.url.includes('/utxo')) {
+      return [{ txid: VALID_TXID, vout: 0, value: 5000, status: { confirmed: true, block_height: 100 } }];
+    }
+    if (req.url.includes('/address/') && req.url.includes('/txs/chain')) {
+      return [{ txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } }];
+    }
     if (req.url.includes('/address/') && req.url.endsWith('/txs/mempool')) return [];
-    if (req.url.includes('/address/') && req.url.endsWith('/txs')) return [{ status: { confirmed: true } }];
-    if (req.url.includes('/address/')) return { address: 'addr1' };
+    if (req.url.includes('/address/') && req.url.endsWith('/txs')) {
+      return [{ txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } }];
+    }
+    if (req.url.includes('/address/')) return { address: 'addr1', chain_stats: {}, mempool_stats: {} };
     return {};
   };
   return { protocol, exec, seen };
@@ -196,7 +202,9 @@ describe('BitcoinRestClient', () => {
     });
 
     it('accepts a custom executor', async () => {
-      const { executor, seen } = mockExecutor({ body: { txid: VALID_TXID, status: { confirmed: false } } });
+      const { executor, seen } = mockExecutor({
+        body : { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } },
+      });
       const rest = new BitcoinRestClient({ host: 'https://example.com' }, executor);
 
       const tx = await rest.transaction.get(VALID_TXID);
@@ -208,11 +216,11 @@ describe('BitcoinRestClient', () => {
   });
 
   describe('response handling', () => {
-    it('returns text for text/plain content type', async () => {
+    it('coerces a text/plain tip height to a number', async () => {
       const { executor } = mockExecutor({ body: '12345', contentType: 'text/plain' });
       const rest = new BitcoinRestClient({ host: 'http://example.com' }, executor);
       const height = await rest.block.count();
-      expect(height).to.equal('12345');
+      expect(height).to.equal(12345);
     });
 
     it('throws MethodError on non-OK responses', async () => {
@@ -259,7 +267,7 @@ describe('BitcoinRestClient', () => {
     });
 
     it('merges config headers into requests', async () => {
-      const { executor, seen } = mockExecutor({ body: {} });
+      const { executor, seen } = mockExecutor({ body: '0', contentType: 'text/plain' });
       const rest = new BitcoinRestClient(
         { host: 'http://example.com', headers: { 'X-Api-Key': 'secret' } },
         executor
@@ -318,7 +326,12 @@ describe('BitcoinTransaction', () => {
   });
 
   it('works end-to-end through BitcoinRestClient with executor', async () => {
-    const mockTx = { txid: VALID_TXID, status: { confirmed: true, block_height: 100, block_hash: 'h', block_time: 0 } };
+    const mockTx = {
+      txid   : VALID_TXID,
+      vin    : [],
+      vout   : [],
+      status : { confirmed: true, block_height: 100, block_hash: 'h', block_time: 0 },
+    };
     const { executor } = mockExecutor({ body: mockTx });
     const rest = new BitcoinRestClient({ host: 'http://node' }, executor);
 
@@ -343,7 +356,7 @@ describe('BitcoinBlock', () => {
 
     const result = await block.get({ blockhash: VALID_HASH });
     expect(seen[0].url).to.include(`/block/${VALID_HASH}`);
-    expect(result).to.have.property('hash');
+    expect(result).to.have.property('id');
   });
 
   it('get() by height resolves hash first', async () => {
@@ -367,12 +380,16 @@ describe('BitcoinBlock', () => {
     }
   });
 
-  it('get() returns undefined when getHash returns non-string', async () => {
+  it('get() throws BitcoinRestError when getHash returns a malformed hash', async () => {
     const protocol = new EsploraProtocol({ host: 'https://test.com' });
     const exec = async () => undefined;
     const block = new BitcoinBlock(protocol, exec);
-    const result = await block.get({ height: 999 });
-    expect(result).to.be.undefined;
+    try {
+      await block.get({ height: 999 });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).to.be.instanceOf(BitcoinRestError);
+    }
   });
 
   it('getHash() delegates to protocol.getBlockHeight()', async () => {
@@ -446,8 +463,8 @@ describe('BitcoinAddress', () => {
   it('isFundedAddress() returns true when confirmed txs exist', async () => {
     const protocol = new EsploraProtocol({ host: 'https://test.com' });
     const exec = async () => [
-      { status: { confirmed: false } },
-      { status: { confirmed: true } },
+      { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } },
+      { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } },
     ];
     const address = new BitcoinAddress(protocol, exec);
     expect(await address.isFundedAddress('addr1')).to.equal(true);
@@ -455,13 +472,13 @@ describe('BitcoinAddress', () => {
 
   it('isFundedAddress() returns false when no confirmed txs', async () => {
     const protocol = new EsploraProtocol({ host: 'https://test.com' });
-    const exec = async () => [{ status: { confirmed: false } }];
+    const exec = async () => [{ txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } }];
     const address = new BitcoinAddress(protocol, exec);
     expect(await address.isFundedAddress('addr1')).to.equal(false);
   });
 
   it('works end-to-end through BitcoinRestClient with executor', async () => {
-    const utxos = [{ txid: VALID_TXID, vout: 0, value: 5000, status: { confirmed: true } }];
+    const utxos = [{ txid: VALID_TXID, vout: 0, value: 5000, status: { confirmed: true, block_height: 100 } }];
     const { executor } = mockExecutor({ body: utxos });
     const rest = new BitcoinRestClient({ host: 'http://node' }, executor);
 

--- a/packages/bitcoin/tests/rpc-client.spec.ts
+++ b/packages/bitcoin/tests/rpc-client.spec.ts
@@ -332,7 +332,7 @@ describe('BitcoinCoreRpcClient', () => {
           const responses = reqBody.map((item: any) => ({
             jsonrpc : '2.0',
             id      : item.id,
-            result  : { txid: item.params[0], hex: 'ff' },
+            result  : { txid: item.params[0], hex: 'ff', vin: [], vout: [] },
           }));
           return new Response(JSON.stringify(responses), {
             status  : 200,
@@ -358,7 +358,7 @@ describe('BitcoinCoreRpcClient', () => {
           const responses = reqBody.map((item: any) => ({
             jsonrpc : '2.0',
             id      : item.id,
-            result  : { txid: item.params[0] },
+            result  : { txid: item.params[0], vin: [], vout: [] },
           }));
           return new Response(JSON.stringify(responses), {
             status  : 200,


### PR DESCRIPTION
* fix(bitcoin): build-time batch ids, response size caps, structural validation, btcToSats edge cases (audit M9, M11, L14)
* test(bitcoin): add client-robustness regression spec and align fixtures with strict response validation
* test(api): return a well-formed transaction from the injected-executor fixture