### PR TITLE
harden the api facade: deactivated-update guard, cas caps and integrity

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -262,6 +262,16 @@ export class DidBtcr2Api {
       }
     }
 
+    // A deactivated DID accepts no further updates: resolvers reject them, so
+    // signing and broadcasting one only burns the beacon UTXO and fees
+    // (audit N3). The marker is the `deactivated` property on the document,
+    // which resolution also surfaces as didDocumentMetadata.deactivated.
+    if (doc?.deactivated === true) {
+      throw new Error(
+        `DID ${did} is deactivated and cannot be updated. Deactivation is permanent.`
+      );
+    }
+
     return await this.btcr2.update({
       sourceDocument    : doc,
       patches,

--- a/packages/api/src/cas.ts
+++ b/packages/api/src/cas.ts
@@ -1,5 +1,5 @@
 import type { HashBytes } from '@did-btcr2/common';
-import { canonicalize, decode as decodeHash, encode as encodeHash } from '@did-btcr2/common';
+import { canonicalize, decode as decodeHash, encode as encodeHash, MethodError } from '@did-btcr2/common';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
 import { create as createDigest } from 'multiformats/hashes/digest';
@@ -7,6 +7,65 @@ import { sha256 } from 'multiformats/hashes/sha2';
 
 /** Default IPFS HTTP gateway used for CAS reads when no CAS config is provided. */
 export const DEFAULT_CAS_GATEWAY = 'https://ipfs.io';
+
+/**
+ * Default maximum accepted CAS response body size (1 MiB). Unbounded
+ * `res.arrayBuffer()` on a hostile gateway is a memory-DoS (audit N4); btcr2
+ * CAS artifacts (updates, announcements, genesis documents) are far below
+ * this bound. Configurable via {@link CasConfig.maxResponseBytes}.
+ */
+export const DEFAULT_MAX_CAS_RESPONSE_BYTES = 1024 * 1024;
+
+/**
+ * Read a fetch response body as bytes, rejecting bodies larger than
+ * `maxBytes` (audit N4). Streams when possible so an over-limit body is cut
+ * off before it is fully buffered.
+ *
+ * @throws {Error} If the body exceeds `maxBytes`.
+ */
+async function readBytesWithLimit(res: Response, maxBytes: number): Promise<Uint8Array> {
+  const contentLength = res.headers.get('Content-Length');
+  if (contentLength !== null) {
+    const declared = Number(contentLength);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error(`CAS response exceeds ${maxBytes}-byte limit (declared Content-Length: ${declared})`);
+    }
+  }
+
+  const body = res.body;
+  if (body && typeof body.getReader === 'function') {
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value?.byteLength ?? 0;
+        if (total > maxBytes) {
+          try { await reader.cancel(); } catch { /* best effort */ }
+          throw new Error(`CAS response exceeds ${maxBytes}-byte limit`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (bytes.byteLength > maxBytes) {
+    throw new Error(`CAS response exceeds ${maxBytes}-byte limit`);
+  }
+  return bytes;
+}
 
 /**
  * Executor interface for content-addressed storage.
@@ -109,9 +168,11 @@ export class BlockstoreCasExecutor implements CasExecutor {
  */
 export class IpfsRpcCasExecutor implements CasExecutor {
   readonly #rpcUrl: string;
+  readonly #maxResponseBytes: number;
 
-  constructor(rpcUrl: string) {
+  constructor(rpcUrl: string, maxResponseBytes: number = DEFAULT_MAX_CAS_RESPONSE_BYTES) {
     this.#rpcUrl = rpcUrl.replace(/\/+$/, '');
+    this.#maxResponseBytes = maxResponseBytes;
   }
 
   async retrieve(hash: string): Promise<Uint8Array | null> {
@@ -122,7 +183,9 @@ export class IpfsRpcCasExecutor implements CasExecutor {
         method : 'POST',
       });
       if (!res.ok) return null;
-      return new Uint8Array(await res.arrayBuffer());
+      // Size-capped read: an unbounded buffer on a hostile node is a
+      // memory-DoS; an over-limit block is treated as unusable (audit N4).
+      return await readBytesWithLimit(res, this.#maxResponseBytes);
     } catch {
       return null;
     }
@@ -166,9 +229,11 @@ export class IpfsRpcCasExecutor implements CasExecutor {
 export class HttpGatewayCasExecutor implements CasExecutor {
   readonly canPublish = false;
   readonly #gatewayUrl: string;
+  readonly #maxResponseBytes: number;
 
-  constructor(gatewayUrl: string) {
+  constructor(gatewayUrl: string, maxResponseBytes: number = DEFAULT_MAX_CAS_RESPONSE_BYTES) {
     this.#gatewayUrl = gatewayUrl.replace(/\/+$/, '');
+    this.#maxResponseBytes = maxResponseBytes;
   }
 
   async retrieve(hash: string): Promise<Uint8Array | null> {
@@ -178,7 +243,9 @@ export class HttpGatewayCasExecutor implements CasExecutor {
         headers : { Accept: 'application/vnd.ipld.raw' },
       });
       if (!res.ok) return null;
-      return new Uint8Array(await res.arrayBuffer());
+      // Size-capped read: an unbounded buffer on a hostile gateway is a
+      // memory-DoS; an over-limit block is treated as unusable (audit N4).
+      return await readBytesWithLimit(res, this.#maxResponseBytes);
     } catch {
       return null;
     }
@@ -212,6 +279,11 @@ export type CasConfig = {
   /** IPFS HTTP gateway URL for read-only CAS access (e.g. `'https://ipfs.io'`). */
   gateway?: string;
   /**
+   * Maximum accepted CAS response body size in bytes (audit N4). Applies to
+   * the HTTP-backed executors (`rpcUrl`, `gateway`). Default: 1 MiB.
+   */
+  maxResponseBytes?: number;
+  /**
    * Timeout in milliseconds for CAS operations. Prevents indefinite hangs
    * when a blockstore lookup, RPC call, or gateway request stalls.
    * Default: 30 000 ms. Set to `0` to disable.
@@ -242,9 +314,9 @@ export class CasApi {
     } else if (config.blockstore) {
       this.#executor = new BlockstoreCasExecutor(config.blockstore);
     } else if (config.rpcUrl) {
-      this.#executor = new IpfsRpcCasExecutor(config.rpcUrl);
+      this.#executor = new IpfsRpcCasExecutor(config.rpcUrl, config.maxResponseBytes);
     } else if (config.gateway) {
-      this.#executor = new HttpGatewayCasExecutor(config.gateway);
+      this.#executor = new HttpGatewayCasExecutor(config.gateway, config.maxResponseBytes);
     } else {
       throw new Error(
         'CAS configuration requires an executor, blockstore, RPC URL, or gateway URL. '
@@ -265,13 +337,27 @@ export class CasApi {
 
   /**
    * Retrieve a JSON object from the CAS by its SHA-256 hash bytes.
+   *
+   * The retrieved bytes are verified against the requested hash before
+   * parsing (audit N5): content-addressed storage must return the content
+   * that hashes to the address, and anything else is an integrity failure.
    * @param hashBytes Raw SHA-256 hash bytes of the JCS-canonicalized object.
    * @returns The parsed JSON object, or `null` if not found.
+   * @throws {MethodError} `CAS_INTEGRITY_ERROR` if the retrieved bytes do not
+   *   hash to the requested address.
    */
   async retrieve(hashBytes: HashBytes): Promise<object | null> {
     const hash = encodeHash(hashBytes, 'base64urlnopad');
     const bytes = await this.#withTimeout(this.#executor.retrieve(hash));
     if (!bytes) return null;
+    const actual = await sha256.digest(bytes);
+    if (actual.digest.length !== hashBytes.length || !actual.digest.every((b, i) => b === hashBytes[i])) {
+      throw new MethodError(
+        'CAS integrity check failed: retrieved bytes do not hash to the requested address',
+        'CAS_INTEGRITY_ERROR',
+        { hash }
+      );
+    }
     return JSON.parse(new TextDecoder().decode(bytes)) as object;
   }
 

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -280,6 +280,16 @@ export class DidMethodApi {
       );
     }
 
+    // A deactivated DID accepts no further updates: resolvers reject them, so
+    // signing and broadcasting one only burns the beacon UTXO and fees
+    // (audit N3).
+    if(sourceDocument.deactivated === true) {
+      throw new UpdateError(
+        `DID ${sourceDocument.id} is deactivated and cannot be updated. Deactivation is permanent.`,
+        INVALID_DID_UPDATE, { beaconId }
+      );
+    }
+
     this.#log.debug('Updating DID', sourceDocument.id, { beaconId, verificationMethodId });
 
     // Factory validates and returns a sans-I/O state machine

--- a/packages/api/tests/api-hardening.spec.ts
+++ b/packages/api/tests/api-hardening.spec.ts
@@ -1,0 +1,172 @@
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { canonicalHashBytes } from '@did-btcr2/common';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { createApi, type DidBtcr2Api } from '../src/index.js';
+import { CasApi, HttpGatewayCasExecutor, IpfsRpcCasExecutor, DEFAULT_MAX_CAS_RESPONSE_BYTES } from '../src/cas.js';
+import type { CasExecutor } from '../src/cas.js';
+
+use(chaiAsPromised);
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+/** Shadow the prototype's lazy btcr2 getter with a capturing stub. */
+function stubBtcr2Update(api: DidBtcr2Api): { called: boolean } {
+  const state = { called: false };
+  Object.defineProperty(api, 'btcr2', {
+    configurable : true,
+    value        : { update: async () => { state.called = true; } },
+  });
+  return state;
+}
+
+describe('api hardening (audit N3, N4, N5)', () => {
+  describe('updateDid rejects deactivated DIDs (N3)', () => {
+    const did = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+
+    it('throws when the caller-supplied source document is deactivated', async () => {
+      const api = createApi();
+      const btcr2 = stubBtcr2Update(api);
+      await expect(
+        api.updateDid({
+          did,
+          patches              : [],
+          verificationMethodId : `${did}#initialKey`,
+          beaconId             : `${did}#beacon-0`,
+          signer               : {} as never,
+          sourceDocument       : { id: did, deactivated: true } as never,
+          sourceVersionId      : 1,
+        })
+      ).to.be.rejectedWith(/deactivated/);
+      expect(btcr2.called).to.equal(false);
+    });
+
+    it('throws when resolution surfaces a deactivated document', async () => {
+      const api = createApi();
+      const btcr2 = stubBtcr2Update(api);
+      (api as any).resolveDid = async () => ({
+        didDocument           : { id: did, deactivated: true },
+        didDocumentMetadata   : { deactivated: true, versionId: '3' },
+        didResolutionMetadata : {},
+      });
+      await expect(
+        api.updateDid({
+          did,
+          patches              : [],
+          verificationMethodId : `${did}#initialKey`,
+          beaconId             : `${did}#beacon-0`,
+          signer               : {} as never,
+        })
+      ).to.be.rejectedWith(/deactivated/);
+      expect(btcr2.called).to.equal(false);
+    });
+
+    it('DidMethodApi.update rejects a deactivated source document before touching bitcoin', async () => {
+      const api: DidBtcr2Api = createApi();
+      await expect(
+        api.btcr2.update({
+          sourceDocument       : { id: did, deactivated: true } as never,
+          patches              : [],
+          sourceVersionId      : 1,
+          verificationMethodId : `${did}#initialKey`,
+          beaconId             : `${did}#beacon-0`,
+          signer               : {} as never,
+          bitcoin              : { rest: {} } as never,
+        })
+      ).to.be.rejectedWith(/deactivated/);
+    });
+  });
+
+  describe('CAS response size cap (N4)', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    const stubFetch = (handler: (url: string) => Response | Promise<Response>) => {
+      globalThis.fetch = (async (input: FetchInput) => handler(
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      )) as typeof fetch;
+    };
+
+    it('gateway retrieve returns null when declared Content-Length exceeds the cap', async () => {
+      stubFetch(() => new Response('x', {
+        status  : 200,
+        headers : { 'Content-Length': String(DEFAULT_MAX_CAS_RESPONSE_BYTES + 1) },
+      }));
+      const executor = new HttpGatewayCasExecutor('https://gateway.example');
+      expect(await executor.retrieve('whatever')).to.be.null;
+    });
+
+    it('gateway retrieve returns null when a streamed body grows past a custom cap', async () => {
+      const chunk = new Uint8Array(256);
+      stubFetch(() => new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < 10; i++) controller.enqueue(chunk);
+          controller.close();
+        },
+      })));
+      const executor = new HttpGatewayCasExecutor('https://gateway.example', 1024);
+      expect(await executor.retrieve('whatever')).to.be.null;
+    });
+
+    it('rpc retrieve returns null when the body exceeds the cap', async () => {
+      stubFetch(() => new Response('x', {
+        status  : 200,
+        headers : { 'Content-Length': String(DEFAULT_MAX_CAS_RESPONSE_BYTES + 1) },
+      }));
+      const executor = new IpfsRpcCasExecutor('http://node:5001');
+      expect(await executor.retrieve('whatever')).to.be.null;
+    });
+
+    it('the cap is configurable through CasConfig.maxResponseBytes', async () => {
+      const bytes = new TextEncoder().encode('{"ok":true}');
+      stubFetch(() => new Response(Uint8Array.from(bytes)));
+      const cas = new CasApi({ gateway: 'https://gateway.example', maxResponseBytes: 4 });
+      const digest = await sha256.digest(bytes);
+      expect(await cas.retrieve(digest.digest)).to.be.null;
+    });
+  });
+
+  describe('CAS retrieval integrity verification (N5)', () => {
+    const object = { hello: 'world' };
+    const hashBytes = canonicalHashBytes(object);
+
+    it('throws CAS_INTEGRITY_ERROR when the executor returns bytes that do not hash to the address', async () => {
+      const hostile: CasExecutor = {
+        retrieve : async () => new TextEncoder().encode('{"hello":"evil"}'),
+        publish  : async () => 'unused',
+      };
+      const cas = new CasApi({ executor: hostile });
+      let error: any;
+      try {
+        await cas.retrieve(hashBytes);
+      } catch (e: any) {
+        error = e;
+      }
+      expect(error).to.not.equal(undefined);
+      expect(error.type).to.equal('CAS_INTEGRITY_ERROR');
+      expect(error.message).to.match(/integrity/);
+    });
+
+    it('returns the parsed object when the bytes hash to the address', async () => {
+      const honest: CasExecutor = {
+        retrieve : async () => new TextEncoder().encode(JSON.stringify(object)),
+        publish  : async () => 'unused',
+      };
+      // JSON.stringify({hello:'world'}) is already JCS-canonical for this object.
+      const cas = new CasApi({ executor: honest });
+      expect(await cas.retrieve(canonicalHashBytes(object))).to.deep.equal(object);
+    });
+
+    it('still returns null when the content is simply absent', async () => {
+      const missing: CasExecutor = {
+        retrieve : async () => null,
+        publish  : async () => 'unused',
+      };
+      const cas = new CasApi({ executor: missing });
+      expect(await cas.retrieve(hashBytes)).to.be.null;
+    });
+  });
+});

--- a/packages/method/src/core/beacon/utils.ts
+++ b/packages/method/src/core/beacon/utils.ts
@@ -4,7 +4,7 @@ import type { KeyBytes, Maybe} from '@did-btcr2/common';
 import { DidMethodError, MethodError } from '@did-btcr2/common';
 import { p2pkh, p2tr, p2wpkh } from '@scure/btc-signer';
 import { Appendix } from '../../utils/appendix.js';
-import type { DidDocument } from '../../utils/did-document.js';
+import type { Btcr2DidDocument } from '../../utils/did-document.js';
 import { Identifier } from '../identifier.js';
 import type { BeaconService } from './interfaces.js';
 import { BeaconError } from './error.js';
@@ -53,7 +53,7 @@ export class BeaconUtils {
    * @returns {DidService[]} An array of DidService objects
    * @throws {TypeError} if the didDocument is not provided
    */
-  static getBeaconServices(didDocument: DidDocument): BeaconService[] {
+  static getBeaconServices(didDocument: Btcr2DidDocument): BeaconService[] {
     // Filter for valid beacon service objects.
     return (didDocument.service.filter(this.isBeaconService) ?? []) as BeaconService[];
   }
@@ -196,7 +196,7 @@ export class BeaconUtils {
    * @param {DidDocument} didDocument The DID Document to extract the services from.
    * @returns {string[]} An array of beacon service ids.
    */
-  static getBeaconServiceIds(didDocument: DidDocument): string[] {
+  static getBeaconServiceIds(didDocument: Btcr2DidDocument): string[] {
     return this.getBeaconServices(didDocument).map((beacon) => beacon.id);
   }
 }

--- a/packages/method/src/core/did-sender-resolver.ts
+++ b/packages/method/src/core/did-sender-resolver.ts
@@ -1,7 +1,7 @@
 import { DidDocumentError, INVALID_DID_DOCUMENT } from '@did-btcr2/common';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
-import type { DidDocument, DidVerificationMethod } from '../utils/did-document.js';
+import type { Btcr2DidDocument, DidVerificationMethod } from '../utils/did-document.js';
 import { Identifier } from './identifier.js';
 import { Resolver } from './resolver.js';
 
@@ -27,7 +27,7 @@ import { Resolver } from './resolver.js';
  *   resolve to a verification method in the document.
  */
 export function getAggregationCommunicationKey(
-  document: DidDocument,
+  document: Btcr2DidDocument,
 ): CompressedSecp256k1PublicKey {
   const invocation = document.capabilityInvocation?.[0];
   if(invocation === undefined) {

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -28,6 +28,7 @@ import {
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { DidBtcr2 } from '../did-btcr2.js';
 import { Appendix } from '../utils/appendix.js';
+import type { Btcr2DidDocument } from '../utils/did-document.js';
 import { DidDocument, ID_PLACEHOLDER_VALUE } from '../utils/did-document.js';
 import { BeaconFactory } from './beacon/factory.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from './beacon/interfaces.js';
@@ -42,7 +43,7 @@ import { equalBytes } from '@noble/curves/utils.js';
  * The response object for DID Resolution.
  */
 export interface DidResolutionResponse {
-  didDocument: DidDocument;
+  didDocument: Btcr2DidDocument;
   metadata: {
     confirmations?: number;
     versionId: string;
@@ -201,7 +202,7 @@ export class Resolver {
    */
   #phase: ResolverPhase;
   #sidecarData: SidecarData;
-  #currentDocument: DidDocument | null;
+  #currentDocument: Btcr2DidDocument | null;
   #providedGenesisDocument: object | null = null;
   #beaconServicesSignals: Map<BeaconService, Array<BeaconSignal>> = new Map();
   #processedServices: Set<string> = new Set();
@@ -246,7 +247,7 @@ export class Resolver {
   constructor(
     didComponents: DidComponents,
     sidecarData: SidecarData,
-    currentDocument: DidDocument | null,
+    currentDocument: Btcr2DidDocument | null,
     options?: { versionId?: string; versionTime?: string; genesisDocument?: object; maxDiscoveryRounds?: number; minConf?: number }
   ) {
     this.#didComponents = didComponents;
@@ -274,10 +275,14 @@ export class Resolver {
 
   /**
    * Implements subsection {@link https://dcdpr.github.io/did-btcr2/operations/resolve.html#if-genesis_bytes-is-a-secp256k1-public-key | 7.2.d.1 if genesis bytes is a secp256k1 Public Key}.
+   *
+   * Returns a plain JSON object (class prototypes stripped) so every
+   * subsequent patch and hash operates on the full JSON content, identically
+   * to any plain-JSON resolver implementation (audit I7).
    * @param {DidComponents} didComponents The decoded components of the did.
-   * @returns {DidDocument} The resolved DID Document object.
+   * @returns {Btcr2DidDocument} The resolved DID Document object.
    */
-  static deterministic(didComponents: DidComponents): DidDocument {
+  static deterministic(didComponents: DidComponents): Btcr2DidDocument {
     // Deconstruct the bytes from the given components
     const genesisBytes = didComponents.genesisBytes;
 
@@ -295,7 +300,7 @@ export class Resolver {
       beaconType : 'SingletonBeacon'
     });
 
-    return new DidDocument({
+    return JSON.parse(JSON.stringify(new DidDocument({
       id                 : did,
       verificationMethod : [{
         id                 : `${did}#initialKey`,
@@ -304,20 +309,25 @@ export class Resolver {
         publicKeyMultibase : multibase.encoded
       }],
       service
-    });
+    }))) as Btcr2DidDocument;
   }
 
   /**
    * Implements subsection {@link https://dcdpr.github.io/did-btcr2/operations/resolve.html#if-genesis_bytes-is-a-sha-256-hash | 7.2.d.2 if genesis_bytes is a SHA-256 Hash}.
+   *
+   * Returns the full plain JSON document (not a class instance): a class
+   * wrapper would silently drop any fields outside its known property set,
+   * diverging both the resolved document and every subsequent patch/hash
+   * from a plain-JSON resolver implementation (audit I7).
    * @param {DidComponents} didComponents BTCR2 DID components used to resolve the DID Document
    * @param {object} genesisDocument The genesis document for resolving the DID Document.
-   * @returns {DidDocument} The resolved DID Document object
+   * @returns {Btcr2DidDocument} The resolved DID Document object
    * @throws {ResolveError} InvalidDidDocument if not conformant to DID Core v1.1
    */
   static external(
     didComponents: DidComponents,
     genesisDocument: object,
-  ): DidDocument {
+  ): Btcr2DidDocument {
     // Canonicalize and sha256 hash the genesis document
     const genesisDocumentHash = canonicalHashBytes(genesisDocument);
 
@@ -340,8 +350,10 @@ export class Resolver {
       JSON.stringify(genesisDocument).replaceAll(ID_PLACEHOLDER_VALUE, did)
     );
 
-    // Return a W3C conformant DID Document
-    return new DidDocument(currentDocument);
+    // Validate as a W3C-conformant DID Document (constructor performs the
+    // checks); the returned value stays the full plain JSON object.
+    new DidDocument(currentDocument);
+    return currentDocument as Btcr2DidDocument;
   }
 
   /**
@@ -388,7 +400,7 @@ export class Resolver {
 
   /**
    * Implements subsection {@link https://dcdpr.github.io/did-btcr2/operations/resolve.html#process-updates | 7.2.f Process updates Array}.
-   * @param {DidDocument} currentDocument The current DID Document to apply the updates to.
+   * @param {Btcr2DidDocument} currentDocument The current DID Document to apply the updates to.
    * @param {Array<[SignedBTCR2Update, BlockMetadata]>} unsortedUpdates The unsorted array of BTCR2 Signed Updates and their associated Block Metadata.
    * @param {string} [versionTime] The optional version time to limit updates to.
    * @param {string} [versionId] The optional version id to limit updates to.
@@ -400,7 +412,7 @@ export class Resolver {
    * @returns {DidResolutionResponse} The updated DID Document, number of confirmations, and version id.
    */
   static updates(
-    currentDocument: DidDocument,
+    currentDocument: Btcr2DidDocument,
     unsortedUpdates: Array<[SignedBTCR2Update, BlockMetadata]>,
     versionTime?: string,
     versionId?: string,
@@ -620,9 +632,9 @@ export class Resolver {
    * @throws {ResolveError} If the update is invalid or cannot be applied.
    */
   private static applyUpdate(
-    currentDocument: DidDocument,
+    currentDocument: Btcr2DidDocument,
     update: SignedBTCR2Update
-  ): DidDocument {
+  ): Btcr2DidDocument {
     // Get the capability id from the to update proof.
     const capabilityId = update.proof?.capability;
     // Since this field is optional, check that it exists
@@ -705,7 +717,7 @@ export class Resolver {
     }
 
     // Apply the update.patch to the currentDocument to get the updatedDocument.
-    const updatedDocument = JSONPatch.apply(currentDocument, update.patch) as DidDocument;
+    const updatedDocument = JSONPatch.apply(currentDocument, update.patch) as Btcr2DidDocument;
 
     // Verify that updatedDocument is conformant to DID Core v1.1.
     DidDocument.validate(updatedDocument);

--- a/packages/method/tests/resolver-plain-documents.spec.ts
+++ b/packages/method/tests/resolver-plain-documents.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import { canonicalHashBytes, IdentifierTypes, JSONPatch } from '@did-btcr2/common';
+import { DidBtcr2 } from '../src/did-btcr2.js';
+import { Identifier } from '../src/core/identifier.js';
+import { Resolver } from '../src/core/resolver.js';
+import { DidDocument } from '../src/utils/did-document.js';
+import deterministicData from './data/deterministic-data.js';
+import externalData from './data/external-data.js';
+
+/**
+ * Regression tests for audit I7: the resolver must operate on full plain-JSON
+ * documents. A class wrapper drops any field outside its known property set
+ * (both at construction and via its toJSON subset used by the patch deep-clone),
+ * which diverged the patched-document hashes from any plain-JSON implementation.
+ */
+describe('resolver plain-document handling (audit I7)', () => {
+  const fixture = externalData[0]!;
+
+  /** A valid EXTERNAL genesis document carrying a field outside the class's known set. */
+  function genesisWithExtraField(): Record<string, unknown> {
+    return {
+      ...JSON.parse(JSON.stringify(fixture.genesisDocument)),
+      alsoKnownAs : ['did:web:example.com'],
+    };
+  }
+
+  function didFor(genesis: Record<string, unknown>): string {
+    return DidBtcr2.create(canonicalHashBytes(genesis), { idType: IdentifierTypes.EXTERNAL, network: 'bitcoin' });
+  }
+
+  it('external() returns a plain object preserving fields outside the class property set', () => {
+    const genesis = genesisWithExtraField();
+    const doc = Resolver.external(Identifier.decode(didFor(genesis)), genesis);
+
+    expect(doc).to.not.be.instanceOf(DidDocument);
+    expect(doc.id).to.not.include('did:btcr2:_');
+    expect((doc as unknown as Record<string, unknown>).alsoKnownAs).to.deep.equal(['did:web:example.com']);
+    // Nested placeholders are replaced throughout, not just at the top level.
+    expect(doc.verificationMethod[0]!.id).to.match(/^did:btcr2:x1.*#key-0$/);
+  });
+
+  it('patching the external() output is hash-symmetric with a plain-JSON implementation', () => {
+    const genesis = genesisWithExtraField();
+    const doc = Resolver.external(Identifier.decode(didFor(genesis)), genesis);
+
+    // Independent plain-JSON baseline: replace placeholders, then patch.
+    const baselineDoc = JSON.parse(JSON.stringify(genesis).replaceAll('did:btcr2:_', doc.id));
+    const patch = [{ op: 'add' as const, path: '/alsoKnownAs/1', value: 'did:web:two.example' }];
+
+    const patched = JSONPatch.apply(doc, patch);
+    const baselinePatched = JSONPatch.apply(baselineDoc, patch);
+
+    expect(patched).to.deep.equal(baselinePatched);
+    expect(canonicalHashBytes(patched)).to.deep.equal(canonicalHashBytes(baselinePatched));
+    // The extra field survived patching (the class-subset path would have dropped it).
+    expect((patched as unknown as Record<string, unknown>).alsoKnownAs).to.have.length(2);
+  });
+
+  it('deterministic() returns a plain object with the defaulted relationship arrays', () => {
+    const doc = Resolver.deterministic(Identifier.decode(deterministicData[0]!.did));
+
+    expect(doc).to.not.be.instanceOf(DidDocument);
+    const keyRef = `${doc.id}#initialKey`;
+    for (const rel of ['authentication', 'assertionMethod', 'capabilityInvocation', 'capabilityDelegation'] as const) {
+      expect(doc[rel], rel).to.deep.equal([keyRef]);
+    }
+  });
+
+  it('patching the deterministic() output keeps every field (no toJSON-subset drop)', () => {
+    const doc = Resolver.deterministic(Identifier.decode(deterministicData[0]!.did));
+    const baselineDoc = JSON.parse(JSON.stringify(doc));
+    const patch = [{ op: 'add' as const, path: '/alsoKnownAs', value: ['did:web:example.com'] }];
+
+    const patched = JSONPatch.apply(doc, patch);
+    const baselinePatched = JSONPatch.apply(baselineDoc, patch);
+
+    expect(patched).to.deep.equal(baselinePatched);
+    expect(canonicalHashBytes(patched)).to.deep.equal(canonicalHashBytes(baselinePatched));
+  });
+});

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -11,7 +11,7 @@ import { p2wpkh } from '@scure/btc-signer';
 import { DidBtcr2 } from '../src/did-btcr2.js';
 import { BeaconUtils } from '../src/core/beacon/utils.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
-import type { DidDocument } from '../src/utils/did-document.js';
+import type { Btcr2DidDocument as DidDocument } from '../src/utils/did-document.js';
 import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import { Resolver } from '../src/core/resolver.js';
 import type { DidResolutionResponse, NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';


### PR DESCRIPTION
* fix(api): guard deactivated updates; cap and verify cas responses (audit N3, N4, N5)
* fix(method): resolve to plain-json documents so patch/hash stays symmetric with plain-json implementations (audit I7)
* test(api): cover deactivated guards, cas size caps, and integrity failures
* test(method): cover plain-document resolution and patch/hash symmetry