### PR TITLE
build the zero-hash smt once and serve proofs by trie walk

### DIFF
--- a/packages/smt/src/btcr2-tree.ts
+++ b/packages/smt/src/btcr2-tree.ts
@@ -1,7 +1,7 @@
 import { didToIndex, inclusionLeafHash, nonInclusionLeafHash } from './btcr2-leaf.js';
 import { serializeProof, type SerializedSMTProof } from './btcr2-proof.js';
 import { blockHash } from './hash.js';
-import { generateZeroHashProof, zeroHashRoot, type ZeroHashEntry } from './zero-hash.js';
+import { ZeroHashTree, type ZeroHashEntry } from './zero-hash.js';
 
 /**
  * A single entry in a {@link BTCR2MerkleTree}.
@@ -30,8 +30,7 @@ export interface TreeEntry {
 export class BTCR2MerkleTree {
   readonly #entries = new Map<bigint, TreeEntry>();
   readonly #indexByDid = new Map<string, bigint>();
-  #leaves: ZeroHashEntry[] | null = null;
-  #root: Uint8Array | null = null;
+  #tree: ZeroHashTree | null = null;
 
   /**
    * @param _allowNonInclusion Retained for API compatibility; non-inclusion
@@ -54,13 +53,14 @@ export class BTCR2MerkleTree {
       this.#entries.set(index, entry);
       this.#indexByDid.set(entry.did, index);
     }
-    this.#leaves = null;
-    this.#root = null;
+    this.#tree = null;
   }
 
   /**
-   * Compute leaf hashes and the zero-hash root.
-   * After this call, {@link rootHash} and {@link proof} become available.
+   * Compute leaf hashes and build the zero-hash tree. The tree structure is
+   * built once here and shared by all subsequent {@link proof} calls
+   * (audit M12). After this call, {@link rootHash} and {@link proof} become
+   * available.
    */
   finalize(): void {
     const leaves: ZeroHashEntry[] = [];
@@ -70,14 +70,13 @@ export class BTCR2MerkleTree {
         : nonInclusionLeafHash(entry.nonce);
       leaves.push({ index, leaf });
     }
-    this.#leaves = leaves;
-    this.#root = zeroHashRoot(leaves);
+    this.#tree = ZeroHashTree.fromLeaves(leaves);
   }
 
   /** Root hash of the finalized tree. Throws if not finalized. */
   get rootHash(): Uint8Array {
-    if (this.#root === null) throw new Error('Tree not finalized: call finalize() first');
-    return this.#root;
+    if (this.#tree === null) throw new Error('Tree not finalized: call finalize() first');
+    return this.#tree.root;
   }
 
   /**
@@ -87,22 +86,21 @@ export class BTCR2MerkleTree {
   proof(did: string): SerializedSMTProof {
     const index = this.#indexByDid.get(did);
     if (index === undefined) throw new RangeError(`DID not in tree: ${did}`);
-    if (this.#leaves === null || this.#root === null) {
+    if (this.#tree === null) {
       throw new Error('Tree not finalized: call finalize() first');
     }
 
     const entry    = this.#entries.get(index)!;
-    const proof    = generateZeroHashProof(this.#leaves, index);
+    const proof    = this.#tree.proof(index);
     const updateId = entry.signedUpdate !== undefined
       ? blockHash(entry.signedUpdate)
       : undefined;
 
-    return serializeProof(this.#root, proof, { nonce: entry.nonce, updateId });
+    return serializeProof(this.#tree.root, proof, { nonce: entry.nonce, updateId });
   }
 
-  /** Clear computed leaves and root, keeping entries. */
+  /** Clear the computed tree, keeping entries. */
   reset(): void {
-    this.#leaves = null;
-    this.#root = null;
+    this.#tree = null;
   }
 }

--- a/packages/smt/src/zero-hash.ts
+++ b/packages/smt/src/zero-hash.ts
@@ -36,7 +36,10 @@ function bitAt(index: bigint, position: number): number {
  */
 export const CACHED_ZERO: readonly Uint8Array[] = (() => {
   const arr: Uint8Array[] = new Array(TREE_DEPTH + 1);
-  let z = new Uint8Array(HASH_BYTE_LENGTH);
+  // Explicit `Uint8Array` annotation: TS 5.9+ would otherwise infer
+  // `Uint8Array<ArrayBuffer>` from the initializer and reject reassignment
+  // from `blockHash` (typed `Uint8Array<ArrayBufferLike>`).
+  let z: Uint8Array = new Uint8Array(HASH_BYTE_LENGTH);
   for (let h = 0; h <= TREE_DEPTH; h++) {
     z = blockHash(z, z);
     arr[h] = z;
@@ -59,51 +62,209 @@ export interface ZeroHashProof {
 }
 
 /**
- * Hash of the subtree spanning `height` levels (whole tree = 256, a leaf = 0).
- * An empty subtree contributes its precomputed zero hash; a single leaf is its
- * own leaf hash; otherwise split on the level's index bit and hash `left||right`.
+ * A compressed-trie branch node. Only divergence points are materialized:
+ * levels where a subtree has a single occupant contribute `CACHED_ZERO`
+ * siblings and are lifted through on demand, so the structure holds at most
+ * `2n - 1` branches for `n` leaves instead of all `256n` path nodes.
  */
-function subtreeHash(leaves: ZeroHashEntry[], height: number): Uint8Array {
-  if (leaves.length === 0) return CACHED_ZERO[height];
-  if (height === 0) return leaves[0]!.leaf;
-  const bit = TREE_DEPTH - height;
-  const left: ZeroHashEntry[] = [];
-  const right: ZeroHashEntry[] = [];
-  for (const e of leaves) (bitAt(e.index, bit) === 0 ? left : right).push(e);
-  return blockHash(subtreeHash(left, height - 1), subtreeHash(right, height - 1));
+interface TrieBranch {
+  /** Subtree height spanned by this branch; it splits on bit `TREE_DEPTH - height`. */
+  height : number;
+  /** Representative leaf index: every leaf in this subtree shares its bits below `TREE_DEPTH - height`. */
+  rep    : bigint;
+  left   : TrieNode;
+  right  : TrieNode;
+  /** Memoized subtree hash at this branch's own height. */
+  hash?  : Uint8Array;
+}
+
+type TrieNode = ZeroHashEntry | TrieBranch;
+
+function isBranch(node: TrieNode): node is TrieBranch {
+  return (node as TrieBranch).left !== undefined;
+}
+
+/**
+ * The lowest bit position at which `a` and `b` differ (the first divergence
+ * in root-to-leaf order, since the root splits on the LSB). Returns
+ * `TREE_DEPTH` when the indices are equal.
+ */
+function lowestDifferingBit(a: bigint, b: bigint): number {
+  let x = a ^ b;
+  let p = 0;
+  while (x !== 0n && (x & 1n) === 0n) { x >>= 1n; p++; }
+  return x === 0n ? TREE_DEPTH : p;
+}
+
+/**
+ * Hash of `node`'s subtree viewed at `slotHeight`, lifting through the empty
+ * sibling chain for any compressed solo levels. Branch hashes are computed
+ * once and memoized; lifts are cheap chains of `blockHash(x, CACHED_ZERO[h])`
+ * with the side determined by the shared prefix bits (audit M12).
+ */
+function nodeHash(node: TrieNode, slotHeight: number): Uint8Array {
+  let acc: Uint8Array;
+  let rep: bigint;
+  let fromHeight: number;
+  if (isBranch(node)) {
+    node.hash ??= blockHash(
+      nodeHash(node.left, node.height - 1),
+      nodeHash(node.right, node.height - 1),
+    );
+    acc = node.hash;
+    rep = node.rep;
+    fromHeight = node.height;
+  } else {
+    acc = node.leaf;
+    rep = node.index;
+    fromHeight = 0;
+  }
+  for (let h = fromHeight + 1; h <= slotHeight; h++) {
+    const bit = TREE_DEPTH - h;
+    acc = bitAt(rep, bit) === 1
+      ? blockHash(CACHED_ZERO[h - 1]!, acc)
+      : blockHash(acc, CACHED_ZERO[h - 1]!);
+  }
+  return acc;
+}
+
+/** Insert `entry` into the subtree rooted at `node`. */
+function insertNode(node: TrieNode | undefined, entry: ZeroHashEntry): TrieNode {
+  if (node === undefined) return entry;
+  const rep = isBranch(node) ? node.rep : node.index;
+  if (entry.index === rep) throw new RangeError('Duplicate leaf index');
+  const nodeHeight = isBranch(node) ? node.height : 0;
+  const p = lowestDifferingBit(entry.index, rep);
+  if (p < TREE_DEPTH - nodeHeight) {
+    // The entry diverges above this node's own split: fork a new branch here.
+    const branch: TrieBranch = {
+      height : TREE_DEPTH - p,
+      rep    : entry.index,
+      left   : bitAt(entry.index, p) === 0 ? entry : node,
+      right  : bitAt(entry.index, p) === 0 ? node : entry,
+    };
+    return branch;
+  }
+  // The entry belongs inside this branch (a leaf with a distinct index always
+  // diverges below TREE_DEPTH and takes the fork path above).
+  const branch = node as TrieBranch;
+  const bit = TREE_DEPTH - branch.height;
+  if (bitAt(entry.index, bit) === 0) {
+    branch.left = insertNode(branch.left, entry);
+  } else {
+    branch.right = insertNode(branch.right, entry);
+  }
+  return branch;
+}
+
+/**
+ * A persistent zero-hash Sparse Merkle Tree (audit M12).
+ *
+ * The naive formulation recomputed the sibling set of every level from
+ * scratch per proof: O(256^2 * n) bit operations plus full subtree rehashing
+ * for each of the 256 levels of each proof. This structure builds a
+ * compressed trie once (O(256 * n) hashes, dominated by the unavoidable
+ * full-depth zero-hash chains) and then answers proofs by a single 256-level
+ * walk with memoized subtree hashes, so generating proofs for every member
+ * of a large cohort is no longer quadratic in the tree depth per proof.
+ *
+ * Construct with {@link ZeroHashTree.fromLeaves}; read {@link root} and call
+ * {@link proof} as needed.
+ */
+export class ZeroHashTree {
+  readonly #rootNode: TrieNode | undefined;
+  readonly #rootHash: Uint8Array;
+
+  private constructor(rootNode: TrieNode | undefined) {
+    this.#rootNode = rootNode;
+    this.#rootHash = rootNode === undefined
+      ? CACHED_ZERO[TREE_DEPTH]!
+      : nodeHash(rootNode, TREE_DEPTH);
+  }
+
+  /** Build a tree from a set of leaves, hashing every subtree once. */
+  static fromLeaves(leaves: readonly ZeroHashEntry[]): ZeroHashTree {
+    let root: TrieNode | undefined;
+    for (const entry of leaves) {
+      root = insertNode(root, entry);
+    }
+    return new ZeroHashTree(root);
+  }
+
+  /** The zero-hash Merkle root. */
+  get root(): Uint8Array {
+    return this.#rootHash;
+  }
+
+  /**
+   * Generate the inclusion (or non-inclusion) proof for `targetIndex` by
+   * walking the compressed trie once: at each level the sibling is the
+   * off-path child of a materialized branch, or `CACHED_ZERO` across
+   * compressed solo levels. `targetIndex` need not be present in the tree.
+   */
+  proof(targetIndex: bigint): ZeroHashProof {
+    // sibling[h] is the sibling hash at level h, or null when the sibling is
+    // empty (the collapsed bit). Collected root-to-leaf, emitted leaf-to-root.
+    const siblings: (Uint8Array | null)[] = new Array(TREE_DEPTH + 1).fill(null);
+    let node = this.#rootNode;
+    let slotHeight = TREE_DEPTH;
+    while (slotHeight > 0 && node !== undefined) {
+      const top = isBranch(node) ? node.height : 0;
+      if (top < slotHeight) {
+        // Compressed solo levels above this node's top: check whether the
+        // target follows the same solo path or forks off inside the gap.
+        const rep = isBranch(node) ? node.rep : node.index;
+        const p = lowestDifferingBit(targetIndex, rep);
+        const matchHeight = TREE_DEPTH - p;
+        const stop = Math.max(top + 1, matchHeight + 1);
+        for (let h = slotHeight; h >= stop; h--) siblings[h] = null;
+        if (matchHeight > top) {
+          // The target diverges from this subtree at matchHeight: the whole
+          // subtree is the sibling there, and everything below is empty.
+          siblings[matchHeight] = nodeHash(node, matchHeight - 1);
+          break;
+        }
+        slotHeight = top;
+        continue;
+      }
+      // A materialized branch at exactly this height: real sibling off-path.
+      const branch = node as TrieBranch;
+      const bit = TREE_DEPTH - branch.height;
+      const goLeft = bitAt(targetIndex, bit) === 0;
+      siblings[branch.height] = nodeHash(goLeft ? branch.right : branch.left, branch.height - 1);
+      node = goLeft ? branch.left : branch.right;
+      slotHeight = branch.height - 1;
+    }
+
+    let collapsed = 0n;
+    const hashes: Uint8Array[] = [];
+    for (let h = 1; h <= TREE_DEPTH; h++) {
+      const sibling = siblings[h];
+      if (sibling == null) {
+        collapsed |= (1n << BigInt(TREE_DEPTH - h));
+      } else {
+        hashes.push(sibling);
+      }
+    }
+    return { collapsed, hashes };
+  }
 }
 
 /** Compute the zero-hash Merkle root for a set of leaves. */
 export function zeroHashRoot(leaves: ZeroHashEntry[]): Uint8Array {
-  return subtreeHash(leaves, TREE_DEPTH);
+  return ZeroHashTree.fromLeaves(leaves).root;
 }
 
 /**
  * Generate the inclusion proof for `targetIndex`. At each level the sibling is
  * the subtree of leaves sharing the target's lower-bit path but diverging at this
  * level; an empty sibling sets the `collapsed` bit, a non-empty one emits a hash.
+ *
+ * Builds a fresh {@link ZeroHashTree} internally; callers generating more
+ * than one proof over the same leaves should hold a `ZeroHashTree` instead.
  */
 export function generateZeroHashProof(leaves: ZeroHashEntry[], targetIndex: bigint): ZeroHashProof {
-  let collapsed = 0n;
-  const hashes: Uint8Array[] = [];
-  for (let height = 1; height <= TREE_DEPTH; height++) {
-    const bit = TREE_DEPTH - height;
-    const siblingLeaves: ZeroHashEntry[] = [];
-    for (const e of leaves) {
-      if (e.index === targetIndex) continue;
-      let sharesLowerPath = true;
-      for (let lower = 0; lower < bit; lower++) {
-        if (bitAt(e.index, lower) !== bitAt(targetIndex, lower)) { sharesLowerPath = false; break; }
-      }
-      if (sharesLowerPath && bitAt(e.index, bit) !== bitAt(targetIndex, bit)) siblingLeaves.push(e);
-    }
-    if (siblingLeaves.length === 0) {
-      collapsed |= (1n << BigInt(bit));
-    } else {
-      hashes.push(subtreeHash(siblingLeaves, height - 1));
-    }
-  }
-  return { collapsed, hashes };
+  return ZeroHashTree.fromLeaves(leaves).proof(targetIndex);
 }
 
 /**

--- a/packages/smt/tests/zero-hash-tree.spec.ts
+++ b/packages/smt/tests/zero-hash-tree.spec.ts
@@ -1,0 +1,183 @@
+import { expect } from 'chai';
+import { randomBytes } from 'node:crypto';
+import { blockHash, hashesEqual } from '../src/hash.js';
+import {
+  CACHED_ZERO,
+  verifyZeroHash,
+  ZeroHashTree,
+  zeroHashRoot,
+  type ZeroHashEntry,
+  type ZeroHashProof,
+} from '../src/zero-hash.js';
+
+/**
+ * Differential tests for the persistent {@link ZeroHashTree} (audit M12).
+ *
+ * The naive O(256^2 * n) formulation is reproduced here verbatim as a
+ * reference oracle: every tree/proof produced by the optimized implementation
+ * must be byte-for-byte identical to the oracle's output.
+ */
+
+const TREE_DEPTH = 256;
+
+function bitAt(index: bigint, position: number): number {
+  return Number((index >> BigInt(position)) & 1n);
+}
+
+/** Naive reference: per-level array partitioning with full rehashing. */
+function naiveSubtreeHash(leaves: ZeroHashEntry[], height: number): Uint8Array {
+  if (leaves.length === 0) return CACHED_ZERO[height]!;
+  if (height === 0) return leaves[0]!.leaf;
+  const bit = TREE_DEPTH - height;
+  const left: ZeroHashEntry[] = [];
+  const right: ZeroHashEntry[] = [];
+  for (const e of leaves) (bitAt(e.index, bit) === 0 ? left : right).push(e);
+  return blockHash(naiveSubtreeHash(left, height - 1), naiveSubtreeHash(right, height - 1));
+}
+
+/** Naive reference: proof by scanning all leaves at every level. */
+function naiveGenerateProof(leaves: ZeroHashEntry[], targetIndex: bigint): ZeroHashProof {
+  let collapsed = 0n;
+  const hashes: Uint8Array[] = [];
+  for (let height = 1; height <= TREE_DEPTH; height++) {
+    const bit = TREE_DEPTH - height;
+    const siblingLeaves: ZeroHashEntry[] = [];
+    for (const e of leaves) {
+      if (e.index === targetIndex) continue;
+      let sharesLowerPath = true;
+      for (let lower = 0; lower < bit; lower++) {
+        if (bitAt(e.index, lower) !== bitAt(targetIndex, lower)) { sharesLowerPath = false; break; }
+      }
+      if (sharesLowerPath && bitAt(e.index, bit) !== bitAt(targetIndex, bit)) siblingLeaves.push(e);
+    }
+    if (siblingLeaves.length === 0) {
+      collapsed |= (1n << BigInt(bit));
+    } else {
+      hashes.push(naiveSubtreeHash(siblingLeaves, height - 1));
+    }
+  }
+  return { collapsed, hashes };
+}
+
+/** A random set of `n` distinct leaves. */
+function randomLeaves(n: number): ZeroHashEntry[] {
+  const leaves: ZeroHashEntry[] = [];
+  const seen = new Set<bigint>();
+  while (leaves.length < n) {
+    const index = BigInt(`0x${randomBytes(32).toString('hex')}`);
+    if (seen.has(index)) continue;
+    seen.add(index);
+    leaves.push({ index, leaf: randomBytes(32) });
+  }
+  return leaves;
+}
+
+/** Two leaves that share exactly their lowest `sharedBits` bits (stressing deep forks). */
+function forkedLeaves(sharedBits: number): [ZeroHashEntry, ZeroHashEntry] {
+  const a = BigInt(`0x${randomBytes(32).toString('hex')}`);
+  const mask = (1n << BigInt(sharedBits)) - 1n;
+  const b = (a & mask) | (~a & ~mask & ((1n << 256n) - 1n));
+  if (a === b) throw new Error('degenerate');
+  return [
+    { index: a, leaf: randomBytes(32) },
+    { index: b, leaf: randomBytes(32) },
+  ];
+}
+
+describe('ZeroHashTree (audit M12)', () => {
+  describe('oracle equivalence', () => {
+    // [leaf count, inclusion targets to check]: the naive oracle is itself
+    // quadratic per proof (that is the defect being fixed), so large sets
+    // sample a few members instead of exhausting all of them.
+    const cases: Array<[number, number]> = [[1, 1], [2, 2], [3, 3], [5, 5], [17, 17], [64, 64], [200, 4]];
+    for (const [n, samples] of cases) {
+      it(`matches the naive root and proofs for n=${n}`, () => {
+        const leaves = randomLeaves(n);
+        const tree = ZeroHashTree.fromLeaves(leaves);
+        expect(hashesEqual(tree.root, naiveSubtreeHash(leaves, TREE_DEPTH))).to.equal(true);
+        expect(hashesEqual(tree.root, zeroHashRoot(leaves))).to.equal(true);
+
+        // Inclusion targets, sampled for large n.
+        for (const e of leaves.slice(0, samples)) {
+          const expected = naiveGenerateProof(leaves, e.index);
+          const proof = tree.proof(e.index);
+          expect(proof.collapsed).to.equal(expected.collapsed);
+          expect(proof.hashes.map(h => Buffer.from(h).toString('hex')))
+            .to.deep.equal(expected.hashes.map(h => Buffer.from(h).toString('hex')));
+          expect(verifyZeroHash(proof.collapsed, proof.hashes, e.index, e.leaf, tree.root)).to.equal(true);
+        }
+
+        // Non-inclusion targets: random indices outside the tree.
+        for (let i = 0; i < 2; i++) {
+          const target = BigInt(`0x${randomBytes(32).toString('hex')}`);
+          const expected = naiveGenerateProof(leaves, target);
+          const proof = tree.proof(target);
+          expect(proof.collapsed).to.equal(expected.collapsed);
+          expect(proof.hashes.map(h => Buffer.from(h).toString('hex')))
+            .to.deep.equal(expected.hashes.map(h => Buffer.from(h).toString('hex')));
+        }
+      });
+    }
+
+    it('matches the naive oracle for deep shared prefixes', () => {
+      // Pairs sharing long prefixes exercise the compressed-gap fork logic.
+      for (const sharedBits of [1, 7, 64, 128, 200, 250]) {
+        const [a, b] = forkedLeaves(sharedBits);
+        const leaves = [a, b];
+        const tree = ZeroHashTree.fromLeaves(leaves);
+        expect(hashesEqual(tree.root, naiveSubtreeHash(leaves, TREE_DEPTH))).to.equal(true);
+        for (const e of leaves) {
+          const expected = naiveGenerateProof(leaves, e.index);
+          const proof = tree.proof(e.index);
+          expect(proof.collapsed).to.equal(expected.collapsed);
+          expect(proof.hashes.map(h => Buffer.from(h).toString('hex')))
+            .to.deep.equal(expected.hashes.map(h => Buffer.from(h).toString('hex')));
+        }
+      }
+    });
+
+    it('matches the naive oracle for an empty tree', () => {
+      const tree = ZeroHashTree.fromLeaves([]);
+      expect(hashesEqual(tree.root, CACHED_ZERO[TREE_DEPTH]!)).to.equal(true);
+      const target = BigInt(`0x${randomBytes(32).toString('hex')}`);
+      const proof = tree.proof(target);
+      const expected = naiveGenerateProof([], target);
+      expect(proof.collapsed).to.equal(expected.collapsed);
+      expect(proof.hashes).to.have.length(0);
+    });
+
+    it('throws on a duplicate leaf index', () => {
+      const index = BigInt(`0x${randomBytes(32).toString('hex')}`);
+      const leaves = [
+        { index, leaf: randomBytes(32) },
+        { index, leaf: randomBytes(32) },
+      ];
+      expect(() => ZeroHashTree.fromLeaves(leaves)).to.throw(RangeError, /Duplicate/);
+    });
+
+    it('rejects a proof for a different leaf at the same index', () => {
+      const leaves = randomLeaves(4);
+      const tree = ZeroHashTree.fromLeaves(leaves);
+      const target = leaves[0]!;
+      const proof = tree.proof(target.index);
+      const wrongLeaf = randomBytes(32);
+      expect(verifyZeroHash(proof.collapsed, proof.hashes, target.index, wrongLeaf, tree.root)).to.equal(false);
+    });
+  });
+
+  describe('performance (audit M12)', () => {
+    it('builds and proves a 500-member cohort well under the naive per-proof cost', () => {
+      const leaves = randomLeaves(500);
+      const start = performance.now();
+      const tree = ZeroHashTree.fromLeaves(leaves);
+      for (const e of leaves) {
+        const proof = tree.proof(e.index);
+        expect(verifyZeroHash(proof.collapsed, proof.hashes, e.index, e.leaf, tree.root)).to.equal(true);
+      }
+      const elapsed = performance.now() - start;
+      // The naive formulation costs O(256^2 * n) per proof; one naive proof at
+      // this size already exceeds this budget. Generous bound to stay CI-safe.
+      expect(elapsed).to.be.lessThan(10_000);
+    });
+  });
+});


### PR DESCRIPTION
* perf(smt): replace per-proof O(256^2*n) rescanning with a persistent compressed trie shared across proofs (audit M12)
* test(smt): differential-test ZeroHashTree against the naive oracle across sizes, deep forks, non-inclusion, and empty trees