### PR TITLE
harden agg transports against malformed events and unauth sends

### DIFF
--- a/packages/aggregation/lib/operations/aggregation/aggregation-participant.ts
+++ b/packages/aggregation/lib/operations/aggregation/aggregation-participant.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * Aggregation Participant - Standalone Process (Runner API)
  *
@@ -36,7 +36,9 @@ if(!SECRET_KEY) {
 const myKeys = SchnorrKeyPair.fromSecret(SECRET_KEY);
 const myDid = DidBtcr2.create(myKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
-const transport = new NostrTransport({ relays: [RELAY] });
+// resolveSenderPk authenticates the service's first advert from its DID, so
+// discovery bootstraps without pre-registered peer keys.
+const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 transport.registerActor(myDid, myKeys);
 transport.start();
 

--- a/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
+++ b/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2 } from '@did-btcr2/method';
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * Aggregation Service - Standalone Process (Runner API)
  *
@@ -29,7 +29,9 @@ const MIN_PARTICIPANTS = Number(process.env.MIN_PARTICIPANTS ?? '2');
 const serviceKeys = SchnorrKeyPair.fromSecret('cbd42da155c70d5a8806a1f68bfb802097e152f28230990d8e3c979e78e52d1d');
 const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
-const transport = new NostrTransport({ relays: [RELAY] });
+// resolveSenderPk authenticates opt-in senders from their DIDs, so participants
+// need no out-of-band key registration for discovery to bootstrap.
+const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 transport.registerActor(serviceDid, serviceKeys);
 transport.start();
 

--- a/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * E2E Demo: Per-Actor Nostr Transports (Runner API)
  *
@@ -58,9 +58,12 @@ const bobGenesis: Record<string, unknown> = {
 };
 const bobDid = DidBtcr2.create(GenesisDocument.toGenesisBytes(bobGenesis), { idType: 'EXTERNAL', network: 'mutinynet' });
 
-const serviceTransport = new NostrTransport({ relays: [RELAY] });
-const aliceTransport = new NostrTransport({ relays: [RELAY] });
-const bobTransport = new NostrTransport({ relays: [RELAY] });
+// resolveSenderPk lets each transport authenticate senders from their DIDs, so
+// no out-of-band key registration is needed for discovery to bootstrap (the
+// registerPeer calls below still seed the encrypted directed path).
+const serviceTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
+const aliceTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
+const bobTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 
 serviceTransport.registerActor(serviceDid, serviceKeys);
 aliceTransport.registerActor(aliceDid, aliceKeys);

--- a/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * E2E Check: End-to-end MuSig2 signing over a real Nostr relay, with
  * cryptographic verification of the aggregated signature against the
@@ -50,9 +50,11 @@ const bobKeys = SchnorrKeyPair.generate();
 const bobDid = DidBtcr2.create(bobKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
 // ── Transports (one per actor, same relay) ──
-const serviceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
-const aliceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
-const bobTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
+// resolveSenderPk lets each transport authenticate senders from their DIDs, so
+// discovery bootstraps without pre-registered peer keys.
+const serviceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
+const aliceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
+const bobTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
 
 serviceTransport.registerActor(serviceDid, serviceKeys);
 aliceTransport.registerActor(aliceDid, aliceKeys);

--- a/packages/aggregation/src/core/transport/envelope-auth.ts
+++ b/packages/aggregation/src/core/transport/envelope-auth.ts
@@ -68,7 +68,15 @@ export function authenticateEnvelopeContent(
     return undefined;
   }
 
-  const flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+  let flat: Record<string, unknown>;
+  try {
+    flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+  } catch(err) {
+    // Malformed wire content (e.g. a bad __bytes sentinel) must never escape:
+    // callers invoke this before verification and cannot trust any of it.
+    logger.debug('Message revival failed:', err);
+    return undefined;
+  }
   const genesisDocument = isRecord(flat.genesisDocument) ? flat.genesisDocument : undefined;
   const senderPk = options.resolveSenderPk(envelope.from, genesisDocument ? { genesisDocument } : undefined);
   if(!senderPk) {

--- a/packages/aggregation/src/core/transport/http/envelope.ts
+++ b/packages/aggregation/src/core/transport/http/envelope.ts
@@ -185,13 +185,25 @@ export function normalizeForWire(value: unknown): unknown {
  * Recursively convert `{ __bytes: hex }` sentinels back into `Uint8Array`
  * values. Call on `envelope.message` *after* successful verification and
  * before handing the payload to a runner's handler.
+ *
+ * Malformed sentinels (non-hex or odd-length strings) throw a typed
+ * {@link HttpTransportError} rather than the raw `hexToBytes` failure, so
+ * callers can catch and drop the offending payload. A `__bytes` key holding a
+ * non-string value is left untouched (it is not a sentinel).
  */
 export function reviveFromWire(value: unknown): unknown {
   if(value && typeof value === 'object' && !Array.isArray(value)) {
     const rec = value as Record<string, unknown>;
     const keys = Object.keys(rec);
     if(keys.length === 1 && keys[0] === '__bytes' && typeof rec.__bytes === 'string') {
-      return hexToBytes(rec.__bytes);
+      const hex = rec.__bytes;
+      if(hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) {
+        throw new HttpTransportError(
+          'Malformed __bytes wire sentinel: expected an even-length lowercase hex string',
+          'WIRE_SENTINEL_INVALID',
+        );
+      }
+      return hexToBytes(hex);
     }
     const out: Record<string, unknown> = {};
     for(const [k, v] of Object.entries(rec)) out[k] = reviveFromWire(v);

--- a/packages/aggregation/src/core/transport/nostr.ts
+++ b/packages/aggregation/src/core/transport/nostr.ts
@@ -63,13 +63,22 @@ export interface NostrTransportConfig {
    * replay a directed subscription's full event history on reconnect, and the
    * timestamp check rejects ancient replays before they reach the state
    * machines. Defaults to {@link DEFAULT_CLOCK_SKEW_SEC} (60s); raise it if
-   * slow relays deliver legitimately delayed traffic.
+   * slow relays deliver legitimately delayed traffic. Values above
+   * {@link MAX_CLOCK_SKEW_SEC} are clamped; non-positive or non-finite values
+   * are rejected.
+   *
+   * Crash-recovery limitation: directed one-shot messages older than this
+   * window are dropped, so a peer that stays offline longer than the window
+   * can miss directed messages published while it was down.
    */
   clockSkewSec?: number;
 }
 
 /** Default `since` lookback for broadcast (COHORT_ADVERT) subscriptions: 5 minutes. */
 export const DEFAULT_BROADCAST_LOOKBACK_MS = 5 * 60 * 1000;
+
+/** Upper bound for the envelope timestamp tolerance: 5 minutes. */
+export const MAX_CLOCK_SKEW_SEC = 300;
 
 /** Internal registration for a single actor sharing this transport. */
 interface ActorEntry {
@@ -121,7 +130,23 @@ export class NostrTransport implements Transport {
     this.#logger = config?.logger ?? CONSOLE_LOGGER;
     this.#broadcastLookbackMs = config?.broadcastLookbackMs ?? DEFAULT_BROADCAST_LOOKBACK_MS;
     this.#resolveSenderPkFn = config?.resolveSenderPk;
-    this.#clockSkewSec = config?.clockSkewSec ?? DEFAULT_CLOCK_SKEW_SEC;
+    this.#clockSkewSec = NostrTransport.#clampClockSkewSec(config?.clockSkewSec, this.#logger);
+  }
+
+  /** Validate the configured skew: reject non-positive/non-finite, clamp to {@link MAX_CLOCK_SKEW_SEC}. */
+  static #clampClockSkewSec(value: number | undefined, logger: Logger): number {
+    if(value === undefined) return DEFAULT_CLOCK_SKEW_SEC;
+    if(!Number.isFinite(value) || value <= 0) {
+      throw new TransportAdapterError(
+        `Invalid clockSkewSec: ${value} (expected a positive number of seconds)`,
+        'INVALID_CLOCK_SKEW', { adapter: 'nostr', clockSkewSec: value }
+      );
+    }
+    if(value > MAX_CLOCK_SKEW_SEC) {
+      logger.warn(`clockSkewSec ${value}s exceeds the ${MAX_CLOCK_SKEW_SEC}s maximum; clamping`);
+      return MAX_CLOCK_SKEW_SEC;
+    }
+    return value;
   }
 
   /**
@@ -454,42 +479,49 @@ export class NostrTransport implements Transport {
    */
   #makeActorEventHandler(actorDid: string): (event: Event) => Promise<void> {
     return async (event: Event) => {
-      const actor = this.#actors.get(actorDid);
-      if(!actor) return;
-
-      // Relay self-echo: sendMessage() adds the sender's own pubkey to the
-      // event's `p` tags (so recipients can reply). The directed subscription
-      // filter `{'#p': [actor_pk]}` therefore matches every event this actor
-      // publishes. Skip - we don't need to process our own outgoing events,
-      // and attempting to NIP-44-decrypt them fails with "invalid MAC" because
-      // the content was encrypted for the recipient, not self.
-      if(event.pubkey === bytesToHex(actor.keys.publicKey.x)) return;
-
-      let content: string;
-
+      // Fail closed: nostr-tools invokes onevent without awaiting it, so any
+      // throw here becomes an unhandled rejection. Every failure mode must
+      // end with the event dropped, never an escape.
       try {
-        if(event.kind === 1) {
-          content = event.content;
-        } else if(event.kind === 1059) {
-          const conversationKey = nip44.v2.utils.getConversationKey(
-            actor.keys.secretKey.bytes,
-            event.pubkey
-          );
-          content = nip44.v2.decrypt(event.content, conversationKey);
-        } else {
+        const actor = this.#actors.get(actorDid);
+        if(!actor) return;
+
+        // Relay self-echo: sendMessage() adds the sender's own pubkey to the
+        // event's `p` tags (so recipients can reply). The directed subscription
+        // filter `{'#p': [actor_pk]}` therefore matches every event this actor
+        // publishes. Skip - we don't need to process our own outgoing events,
+        // and attempting to NIP-44-decrypt them fails with "invalid MAC" because
+        // the content was encrypted for the recipient, not self.
+        if(event.pubkey === bytesToHex(actor.keys.publicKey.x)) return;
+
+        let content: string;
+
+        try {
+          if(event.kind === 1) {
+            content = event.content;
+          } else if(event.kind === 1059) {
+            const conversationKey = nip44.v2.utils.getConversationKey(
+              actor.keys.secretKey.bytes,
+              event.pubkey
+            );
+            content = nip44.v2.decrypt(event.content, conversationKey);
+          } else {
+            return;
+          }
+        } catch(err) {
+          this.#logger.debug(`Failed to parse event ${event.id} for ${actorDid}:`, err);
           return;
         }
+
+        // Authenticate the envelope; directed messages must also be addressed to
+        // this actor. Unverifiable senders are dropped here, never dispatched.
+        const message = this.#authenticateContent(content, { expectedTo: actorDid });
+        if(!message) return;
+
+        this.#dispatchMessage(message, actor);
       } catch(err) {
-        this.#logger.debug(`Failed to parse event ${event.id} for ${actorDid}:`, err);
-        return;
+        this.#logger.debug(`Dropping directed event ${event.id} for ${actorDid}:`, err);
       }
-
-      // Authenticate the envelope; directed messages must also be addressed to
-      // this actor. Unverifiable senders are dropped here, never dispatched.
-      const message = this.#authenticateContent(content, { expectedTo: actorDid });
-      if(!message) return;
-
-      this.#dispatchMessage(message, actor);
     };
   }
 
@@ -504,18 +536,27 @@ export class NostrTransport implements Transport {
    * @returns
    */
   async #handleBroadcastEvent(event: Event): Promise<void> {
-    if(event.kind !== 1) return;
+    // Fail closed: nostr-tools invokes onevent without awaiting it, so any
+    // throw here becomes an unhandled rejection. Every failure mode must end
+    // with the event dropped, never an escape.
+    try {
+      if(event.kind !== 1) return;
 
-    const message = this.#authenticateContent(event.content);
-    if(!message) return;
+      const message = this.#authenticateContent(event.content);
+      if(!message) return;
 
-    const messageType = message.type as string;
-    if(!messageType || !isAggregationMessageType(messageType)) return;
+      const messageType = message.type as string;
+      if(!messageType || !isAggregationMessageType(messageType)) return;
 
-    // Dispatch to ALL actors that have a handler for this message type
-    for(const actor of this.#actors.values()) {
-      const handler = actor.handlers.get(messageType);
-      if(handler) await handler(message);
+      // Dispatch to ALL actors that have a handler for this message type
+      for(const actor of this.#actors.values()) {
+        const handler = actor.handlers.get(messageType);
+        if(!handler) continue;
+        try { await handler(message); }
+        catch(err) { this.#logger.debug(`Broadcast handler threw for ${messageType}:`, err); }
+      }
+    } catch(err) {
+      this.#logger.debug(`Dropping broadcast event ${event.id}:`, err);
     }
   }
 

--- a/packages/aggregation/src/participant/http-client.ts
+++ b/packages/aggregation/src/participant/http-client.ts
@@ -331,8 +331,8 @@ export class HttpClientTransport implements Transport {
       return;
     }
 
-    const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
-    const flat = flattenMessage(revived);
+    const flat = this.#reviveAndBind(envelope);
+    if(!flat) return;
     const messageType = typeof flat.type === 'string' ? flat.type : undefined;
     if(!messageType) return;
 
@@ -361,13 +361,36 @@ export class HttpClientTransport implements Transport {
       return;
     }
 
-    const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
-    const flat = flattenMessage(revived);
+    const flat = this.#reviveAndBind(envelope);
+    if(!flat) return;
     const messageType = typeof flat.type === 'string' ? flat.type : undefined;
     if(!messageType) return;
 
     const handler = entry.handlers.get(messageType);
     if(handler) await handler(flat);
+  }
+
+  /**
+   * Revive a verified envelope's message and bind its `from` to the
+   * authenticated envelope sender, mirroring the Nostr path's
+   * `authenticateEnvelopeContent`: a mismatching inner `from` drops the
+   * message, and a missing one is rebound, so a verified sender can never
+   * dispatch under another DID. Malformed wire content is dropped, not
+   * propagated into the SSE loops.
+   */
+  #reviveAndBind(envelope: SignedEnvelope): Record<string, unknown> | undefined {
+    let flat: Record<string, unknown>;
+    try {
+      flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    } catch(err) {
+      this.#logger.debug('Message revival failed:', err);
+      return undefined;
+    }
+    if(flat.from !== undefined && flat.from !== envelope.from) {
+      this.#logger.debug(`Dropping message with spoofed inner from: ${String(flat.from)} !== ${envelope.from}`);
+      return undefined;
+    }
+    return { ...flat, from: envelope.from };
   }
 
   #resolveSenderPk(

--- a/packages/aggregation/src/participant/participant-runner.ts
+++ b/packages/aggregation/src/participant/participant-runner.ts
@@ -89,7 +89,10 @@ export interface AggregationParticipantRunnerOptions {
  *
  * @example
  * ```typescript
- * const transport = new NostrTransport({ relays: [RELAY] });
+ * // Inject a DID-aware sender resolver (e.g. resolveBtcr2SenderPk from
+ * // @did-btcr2/method) so a first advert from an unregistered service still
+ * // authenticates and discovery can bootstrap.
+ * const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
  * transport.registerActor(myDid, myKeys);
  *
  * const runner = new AggregationParticipantRunner({

--- a/packages/aggregation/src/service/http-server.ts
+++ b/packages/aggregation/src/service/http-server.ts
@@ -418,8 +418,13 @@ export class HttpServerTransport implements Transport {
       return this.#respondJson(404, { error: 'unknown_recipient' }, req);
     }
 
-    const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
-    const flat = flattenMessage(revived);
+    let flat: Record<string, unknown>;
+    try {
+      flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    } catch(err) {
+      this.#logger.debug('POST /v1/messages: malformed wire content:', err);
+      return this.#respondJson(400, { error: 'invalid_message' }, req);
+    }
 
     // Bind the inner message to the authenticated envelope: a sender may only speak as
     // itself. The envelope signature authenticates envelope.from, but the dispatched
@@ -611,7 +616,13 @@ export class HttpServerTransport implements Transport {
 
     // Inspect the still-untrusted message only to derive a candidate key; nothing is
     // trusted until the envelope verifies against that key below.
-    const flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    let flat: Record<string, unknown>;
+    try {
+      flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    } catch(err) {
+      this.#logger.debug('POST /v1/messages: bootstrap revival failed:', err);
+      return undefined;
+    }
     if(flat.type !== COHORT_OPT_IN) return undefined;
 
     const genesisDocument = flat.genesisDocument;

--- a/packages/aggregation/src/service/service-runner.ts
+++ b/packages/aggregation/src/service/service-runner.ts
@@ -206,7 +206,10 @@ interface RunContext {
  *
  * @example
  * ```typescript
- * const transport = new NostrTransport({ relays: [RELAY] });
+ * // Inject a DID-aware sender resolver (e.g. resolveBtcr2SenderPk from
+ * // @did-btcr2/method) so opt-ins from unregistered participants still
+ * // authenticate and discovery can bootstrap.
+ * const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
  * transport.registerActor(serviceDid, serviceKeys);
  *
  * const runner = new AggregationServiceRunner({

--- a/packages/aggregation/src/transport-factory.ts
+++ b/packages/aggregation/src/transport-factory.ts
@@ -6,6 +6,7 @@ import { HttpClientTransport } from './participant/http-client.js';
 import type { HttpServerTransportConfig } from './service/http-server.js';
 import { HttpServerTransport } from './service/http-server.js';
 import { NostrTransport } from './core/transport/nostr.js';
+import type { NostrTransportConfig } from './core/transport/nostr.js';
 import type { Transport } from './core/transport/transport.js';
 
 /** Discriminated-union config for {@link TransportFactory.establish}. */
@@ -20,6 +21,16 @@ export interface NostrTransportConfigOption {
   relays?: string[];
   logger?: Logger;
   broadcastLookbackMs?: number;
+  /**
+   * Optional DID -> communication-public-key resolver for senders that are not
+   * pre-registered peers (for example `resolveBtcr2SenderPk` from
+   * `@did-btcr2/method`, injected by the caller - this package stays
+   * DID-method-agnostic). Without it, a factory-built transport drops every
+   * message from an unregistered sender, so cohort discovery cannot bootstrap.
+   */
+  resolveSenderPk?: NostrTransportConfig['resolveSenderPk'];
+  /** Envelope timestamp tolerance in seconds; see {@link NostrTransportConfig.clockSkewSec}. */
+  clockSkewSec?: number;
 }
 
 export interface DidCommTransportConfigOption {
@@ -45,6 +56,8 @@ export class TransportFactory {
           relays              : config.relays,
           logger              : config.logger,
           broadcastLookbackMs : config.broadcastLookbackMs,
+          resolveSenderPk     : config.resolveSenderPk,
+          clockSkewSec        : config.clockSkewSec,
         });
       case 'didcomm':
         throw new NotImplementedError('DIDComm transport not implemented yet.');

--- a/packages/aggregation/tests/aggregation-http-client.spec.ts
+++ b/packages/aggregation/tests/aggregation-http-client.spec.ts
@@ -325,6 +325,46 @@ describe('HttpClientTransport', () => {
       await new Promise((r) => setTimeout(r, 30));
       expect(delivered).to.be.false;
     });
+
+    // MS-19: the envelope signature authenticates did2, but the inner message
+    // claims a victim sender; the dispatch must drop it (Nostr-path parity).
+    it('drops a broadcast whose inner from differs from the authenticated sender', async () => {
+      client = makeClient();
+      client.registerActor(did1, keys1);
+
+      let delivered = false;
+      client.registerMessageHandler(did1, COHORT_ADVERT, () => { delivered = true; });
+      client.start();
+      await helper.waitForCall(HTTP_ROUTE.ADVERTS);
+
+      const victim = DidBtcr2.create(
+        SchnorrKeyPair.generate().publicKey.compressed,
+        { idType: 'KEY', network: 'mutinynet' },
+      );
+      const spoofed = new BaseMessage({ type: COHORT_ADVERT, from: victim, body: { cohortId: 'c1' } });
+      const envelope = signEnvelope(spoofed, { did: did2, keys: keys2 });
+      helper.pushEvent(HTTP_ROUTE.ADVERTS, SSE_EVENT.ADVERT, JSON.stringify(envelope));
+
+      await new Promise((r) => setTimeout(r, 30));
+      expect(delivered).to.be.false;
+    });
+
+    it('rebinds a missing inner from to the authenticated broadcast sender', async () => {
+      client = makeClient();
+      client.registerActor(did1, keys1);
+
+      const received = new Promise<Record<string, unknown>>((resolve) => {
+        client.registerMessageHandler(did1, COHORT_ADVERT, (msg) => resolve(msg));
+      });
+      client.start();
+      await helper.waitForCall(HTTP_ROUTE.ADVERTS);
+
+      const envelope = signEnvelope({ type: COHORT_ADVERT, body: { cohortId: 'c1' } }, { did: did2, keys: keys2 });
+      helper.pushEvent(HTTP_ROUTE.ADVERTS, SSE_EVENT.ADVERT, JSON.stringify(envelope));
+
+      const delivered = await received;
+      expect(delivered.from).to.equal(did2);
+    });
   });
 
   describe('inbox dispatch', () => {
@@ -370,6 +410,30 @@ describe('HttpClientTransport', () => {
       );
       const msg = new BaseMessage({ type: COHORT_READY, from: did2, to: wrongRecipient, body: { cohortId: 'c1' } });
       const envelope = signEnvelope(msg, { did: did2, keys: keys2 }, { to: wrongRecipient });
+      helper.pushEvent(inboxPath, SSE_EVENT.MESSAGE, JSON.stringify(envelope));
+
+      await new Promise((r) => setTimeout(r, 30));
+      expect(delivered).to.be.false;
+    });
+
+    // MS-19: the envelope signature authenticates did2, but the inner message
+    // claims a victim sender; the dispatch must drop it (Nostr-path parity).
+    it('drops a directed message whose inner from differs from the authenticated sender', async () => {
+      client = makeClient();
+      client.registerActor(did1, keys1);
+
+      let delivered = false;
+      client.registerMessageHandler(did1, COHORT_READY, () => { delivered = true; });
+      client.start();
+      const inboxPath = `/v1/actors/${encodeURIComponent(did1)}/inbox`;
+      await helper.waitForCall(inboxPath);
+
+      const victim = DidBtcr2.create(
+        SchnorrKeyPair.generate().publicKey.compressed,
+        { idType: 'KEY', network: 'mutinynet' },
+      );
+      const spoofed = new BaseMessage({ type: COHORT_READY, from: victim, to: did1, body: { cohortId: 'c1' } });
+      const envelope = signEnvelope(spoofed, { did: did2, keys: keys2 }, { to: did1 });
       helper.pushEvent(inboxPath, SSE_EVENT.MESSAGE, JSON.stringify(envelope));
 
       await new Promise((r) => setTimeout(r, 30));

--- a/packages/aggregation/tests/aggregation-http-envelope.spec.ts
+++ b/packages/aggregation/tests/aggregation-http-envelope.spec.ts
@@ -262,5 +262,26 @@ describe('HTTP transport envelope', () => {
       expect(Array.from(revived.body.participantPk)).to.deep.equal(Array.from(pk));
       expect(Array.from(revived.body.communicationPk)).to.deep.equal(Array.from(pk));
     });
+
+    // MS-01 hardening: malformed sentinels must fail with a typed, catchable
+    // error before hexToBytes runs, so transport callers can drop the payload.
+    it('reviveFromWire throws a typed error on a non-hex __bytes sentinel', () => {
+      expect(() => reviveFromWire({ __bytes: 'zz' }))
+        .to.throw(HttpTransportError).with.property('type', 'WIRE_SENTINEL_INVALID');
+    });
+
+    it('reviveFromWire throws a typed error on an odd-length __bytes sentinel', () => {
+      expect(() => reviveFromWire({ __bytes: 'abc' }))
+        .to.throw(HttpTransportError).with.property('type', 'WIRE_SENTINEL_INVALID');
+    });
+
+    it('reviveFromWire throws a typed error on a nested malformed sentinel', () => {
+      expect(() => reviveFromWire({ outer: [{ inner: { __bytes: 'x1' } }] }))
+        .to.throw(HttpTransportError).with.property('type', 'WIRE_SENTINEL_INVALID');
+    });
+
+    it('reviveFromWire leaves a non-string __bytes value untouched (not a sentinel)', () => {
+      expect(reviveFromWire({ __bytes: 7 })).to.deep.equal({ __bytes: 7 });
+    });
   });
 });

--- a/packages/aggregation/tests/aggregation-nostr-transport.spec.ts
+++ b/packages/aggregation/tests/aggregation-nostr-transport.spec.ts
@@ -1,0 +1,359 @@
+import { canonicalHashBytes } from '@did-btcr2/common';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils';
+import { expect } from 'chai';
+import type { Event, EventTemplate } from 'nostr-tools';
+import { finalizeEvent } from 'nostr-tools';
+
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
+
+import {
+  BaseMessage,
+  COHORT_ADVERT,
+  COHORT_OPT_IN,
+  HTTP_ENVELOPE_VERSION,
+  MAX_CLOCK_SKEW_SEC,
+  NostrTransport,
+  SILENT_LOGGER,
+  TransportAdapterError,
+  TransportFactory,
+  signEnvelope,
+} from '../src/index.js';
+import {
+  fakeNostrRelay,
+  installFakeRelaySockets,
+  uninstallFakeRelaySockets,
+} from './helpers/fake-nostr-relay.js';
+
+/**
+ * NostrTransport integration tests over an in-process fake relay: the real
+ * transport event handlers run against real (validly signed) Nostr events,
+ * with no network. Covers MS-01 (malformed wire content must be dropped, never
+ * an unhandled rejection), MS-05 (factory-built transports bootstrap first-advert
+ * discovery via an injected sender resolver), and MS-27 (clockSkewSec clamping).
+ */
+
+interface Identity { keys: SchnorrKeyPair; did: string }
+
+let relaySeq = 0;
+function freshRelayUrl(): string {
+  relaySeq += 1;
+  return `ws://nostr.test/r${relaySeq}`;
+}
+
+function makeIdentity(network = 'mutinynet'): Identity {
+  const keys = SchnorrKeyPair.generate();
+  const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network });
+  return { keys, did };
+}
+
+function makeAdvert(sender: Identity): BaseMessage {
+  return new BaseMessage({
+    type : COHORT_ADVERT,
+    from : sender.did,
+    body : {
+      cohortId        : 'c-bootstrap',
+      minParticipants : 2,
+      beaconType      : 'CASBeacon',
+      network         : 'mutinynet',
+    },
+  });
+}
+
+/** Wrap envelope JSON in a real, validly-signed kind-1 relay event. */
+function toRelayEvent(sender: Identity, content: string, tags: string[][]): Event {
+  return finalizeEvent({
+    kind       : 1,
+    created_at : Math.floor(Date.now() / 1000),
+    tags,
+    content,
+  } as EventTemplate, sender.keys.secretKey.bytes);
+}
+
+/**
+ * Envelope JSON whose message carries a malformed `__bytes` sentinel, signed
+ * with the sender's real key: the envelope signature is valid, so only the
+ * malformed content can cause a drop.
+ */
+function signedMalformedEnvelope(sender: Identity, sentinel: string, opts?: { to?: string }): string {
+  const unsigned = {
+    v         : HTTP_ENVELOPE_VERSION,
+    from      : sender.did,
+    ...(opts?.to !== undefined ? { to: opts.to } : {}),
+    timestamp : Math.floor(Date.now() / 1000),
+    nonce     : bytesToHex(randomBytes(16)),
+    message   : {
+      type : COHORT_ADVERT,
+      from : sender.did,
+      body : { cohortId: 'c1', blob: { __bytes: sentinel } },
+    },
+  };
+  const sig = sender.keys.secretKey.sign(canonicalHashBytes(unsigned), { scheme: 'schnorr' });
+  return JSON.stringify({ ...unsigned, sig: bytesToHex(sig) });
+}
+
+async function waitForSubscriptions(url: string, count: number): Promise<void> {
+  const relay = fakeNostrRelay(url);
+  const start = Date.now();
+  while(relay.subscriptionCount < count) {
+    if(Date.now() - start > 2000) {
+      throw new Error(`timed out waiting for ${count} subscription(s), saw ${relay.subscriptionCount}`);
+    }
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+describe('NostrTransport (fake relay)', () => {
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown): void => { rejections.push(reason); };
+
+  before(() => installFakeRelaySockets());
+
+  after(() => uninstallFakeRelaySockets());
+
+  beforeEach(() => {
+    rejections.length = 0;
+    process.on('unhandledRejection', onRejection);
+  });
+
+  afterEach(() => {
+    process.removeListener('unhandledRejection', onRejection);
+  });
+
+  describe('malformed wire content (MS-01)', () => {
+    function setupTransport(url: string): { alice: Identity; transport: NostrTransport; delivered: Record<string, unknown>[] } {
+      const alice = makeIdentity();
+      const transport = new NostrTransport({
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+      });
+      const delivered: Record<string, unknown>[] = [];
+      transport.registerActor(alice.did, alice.keys);
+      transport.registerMessageHandler(alice.did, COHORT_ADVERT, (msg) => { delivered.push(msg); });
+      transport.registerMessageHandler(alice.did, COHORT_OPT_IN, (msg) => { delivered.push(msg); });
+      transport.start();
+      return { alice, transport, delivered };
+    }
+
+    it('drops a broadcast event carrying a non-hex __bytes sentinel, with no unhandled rejection', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const { delivered } = setupTransport(url);
+      await waitForSubscriptions(url, 2);
+
+      const event = toRelayEvent(mallory, signedMalformedEnvelope(mallory, 'zz'), [['t', COHORT_ADVERT]]);
+      fakeNostrRelay(url).inject(event);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.deep.equal([]);
+      expect(rejections).to.deep.equal([]);
+    });
+
+    it('drops a broadcast event carrying an odd-length-hex __bytes sentinel, with no unhandled rejection', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const { delivered } = setupTransport(url);
+      await waitForSubscriptions(url, 2);
+
+      const event = toRelayEvent(mallory, signedMalformedEnvelope(mallory, 'abc'), [['t', COHORT_ADVERT]]);
+      fakeNostrRelay(url).inject(event);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.deep.equal([]);
+      expect(rejections).to.deep.equal([]);
+    });
+
+    it('drops a directed event carrying a malformed __bytes sentinel, with no unhandled rejection', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const { alice, delivered } = setupTransport(url);
+      await waitForSubscriptions(url, 2);
+
+      const tags = [['p', bytesToHex(alice.keys.publicKey.x)], ['t', COHORT_OPT_IN]];
+      const content = signedMalformedEnvelope(mallory, 'zz', { to: alice.did });
+      fakeNostrRelay(url).inject(toRelayEvent(mallory, content, tags));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.deep.equal([]);
+      expect(rejections).to.deep.equal([]);
+    });
+
+    it('delivers a valid signed advert through the broadcast path (control)', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const { delivered } = setupTransport(url);
+      await waitForSubscriptions(url, 2);
+
+      const envelope = signEnvelope(makeAdvert(mallory), { did: mallory.did, keys: mallory.keys });
+      fakeNostrRelay(url).inject(toRelayEvent(mallory, JSON.stringify(envelope), [['t', COHORT_ADVERT]]));
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(delivered).to.have.lengthOf(1);
+      expect(delivered[0].from).to.equal(mallory.did);
+      expect(delivered[0].cohortId).to.equal('c-bootstrap');
+      expect(rejections).to.deep.equal([]);
+    });
+  });
+
+  describe('TransportFactory bootstrap (MS-05)', () => {
+    it('bootstraps first-advert discovery between factory-built transports with no pre-registration', async () => {
+      const url = freshRelayUrl();
+      const service = makeIdentity();
+      const participant = makeIdentity();
+
+      const serviceTransport = TransportFactory.establish({
+        type            : 'nostr',
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+      });
+      const participantTransport = TransportFactory.establish({
+        type            : 'nostr',
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+      });
+
+      serviceTransport.registerActor(service.did, service.keys);
+      participantTransport.registerActor(participant.did, participant.keys);
+      const received = new Promise<Record<string, unknown>>((resolve) => {
+        participantTransport.registerMessageHandler(participant.did, COHORT_ADVERT, (msg) => resolve(msg));
+      });
+
+      serviceTransport.start();
+      participantTransport.start();
+      await waitForSubscriptions(url, 4);
+
+      // No registerPeer calls anywhere: the participant authenticates the
+      // service's first advert purely through the injected DID resolver.
+      await serviceTransport.sendMessage(makeAdvert(service), service.did);
+
+      const advert = await received;
+      expect(advert.from).to.equal(service.did);
+      expect(advert.cohortId).to.equal('c-bootstrap');
+    });
+
+    it('drops the first advert when no sender resolver is configured (documents the bootstrap gap)', async () => {
+      const url = freshRelayUrl();
+      const service = makeIdentity();
+      const participant = makeIdentity();
+
+      const serviceTransport = TransportFactory.establish({ type: 'nostr', relays: [url], logger: SILENT_LOGGER });
+      const participantTransport = TransportFactory.establish({ type: 'nostr', relays: [url], logger: SILENT_LOGGER });
+
+      serviceTransport.registerActor(service.did, service.keys);
+      participantTransport.registerActor(participant.did, participant.keys);
+      let delivered = false;
+      participantTransport.registerMessageHandler(participant.did, COHORT_ADVERT, () => { delivered = true; });
+
+      serviceTransport.start();
+      participantTransport.start();
+      await waitForSubscriptions(url, 4);
+
+      await serviceTransport.sendMessage(makeAdvert(service), service.did);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.be.false;
+    });
+
+    it('forwards clockSkewSec to the Nostr transport', () => {
+      expect(() => TransportFactory.establish({ type: 'nostr', clockSkewSec: 0 }))
+        .to.throw(TransportAdapterError).with.property('type', 'INVALID_CLOCK_SKEW');
+    });
+  });
+
+  describe('clockSkewSec clamping (MS-27)', () => {
+    it('rejects zero', () => {
+      expect(() => new NostrTransport({ clockSkewSec: 0 }))
+        .to.throw(TransportAdapterError).with.property('type', 'INVALID_CLOCK_SKEW');
+    });
+
+    it('rejects a negative value', () => {
+      expect(() => new NostrTransport({ clockSkewSec: -60 }))
+        .to.throw(TransportAdapterError).with.property('type', 'INVALID_CLOCK_SKEW');
+    });
+
+    it('rejects non-finite values', () => {
+      for(const value of [Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(() => new NostrTransport({ clockSkewSec: value }))
+          .to.throw(TransportAdapterError).with.property('type', 'INVALID_CLOCK_SKEW');
+      }
+    });
+
+    it('drops an advert older than the default timestamp window', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const alice = makeIdentity();
+      const transport = new NostrTransport({
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+      });
+      transport.registerActor(alice.did, alice.keys);
+      let delivered = false;
+      transport.registerMessageHandler(alice.did, COHORT_ADVERT, () => { delivered = true; });
+      transport.start();
+      await waitForSubscriptions(url, 2);
+
+      const stale = Math.floor(Date.now() / 1000) - 250;
+      const envelope = signEnvelope(makeAdvert(mallory), { did: mallory.did, keys: mallory.keys }, { timestamp: stale });
+      fakeNostrRelay(url).inject(toRelayEvent(mallory, JSON.stringify(envelope), [['t', COHORT_ADVERT]]));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.be.false;
+    });
+
+    it('honors a custom clockSkewSec within the maximum', async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const alice = makeIdentity();
+      const transport = new NostrTransport({
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+        clockSkewSec    : MAX_CLOCK_SKEW_SEC,
+      });
+      transport.registerActor(alice.did, alice.keys);
+      const received = new Promise<Record<string, unknown>>((resolve) => {
+        transport.registerMessageHandler(alice.did, COHORT_ADVERT, (msg) => resolve(msg));
+      });
+      transport.start();
+      await waitForSubscriptions(url, 2);
+
+      // 250s old: beyond the 60s default but inside the configured 300s window.
+      const stale = Math.floor(Date.now() / 1000) - 250;
+      const envelope = signEnvelope(makeAdvert(mallory), { did: mallory.did, keys: mallory.keys }, { timestamp: stale });
+      fakeNostrRelay(url).inject(toRelayEvent(mallory, JSON.stringify(envelope), [['t', COHORT_ADVERT]]));
+
+      const advert = await received;
+      expect(advert.from).to.equal(mallory.did);
+    });
+
+    it(`clamps an excessive clockSkewSec to the ${MAX_CLOCK_SKEW_SEC}s maximum`, async () => {
+      const url = freshRelayUrl();
+      const mallory = makeIdentity();
+      const alice = makeIdentity();
+      const transport = new NostrTransport({
+        relays          : [url],
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+        clockSkewSec    : 10_000,
+      });
+      transport.registerActor(alice.did, alice.keys);
+      let delivered = false;
+      transport.registerMessageHandler(alice.did, COHORT_ADVERT, () => { delivered = true; });
+      transport.start();
+      await waitForSubscriptions(url, 2);
+
+      // 400s old: inside the configured 10000s but beyond the 300s clamp, so
+      // the advert is dropped only if the configured value was clamped.
+      const stale = Math.floor(Date.now() / 1000) - 400;
+      const envelope = signEnvelope(makeAdvert(mallory), { did: mallory.did, keys: mallory.keys }, { timestamp: stale });
+      fakeNostrRelay(url).inject(toRelayEvent(mallory, JSON.stringify(envelope), [['t', COHORT_ADVERT]]));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(delivered).to.be.false;
+    });
+  });
+});

--- a/packages/aggregation/tests/helpers/fake-nostr-relay.ts
+++ b/packages/aggregation/tests/helpers/fake-nostr-relay.ts
@@ -1,0 +1,169 @@
+/**
+ * In-process fake Nostr relay for transport tests.
+ *
+ * Installed via nostr-tools' `useWebSocketImplementation`, so a NostrTransport's
+ * SimplePool "connects" to an in-memory relay keyed by URL instead of the
+ * network. Transports pointing at the same URL share one relay, which stores
+ * published events, answers REQ with matching history + EOSE, and fans new
+ * events out to every matching subscription - the narrow harness needed to
+ * drive the real NostrTransport event handlers without a network.
+ */
+import type { Event, Filter } from 'nostr-tools';
+import { matchFilters } from 'nostr-tools';
+import { useWebSocketImplementation } from 'nostr-tools/pool';
+
+type Frame = unknown[];
+
+class FakeNostrRelay {
+  static #registry = new Map<string, FakeNostrRelay>();
+  static #nextSocketId = 0;
+
+  static forUrl(url: string): FakeNostrRelay {
+    const key = FakeNostrRelay.#normalize(url);
+    let relay = this.#registry.get(key);
+    if(!relay) {
+      relay = new FakeNostrRelay();
+      this.#registry.set(key, relay);
+    }
+    return relay;
+  }
+
+  static reset(): void {
+    this.#registry.clear();
+    this.#nextSocketId = 0;
+  }
+
+  static nextSocketId(): number {
+    return ++this.#nextSocketId;
+  }
+
+  /** Mirror nostr-tools' normalizeURL closely enough to key the registry. */
+  static #normalize(url: string): string {
+    const parsed = new URL(url.indexOf('://') === -1 ? `wss://${url}` : url);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    return parsed.toString();
+  }
+
+  #sockets = new Set<FakeRelaySocket>();
+  // Keyed by `${socket.id}:${subId}`: nostr-tools numbers subscription ids
+  // per pool, so two transports on one relay reuse the same ids.
+  #subs    = new Map<string, { socket: FakeRelaySocket; id: string; filters: Filter[] }>();
+  #stored  : Event[] = [];
+
+  get subscriptionCount(): number { return this.#subs.size; }
+  get storedEvents(): readonly Event[] { return this.#stored; }
+
+  connect(socket: FakeRelaySocket): void { this.#sockets.add(socket); }
+
+  disconnect(socket: FakeRelaySocket): void {
+    this.#sockets.delete(socket);
+    for(const [key, sub] of this.#subs) {
+      if(sub.socket === socket) this.#subs.delete(key);
+    }
+  }
+
+  static subKey(socket: FakeRelaySocket, id: string): string {
+    return `${socket.id}:${id}`;
+  }
+
+  /** Handle one client frame (REQ / EVENT / CLOSE) from a connected socket. */
+  handle(socket: FakeRelaySocket, raw: string): void {
+    const msg = JSON.parse(raw) as unknown[];
+    switch(msg[0]) {
+      case 'REQ': {
+        const [, id, ...filters] = msg as [unknown, string, ...Filter[]];
+        this.#subs.set(FakeNostrRelay.subKey(socket, id), { socket, id, filters });
+        for(const event of this.#stored) {
+          if(matchFilters(filters, event)) socket.deliver(['EVENT', id, event]);
+        }
+        socket.deliver(['EOSE', id]);
+        break;
+      }
+      case 'EVENT': {
+        const event = msg[1] as Event;
+        this.#stored.push(event);
+        socket.deliver(['OK', event.id, true, '']);
+        this.#fanout(event);
+        break;
+      }
+      case 'CLOSE': {
+        this.#subs.delete(FakeNostrRelay.subKey(socket, msg[1] as string));
+        break;
+      }
+    }
+  }
+
+  /** Inject an event as if a third-party client published it (test entry point). */
+  inject(event: Event): void {
+    this.#stored.push(event);
+    this.#fanout(event);
+  }
+
+  #fanout(event: Event): void {
+    for(const sub of this.#subs.values()) {
+      if(matchFilters(sub.filters, event)) sub.socket.deliver(['EVENT', sub.id, event]);
+    }
+  }
+}
+
+/** WebSocket stand-in wired to a shared {@link FakeNostrRelay}. */
+export class FakeRelaySocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN       = 1;
+  static readonly CLOSING    = 2;
+  static readonly CLOSED     = 3;
+
+  readyState: number = FakeRelaySocket.CONNECTING;
+  onopen   : (() => void) | null                       = null;
+  onerror  : ((ev: unknown) => void) | null            = null;
+  onclose  : ((ev: { message?: string }) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null     = null;
+
+  readonly id: number;
+  readonly #relay: FakeNostrRelay;
+
+  constructor(url: string | URL) {
+    this.#relay = FakeNostrRelay.forUrl(String(url));
+    this.id = FakeNostrRelay.nextSocketId();
+    queueMicrotask(() => {
+      if(this.readyState !== FakeRelaySocket.CONNECTING) return;
+      this.readyState = FakeRelaySocket.OPEN;
+      this.#relay.connect(this);
+      this.onopen?.();
+    });
+  }
+
+  send(data: string): void {
+    if(this.readyState !== FakeRelaySocket.OPEN) return;
+    this.#relay.handle(this, data);
+  }
+
+  close(): void {
+    if(this.readyState !== FakeRelaySocket.OPEN) return;
+    this.readyState = FakeRelaySocket.CLOSED;
+    this.#relay.disconnect(this);
+  }
+
+  /** Deliver a relay frame to the nostr-tools client (async, like a real socket). */
+  deliver(frame: Frame): void {
+    queueMicrotask(() => {
+      if(this.readyState === FakeRelaySocket.OPEN) this.onmessage?.({ data: JSON.stringify(frame) });
+    });
+  }
+}
+
+/** Test-facing handle to the shared in-memory relay behind a URL. */
+export function fakeNostrRelay(url: string): FakeNostrRelay {
+  return FakeNostrRelay.forUrl(url);
+}
+
+/** Point every subsequently created SimplePool at the in-memory relays. */
+export function installFakeRelaySockets(): void {
+  useWebSocketImplementation(FakeRelaySocket);
+}
+
+/** Restore the default (global WebSocket) implementation and drop all relay state. */
+export function uninstallFakeRelaySockets(): void {
+  useWebSocketImplementation(undefined);
+  FakeNostrRelay.reset();
+}

--- a/packages/method/README.md
+++ b/packages/method/README.md
@@ -122,11 +122,15 @@ Aggregation lets multiple DID controllers coordinate a single Bitcoin transactio
 ```typescript
 import { AggregationServiceRunner } from '@did-btcr2/aggregation/service';
 import { TransportFactory } from '@did-btcr2/aggregation';
+import { resolveBtcr2SenderPk } from '@did-btcr2/method';
 
 // Pick a transport. Nostr (relay-based) or HTTP/REST (operator-hosted).
+// resolveSenderPk authenticates senders from their DIDs so cohort discovery
+// bootstraps without out-of-band peer-key registration.
 const transport = TransportFactory.establish({
-  type   : 'nostr',
-  relays : ['wss://relay.damus.io'],
+  type            : 'nostr',
+  relays          : ['wss://relay.damus.io'],
+  resolveSenderPk : resolveBtcr2SenderPk,
 });
 // Or for HTTP: { type: 'http', role: 'server' } on the operator side,
 //              { type: 'http', role: 'client', baseUrl: '...' } on the participant side.

--- a/packages/method/docs/aggregation.md
+++ b/packages/method/docs/aggregation.md
@@ -106,7 +106,7 @@ A single `Transport` instance can serve multiple registered actors. In productio
 ```typescript
 import { NostrTransport, SILENT_LOGGER } from '@did-btcr2/method';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
-import { DidBtcr2 } from '@did-btcr2/method';
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
 
 // 1. Generate identity
 const keys = SchnorrKeyPair.generate();
@@ -125,6 +125,10 @@ const transport = new NostrTransport({
   // Some relays don't backfill historical events to late subscribers; this
   // gives them a bounded window of recent events to replay. Default 5 min.
   broadcastLookbackMs : 5 * 60 * 1000,
+  // Recommended: authenticate senders from their DIDs so a first advert or
+  // opt-in from an unregistered peer is accepted; without it, only
+  // pre-registered peers can authenticate and discovery cannot bootstrap.
+  resolveSenderPk     : resolveBtcr2SenderPk,
 });
 
 // 3. Register the actor (DID + keys) with the transport
@@ -146,6 +150,8 @@ That's the entire transport setup. From here on, you only interact with the Runn
 | `relays` | `DEFAULT_NOSTR_RELAYS` (4 public relays) | Array of relay URLs to connect to |
 | `logger` | `CONSOLE_LOGGER` | Injectable `Logger` for transport diagnostics |
 | `broadcastLookbackMs` | 5 min | `since` filter on broadcast (COHORT_ADVERT) subscription. Set to `0` to disable. |
+| `resolveSenderPk` | none (registered peers only) | DID -> communication-public-key resolver for unregistered senders (e.g. `resolveBtcr2SenderPk`). Required for cohort discovery to bootstrap. |
+| `clockSkewSec` | 60s | Envelope timestamp tolerance; messages older than this are dropped. Clamped to 300s max. |
 
 ### Choosing between Nostr and HTTP
 
@@ -165,8 +171,9 @@ Factory invocation for each:
 ```typescript
 // Nostr
 const transport = TransportFactory.establish({
-  type   : 'nostr',
-  relays : ['wss://relay.damus.io', 'wss://nos.lol'],
+  type            : 'nostr',
+  relays          : ['wss://relay.damus.io', 'wss://nos.lol'],
+  resolveSenderPk : resolveBtcr2SenderPk,
 });
 
 // HTTP client (participant side)

--- a/packages/method/docs/beacon-system-overview.md
+++ b/packages/method/docs/beacon-system-overview.md
@@ -205,12 +205,15 @@ import {
   AggregationParticipantRunner,
   DidBtcr2,
   NostrTransport,
+  resolveBtcr2SenderPk,
 } from '@did-btcr2/method';
 
 // --- Service Setup ---
 const serviceKeys = SchnorrKeyPair.generate();
 const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
-const transport = new NostrTransport({ relays: ['wss://relay.example'] });
+// resolveSenderPk authenticates senders from their DIDs so cohort discovery
+// bootstraps without out-of-band peer-key registration.
+const transport = new NostrTransport({ relays: ['wss://relay.example'], resolveSenderPk: resolveBtcr2SenderPk });
 
 const service = new AggregationServiceRunner({
   transport,
@@ -236,7 +239,7 @@ const result = await service.run();
 // --- Participant Setup ---
 const aliceKeys = SchnorrKeyPair.generate();
 const aliceDid = DidBtcr2.create(aliceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
-const aliceTransport = new NostrTransport({ relays: ['wss://relay.example'] });
+const aliceTransport = new NostrTransport({ relays: ['wss://relay.example'], resolveSenderPk: resolveBtcr2SenderPk });
 
 const alice = new AggregationParticipantRunner({
   transport       : aliceTransport,


### PR DESCRIPTION
* fix(aggregation-transport): fail-closed event parsing, sentinel validation, factory resolver wiring, clockSkewSec clamp (audit C1, L20; review MS-01, MS-05, MS-27)
* fix(aggregation-participant): rebind or drop http-client messages whose inner from mismatches the authenticated sender (audit H7; review MS-19)
* test(aggregation): raw-event NostrTransport coverage over a fake relay; first-advert discovery; inner-from mismatch (review MS-47.1)
* docs(method): document resolveSenderPk and clockSkewSec in transport examples