### PR TITLE
add pre-broadcast confirmation and a fee-rate ceiling to the cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -92,8 +92,11 @@ Required flags: `-s/--source-document`, `--source-version-id`, `-p/--patches`, `
 | `-m, --verification-method-id <id>` | DID document verification method ID |
 | `-b, --beacon-id <json>` | Beacon ID as a JSON string |
 | `--publish-to-cas <mode>` | Publish update artifacts to a writable CAS before broadcast: `auto`, `always`, or `never` (default: `never`). See [Publishing updates to CAS](#publishing-updates-to-cas) |
-| `--fee-rate <satsPerVByte>` | Fee rate in sats/vByte for the beacon transaction (default: `5`). Raise it under congestion so the transaction confirms (also `BTCR2_FEE_RATE`, profile `btc.feeRate`) |
+| `--fee-rate <satsPerVByte>` | Fee rate in sats/vByte for the beacon transaction (default: `5`, maximum `1000`). Raise it under congestion so the transaction confirms (also `BTCR2_FEE_RATE`, profile `btc.feeRate`) |
 | `--change-address <address>` | Send transaction change to this address instead of the beacon address, so a DID's announcements are not linked on-chain (profile `btc.changeAddress`) |
+| `-y, --yes` | Confirm the on-chain broadcast without an interactive prompt (required for non-interactive use on public networks) |
+
+On public networks, `update` (and `deactivate`) shows the broadcast plan with the estimated absolute fee and asks for confirmation before spending the beacon UTXO; non-interactive invocations must pass `--yes`. Regtest skips the prompt.
 
 On a network with a block explorer, text-mode `update` (and `deactivate`) also prints a `Watch:` link on stderr for the broadcast txid, suppressed under `--quiet` and `-o json`.
 
@@ -101,7 +104,7 @@ On a network with a block explorer, text-mode `update` (and `deactivate`) also p
 
 Permanently deactivates a DID. This is irreversible. Deactivation applies the `{ "op": "add", "path": "/deactivated", "value": true }` patch and routes through the same signed-update path as `update`, so it also signs via the keystore.
 
-Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>`, `--fee-rate <satsPerVByte>`, `--change-address <address>` (same as `update`).
+Required flags: `-s/--source-document`, `--source-version-id`, `-m/--verification-method-id`, `-b/--beacon-id`. Optional: `--publish-to-cas <mode>`, `--fee-rate <satsPerVByte>`, `--change-address <address>`, `-y/--yes` (same as `update`). The pre-broadcast confirmation warns that deactivation is permanent.
 
 ### init
 

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -1,7 +1,9 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
+import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
+import { confirmBroadcast, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
 import { CLIError } from '../error.js';
 import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
@@ -55,6 +57,11 @@ export function registerDeactivateCommand(
       'Send transaction change to this address instead of the beacon address, '
         + 'so a DID\'s announcements are not linked on-chain (ADR 044).',
     )
+    .option(
+      '-y, --yes',
+      'Confirm the on-chain broadcast without an interactive prompt '
+        + '(required for non-interactive use on public networks).',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
@@ -63,6 +70,7 @@ export function registerDeactivateCommand(
       publishToCas         : PublishToCasMode;
       feeRate?             : string;
       changeAddress?       : string;
+      yes?                 : boolean;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -101,6 +109,19 @@ export function registerDeactivateCommand(
         feeRate       : options.feeRate,
         changeAddress : options.changeAddress,
       });
+      // Deactivation is irreversible and spends the beacon UTXO on-chain:
+      // require explicit operator confirmation unless --yes was given.
+      // Skipped on regtest (audit M8).
+      const feeEstimator = broadcastOptions?.feeEstimator;
+      confirmBroadcast({
+        action              : 'deactivate',
+        did,
+        network,
+        beaconId            : String(parsed.beaconId),
+        feeRateSatsPerVByte : feeEstimator instanceof StaticFeeEstimator
+          ? feeEstimator.satsPerVbyte
+          : DEFAULT_FEE_RATE_SATS_PER_VBYTE,
+      }, { yes: options.yes });
       // CAS publication is optional and never required: every beacon update can
       // be completed and shared via sidecar alone. It is opt-in and defaults to
       // 'never'; pass --publish-to-cas auto|always to publish the signed update

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,7 +1,9 @@
 import type { PublishToCasMode } from '@did-btcr2/api';
 import { KeyManagerSigner } from '@did-btcr2/key-manager';
+import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
+import { confirmBroadcast, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
 import { CLIError } from '../error.js';
 import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
@@ -56,6 +58,11 @@ export function registerUpdateCommand(
       'Send transaction change to this address instead of the beacon address, '
         + 'so a DID\'s announcements are not linked on-chain (ADR 044).',
     )
+    .option(
+      '-y, --yes',
+      'Confirm the on-chain broadcast without an interactive prompt '
+        + '(required for non-interactive use on public networks).',
+    )
     .action(async (options: {
       sourceDocument       : unknown;
       sourceVersionId      : string;
@@ -65,6 +72,7 @@ export function registerUpdateCommand(
       publishToCas         : PublishToCasMode;
       feeRate?             : string;
       changeAddress?       : string;
+      yes?                 : boolean;
     }) => {
       if (!/^\d+$/.test(options.sourceVersionId)) {
         throw new CLIError(
@@ -101,6 +109,19 @@ export function registerUpdateCommand(
         feeRate       : options.feeRate,
         changeAddress : options.changeAddress,
       });
+      // On-chain spends require explicit operator confirmation: show the plan
+      // (including the estimated absolute fee) and prompt, unless --yes was
+      // given. Skipped on regtest (audit M8).
+      const feeEstimator = broadcastOptions?.feeEstimator;
+      confirmBroadcast({
+        action              : 'update',
+        did,
+        network,
+        beaconId            : String(parsed.beaconId),
+        feeRateSatsPerVByte : feeEstimator instanceof StaticFeeEstimator
+          ? feeEstimator.satsPerVbyte
+          : DEFAULT_FEE_RATE_SATS_PER_VBYTE,
+      }, { yes: options.yes });
       // CAS publication is optional and never required: every beacon update can
       // be completed and shared via sidecar alone. It is opt-in and defaults to
       // 'never'; pass --publish-to-cas auto|always to publish the signed update

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -5,6 +5,7 @@ import type { BroadcastOptions } from '@did-btcr2/method';
 import { readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { CLIError } from './error.js';
+import { MAX_FEE_RATE_SATS_PER_VBYTE } from './confirm.js';
 import { ensureDir, writeFileAtomic } from './keystore/atomic.js';
 import { FileBackedKeyManager } from './keystore/file-backed-key-manager.js';
 import { keystoreProtection, keystoreVerifierId } from './keystore/file-key-store.js';
@@ -835,9 +836,11 @@ export function resolveBroadcastOptions(
 /** Parses a positive sats/vByte fee rate, throwing a {@link CLIError} otherwise. */
 function parseFeeRate(raw: string): number {
   const rate = Number(raw);
-  if (!Number.isFinite(rate) || rate <= 0) {
+  // A sanity ceiling catches fat-fingered rates (audit M8): anything above
+  // MAX_FEE_RATE_SATS_PER_VBYTE is far beyond historical congestion peaks.
+  if (!Number.isFinite(rate) || rate <= 0 || rate > MAX_FEE_RATE_SATS_PER_VBYTE) {
     throw new CLIError(
-      `Invalid --fee-rate "${raw}": expected a positive number of sats per vByte.`,
+      `Invalid fee rate "${raw}": expected a positive number of sats per vByte (maximum ${MAX_FEE_RATE_SATS_PER_VBYTE}).`,
       'INVALID_ARGUMENT_ERROR',
       { value: raw },
     );

--- a/packages/cli/src/confirm.ts
+++ b/packages/cli/src/confirm.ts
@@ -1,0 +1,119 @@
+import { readSync } from 'node:fs';
+import { CLIError } from './error.js';
+import type { NetworkOption } from './types.js';
+
+/**
+ * Hard ceiling for the `--fee-rate` flag, the `BTCR2_FEE_RATE` env var, and the
+ * profile `btc.feeRate` value (audit M8). Far above historical congestion
+ * peaks; anything higher is a fat-finger, not a fee choice.
+ */
+export const MAX_FEE_RATE_SATS_PER_VBYTE = 1000;
+
+/** The SDK default fee rate applied when the operator sets none. */
+export const DEFAULT_FEE_RATE_SATS_PER_VBYTE = 5;
+
+/**
+ * Approximate vsize of a single-party beacon signal transaction (P2PKH input
+ * is the worst case; P2WPKH/P2TR are smaller). Used only for the pre-broadcast
+ * fee estimate shown at the confirmation prompt; the exact fee is fixed later
+ * inside the beacon's two-pass transaction build.
+ */
+export const ESTIMATED_BEACON_TX_VBYTES = 250;
+
+/** A planned on-chain broadcast presented to the operator for confirmation. */
+export type BroadcastPlan = {
+  /** The command doing the broadcast. */
+  action          : 'update' | 'deactivate';
+  /** The DID being updated or deactivated. */
+  did             : string;
+  /** The network the beacon transaction will land on. */
+  network         : NetworkOption;
+  /** The beacon service id spending the UTXO. */
+  beaconId        : string;
+  /** The effective fee rate in sats/vByte. */
+  feeRateSatsPerVByte : number;
+};
+
+/** Options for {@link confirmBroadcast}. */
+export type ConfirmBroadcastOptions = {
+  /** Operator pre-confirmation via `--yes` (required for non-interactive use). */
+  yes?: boolean;
+  /**
+   * Interactive prompter; defaults to a terminal prompt when stdin is a TTY.
+   * When no prompter is available and `--yes` was not given, confirmation
+   * fails closed.
+   */
+  prompt?: (label: string) => string;
+};
+
+/**
+ * Requires explicit operator confirmation before an on-chain beacon broadcast
+ * (audit M8). Skipped on regtest (a local, disposable network) and when
+ * `--yes` was passed. Otherwise displays the plan, including the estimated
+ * absolute fee, and requires a "yes" answer. Non-interactive invocations
+ * without `--yes` fail closed with `CONFIRMATION_REQUIRED_ERROR`.
+ *
+ * @throws {CLIError} `CONFIRMATION_REQUIRED_ERROR` when no confirmation
+ * channel is available, or `BROADCAST_ABORTED_ERROR` when the operator
+ * declines.
+ */
+export function confirmBroadcast(plan: BroadcastPlan, options: ConfirmBroadcastOptions = {}): void {
+  if (plan.network === 'regtest') return;
+  if (options.yes) return;
+
+  const estimatedSats = Math.ceil(plan.feeRateSatsPerVByte * ESTIMATED_BEACON_TX_VBYTES);
+  const lines = [
+    `About to broadcast an on-chain ${plan.action}:`,
+    `  DID:      ${plan.did}`,
+    `  Network:  ${plan.network}`,
+    `  Beacon:   ${plan.beaconId}`,
+    `  Fee:      ~${estimatedSats} sats (${(estimatedSats / 1e8).toFixed(8)} BTC) `
+      + `at ${plan.feeRateSatsPerVByte} sat/vB (estimated for a ~${ESTIMATED_BEACON_TX_VBYTES} vB transaction)`,
+  ];
+  if (plan.action === 'deactivate') {
+    lines.push('  WARNING:  deactivation is permanent and cannot be undone.');
+  }
+
+  const prompt = options.prompt ?? (process.stdin.isTTY ? ttyPrompt : undefined);
+  if (!prompt) {
+    throw new CLIError(
+      `Refusing to broadcast an on-chain ${plan.action} without confirmation. `
+        + 'Re-run with --yes to confirm, or run in a terminal to be prompted.',
+      'CONFIRMATION_REQUIRED_ERROR',
+      { did: plan.did, network: plan.network },
+    );
+  }
+
+  const answer = prompt(`${lines.join('\n')}\nType "yes" to broadcast: `).trim().toLowerCase();
+  if (answer !== 'yes' && answer !== 'y') {
+    throw new CLIError(
+      'Broadcast aborted: not confirmed.',
+      'BROADCAST_ABORTED_ERROR',
+      { did: plan.did },
+    );
+  }
+}
+
+/**
+ * Reads one line from the terminal synchronously (canonical mode, echo on).
+ * The label goes to stderr so `--output json` on stdout stays machine-clean.
+ */
+function ttyPrompt(label: string): string {
+  process.stderr.write(label);
+  const byte = Buffer.alloc(1);
+  const bytes: number[] = [];
+  for (;;) {
+    let read = 0;
+    try {
+      read = readSync(process.stdin.fd, byte, 0, 1, null);
+    } catch {
+      break;
+    }
+    if (read === 0) break;
+    const ch = byte[0];
+    if (ch === 0x0a || ch === 0x0d) break;
+    bytes.push(ch);
+  }
+  process.stderr.write('\n');
+  return Buffer.from(bytes).toString('utf-8');
+}

--- a/packages/cli/tests/broadcast-safety.spec.ts
+++ b/packages/cli/tests/broadcast-safety.spec.ts
@@ -1,0 +1,246 @@
+import { createApi, type DidBtcr2Api } from '@did-btcr2/api';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import type { Command } from 'commander';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DidBtcr2Cli } from '../src/cli.js';
+import {
+  confirmBroadcast,
+  DEFAULT_FEE_RATE_SATS_PER_VBYTE,
+  ESTIMATED_BEACON_TX_VBYTES,
+  MAX_FEE_RATE_SATS_PER_VBYTE,
+} from '../src/confirm.js';
+import type { ApiFactory } from '../src/config.js';
+import { CLIError } from '../src/error.js';
+import { createKeystoreTestApiFactory, createTestApiFactory, expect, originalConsoleLog } from './helpers.js';
+
+function sub(cli: DidBtcr2Cli, name: string): Command {
+  const c = cli.program.commands.find(x => x.name() === name);
+  if (!c) throw new Error(`${name} not found`);
+  return c;
+}
+
+/** Forces stdin non-interactive for the duration of `fn`, then restores it. */
+function withNonTtyStdinSync<T>(fn: () => T): T {
+  const stdin = process.stdin as unknown as { isTTY?: boolean };
+  const had = Object.prototype.hasOwnProperty.call(stdin, 'isTTY');
+  const prev = stdin.isTTY;
+  stdin.isTTY = false;
+  try {
+    return fn();
+  } finally {
+    if (had) stdin.isTTY = prev;
+    else delete stdin.isTTY;
+  }
+}
+
+/** Async variant of {@link withNonTtyStdinSync}. */
+async function withNonTtyStdin<T>(fn: () => Promise<T>): Promise<T> {
+  const stdin = process.stdin as unknown as { isTTY?: boolean };
+  const had = Object.prototype.hasOwnProperty.call(stdin, 'isTTY');
+  const prev = stdin.isTTY;
+  stdin.isTTY = false;
+  try {
+    return await fn();
+  } finally {
+    if (had) stdin.isTTY = prev;
+    else delete stdin.isTTY;
+  }
+}
+
+describe('broadcast confirmation (audit M8)', () => {
+  const base = {
+    did                 : 'did:btcr2:xxxx',
+    network             : 'bitcoin' as const,
+    beaconId            : '#beacon-0',
+    feeRateSatsPerVByte : 12,
+  };
+
+  it('skips confirmation on regtest', () => {
+    expect(() => confirmBroadcast({ ...base, action: 'update', network: 'regtest' })).to.not.throw();
+    expect(() => confirmBroadcast({ ...base, action: 'deactivate', network: 'regtest' })).to.not.throw();
+  });
+
+  it('skips the prompt when --yes was passed', () => {
+    let prompted = false;
+    confirmBroadcast({ ...base, action: 'update' }, {
+      yes    : true,
+      prompt : () => { prompted = true; return 'no'; },
+    });
+    expect(prompted).to.equal(false);
+  });
+
+  it('proceeds when the operator answers yes', () => {
+    expect(() => confirmBroadcast({ ...base, action: 'update' }, { prompt: () => 'yes' })).to.not.throw();
+    expect(() => confirmBroadcast({ ...base, action: 'update' }, { prompt: () => ' y ' })).to.not.throw();
+  });
+
+  it('aborts when the operator declines', () => {
+    expect(() => confirmBroadcast({ ...base, action: 'update' }, { prompt: () => 'no' }))
+      .to.throw(CLIError, /not confirmed/);
+    expect(() => confirmBroadcast({ ...base, action: 'update' }, { prompt: () => '' }))
+      .to.throw(CLIError, /not confirmed/);
+  });
+
+  it('fails closed when no confirmation channel is available', () => {
+    // With stdin non-interactive and no --yes, confirmation must fail closed.
+    withNonTtyStdinSync(() => {
+      expect(() => confirmBroadcast({ ...base, action: 'update' })).to.throw(CLIError, /--yes/);
+    });
+    withNonTtyStdinSync(() => {
+      try {
+        confirmBroadcast({ ...base, action: 'deactivate' });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('CONFIRMATION_REQUIRED_ERROR');
+      }
+    });
+  });
+
+  it('displays the plan with an estimated absolute fee', () => {
+    let label = '';
+    confirmBroadcast({ ...base, action: 'update' }, {
+      prompt : (l) => { label = l; return 'yes'; },
+    });
+    expect(label).to.include(base.did);
+    expect(label).to.include('bitcoin');
+    expect(label).to.include('#beacon-0');
+    const estimatedSats = Math.ceil(base.feeRateSatsPerVByte * ESTIMATED_BEACON_TX_VBYTES);
+    expect(label).to.include(`~${estimatedSats} sats`);
+    expect(label).to.include('12 sat/vB');
+  });
+
+  it('warns that deactivation is permanent', () => {
+    let label = '';
+    confirmBroadcast({ ...base, action: 'deactivate' }, {
+      prompt : (l) => { label = l; return 'yes'; },
+    });
+    expect(label).to.match(/permanent|irreversible/i);
+  });
+});
+
+describe('fee-rate ceiling and command-level confirmation (audit M8)', () => {
+  let dir: string;
+  let keystore: string;
+  let did: string;
+  let captured: { params?: any };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'btcr2-broadcast-safety-'));
+    keystore = join(dir, 'keystore.json');
+    captured = {};
+    console.log = () => {};
+    createKeystoreTestApiFactory(keystore, 'pw')().kms.generateKey({ setActive: true });
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function stubFactory(): ApiFactory {
+    return () => {
+      const realApi = createKeystoreTestApiFactory(keystore, 'pw')();
+      return {
+        kms   : realApi.kms,
+        btcr2 : { update: async (params: unknown) => { captured.params = params; return { signed: 'mock' }; } },
+      } as unknown as DidBtcr2Api;
+    };
+  }
+
+  const didFor = (network: string): string =>
+    createApi().createDid('deterministic', SchnorrKeyPair.generate().publicKey.compressed, { network: network as never });
+
+  const updateArgs = (id: string, extra: string[] = []): string[] => [
+    '-s', JSON.stringify({ id }),
+    '--source-version-id', '1',
+    '-p', '[]',
+    '-m', '#k0',
+    '-b', '"#beacon-0"',
+    ...extra,
+  ];
+
+  it('rejects a fat-fingered --fee-rate above the ceiling', async () => {
+    did = didFor('regtest');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await expect(
+      sub(cli, 'update').parseAsync(updateArgs(did, ['--fee-rate', '50000']), { from: 'user' }),
+    ).to.be.rejectedWith(CLIError, new RegExp(`maximum ${MAX_FEE_RATE_SATS_PER_VBYTE}`));
+    expect(captured.params).to.equal(undefined);
+  });
+
+  it('accepts a --fee-rate at the ceiling', async () => {
+    did = didFor('regtest');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await sub(cli, 'update').parseAsync(
+      updateArgs(did, ['--fee-rate', String(MAX_FEE_RATE_SATS_PER_VBYTE)]),
+      { from: 'user' },
+    );
+    expect(captured.params.broadcastOptions.feeEstimator.satsPerVbyte).to.equal(MAX_FEE_RATE_SATS_PER_VBYTE);
+  });
+
+  it('rejects an excessive BTCR2_FEE_RATE from the environment', async () => {
+    did = didFor('regtest');
+    process.env.BTCR2_FEE_RATE = '50000';
+    try {
+      const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+      await expect(
+        sub(cli, 'update').parseAsync(updateArgs(did), { from: 'user' }),
+      ).to.be.rejectedWith(CLIError, /maximum/);
+      expect(captured.params).to.equal(undefined);
+    } finally {
+      delete process.env.BTCR2_FEE_RATE;
+    }
+  });
+
+  it('requires --yes on a public network when non-interactive', async () => {
+    did = didFor('mutinynet');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await withNonTtyStdin(async () => {
+      await expect(
+        sub(cli, 'update').parseAsync(updateArgs(did), { from: 'user' }),
+      ).to.be.rejectedWith(CLIError, /--yes/);
+    });
+    expect(captured.params).to.equal(undefined);
+  });
+
+  it('proceeds on a public network with --yes', async () => {
+    did = didFor('mutinynet');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    await withNonTtyStdin(async () => {
+      await sub(cli, 'update').parseAsync(updateArgs(did, ['--yes']), { from: 'user' });
+    });
+    expect(captured.params).to.not.equal(undefined);
+  });
+
+  it('requires --yes for a non-interactive deactivate on a public network', async () => {
+    did = didFor('mutinynet');
+    const cli = new DidBtcr2Cli(createTestApiFactory(), stubFactory());
+    const args = [
+      '-s', JSON.stringify({ id: did }),
+      '--source-version-id', '1',
+      '-m', '#k0',
+      '-b', '"#beacon-0"',
+    ];
+    await withNonTtyStdin(async () => {
+      await expect(
+        sub(cli, 'deactivate').parseAsync(args, { from: 'user' }),
+      ).to.be.rejectedWith(CLIError, /--yes/);
+    });
+    expect(captured.params).to.equal(undefined);
+  });
+
+  it('shows the default fee rate in the plan when none is configured', () => {
+    // Unit-level: no fee flag/env/profile means the SDK default is displayed.
+    let label = '';
+    confirmBroadcast({
+      action              : 'update',
+      did                 : 'did:btcr2:xxxx',
+      network             : 'signet',
+      beaconId            : '#beacon-0',
+      feeRateSatsPerVByte : DEFAULT_FEE_RATE_SATS_PER_VBYTE,
+    }, { prompt: (l) => { label = l; return 'yes'; } });
+    expect(label).to.include(`${DEFAULT_FEE_RATE_SATS_PER_VBYTE} sat/vB`);
+  });
+});

--- a/packages/cli/tests/update.spec.ts
+++ b/packages/cli/tests/update.spec.ts
@@ -256,7 +256,8 @@ describe('update/deactivate watch hint (ADR 082)', () => {
     const did = didFor('mutinynet');
     const cli = new DidBtcr2Cli(createTestApiFactory(), txidStub('cafe1234'));
     await sub(cli, 'update').parseAsync(
-      ['-s', JSON.stringify({ id: did }), '--source-version-id', '1', '-p', '[]', '-m', '#k0', '-b', '"#beacon-0"'],
+      ['-s', JSON.stringify({ id: did }), '--source-version-id', '1', '-p', '[]', '-m', '#k0', '-b', '"#beacon-0"',
+        '--yes'],
       { from: 'user' },
     );
     expect(err.join(' ')).to.match(/Watch:\s+https:\/\/mutinynet\.com\/tx\/cafe1234/);


### PR DESCRIPTION
* fix(cli): require explicit confirmation before on-chain update/deactivate broadcasts and cap --fee-rate at 1000 sats/vB (audit M8)
* test(cli): cover confirmation accept/abort/fail-closed paths and fee ceiling across flag and env layers
* docs(cli): document --yes, the confirmation gate, and the fee-rate maximum