### PR TITLE
pin ci actions to shas and scope the write token to the badge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,35 @@
 name: CI
 
 on:
-  push
+  # Vets external pull requests too (audit N2): pull_request runs with a
+  # read-only token on forked repos, and same-repo PRs simply get both a push
+  # and a pull_request run.
+  - push
+  - pull_request
+
+# No token permissions by default; jobs opt in to exactly what they need
+# (audit N2).
+permissions: {}
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
-    # contents: write is needed by the badge-publish step to force-push the
-    # ci-badges branch (ADR 084); everything else only reads.
+    # The test job executes dependency code (install scripts, build, tests),
+    # so it must not hold a write token (audit N2). All actions are pinned to
+    # full commit SHAs, not mutable major tags (audit N1).
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js with pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
 
@@ -45,6 +54,40 @@ jobs:
       - name: Coverage report
         run: pnpm coverage:report
         continue-on-error: true
+
+      # Hand the badge artifacts to the write-scoped badge job; on push runs
+      # only a few kilobytes are kept, for one day.
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report
+          path: |
+            .github/badges/coverage.svg
+            COVERAGE.md
+          if-no-files-found: ignore
+          retention-days: 1
+
+  badge:
+    needs: ci
+    # Publishes only from pushes to this repository, never from pull requests
+    # (a fork PR must not reach a write token).
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    # contents: write is needed to force-push the ci-badges branch (ADR 084);
+    # it is scoped to this job only, which runs no dependency code (audit N2).
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage-report
+          path: .
 
       # Publish the regenerated badge + report to the dedicated ci-badges
       # branch (single orphan commit, force-pushed) so the README badge tracks


### PR DESCRIPTION
* ci(workflows): pin actions to commit shas, split the write token out of the test job, and add pull_request vetting (audit N1, N2)