### PR TITLE
harden aggregation against cohort-kill messages and resource exhaustion

### DIFF
--- a/packages/aggregation/src/core/conditions.ts
+++ b/packages/aggregation/src/core/conditions.ts
@@ -25,6 +25,17 @@ export const KNOWN_BEACON_TYPES = ['CASBeacon', 'SMTBeacon'] as const;
 export const KNOWN_FUNDING_MODELS = ['operator-funded', 'participant-funded'] as const;
 
 /**
+ * Default ceiling on cohort size applied when a cohort advertises no explicit
+ * `maxParticipants` (audit MS-08): without it a default-configured service has
+ * no cohort-size bound at all. MuSig2 key-path signing is n-of-n, so every
+ * member must contribute a nonce and a partial signature per round; past ~100
+ * members rounds rarely complete and per-cohort coordination/memory cost grows
+ * linearly, so 100 is a sane default ceiling. Operators may advertise a higher
+ * (or lower) explicit `maxParticipants`.
+ */
+export const DEFAULT_MAX_PARTICIPANTS = 100;
+
+/**
  * An advertised price. `unit` is operator-defined (the spec does not specify a
  * currency); `basis` distinguishes a per-DID from a per-participant charge for
  * "cost per announcement". Advertised only - never settled by the protocol.
@@ -41,7 +52,7 @@ export interface CohortConditions {
   beaconType: string;
   /** 2. Lower bound on cohort size. Enforced (finalize floor). */
   minParticipants: number;
-  /** 2. Upper bound on cohort size. Enforced (accept/finalize ceiling). */
+  /** 2. Upper bound on cohort size. Enforced (accept/finalize ceiling); absent defaults to {@link DEFAULT_MAX_PARTICIPANTS} at enforcement time. */
   maxParticipants?: number;
   /** 3. Lower bound on DIDs a participant may register. Advertised; enforcement staged (AGG-5). */
   minDidsPerParticipant?: number;

--- a/packages/aggregation/src/core/messages/base.ts
+++ b/packages/aggregation/src/core/messages/base.ts
@@ -7,7 +7,7 @@ import type { CohortConditions } from '../conditions.js';
  * requires coordinated updates across all participants and any intermediate
  * relays that inspect message content.
  */
-export const AGGREGATION_WIRE_VERSION = 1;
+export const AGGREGATION_WIRE_VERSION = 2;
 
 // Cohort conditions (beaconType, minParticipants, maxParticipants, ...) ride on
 // the wire as flat optional body fields, supplied via `Partial<CohortConditions>`

--- a/packages/aggregation/src/core/messages/bodies.ts
+++ b/packages/aggregation/src/core/messages/bodies.ts
@@ -265,9 +265,22 @@ export function isCohortReadyMessage(m: BaseMessage): m is CohortReadyMessage {
 }
 
 export function isSubmitUpdateMessage(m: BaseMessage): m is SubmitUpdateMessage {
-  return m.type === SUBMIT_UPDATE
-    && hasStr(m.body, 'cohortId')
-    && !!m.body && typeof (m.body as Record<string, unknown>).signedUpdate === 'object';
+  if(m.type !== SUBMIT_UPDATE || !hasStr(m.body, 'cohortId')) return false;
+  const signedUpdate = (m.body as Record<string, unknown>).signedUpdate;
+  if(!signedUpdate || typeof signedUpdate !== 'object') return false;
+  // When a proof is carried it must be an object whose verificationMethod and
+  // proofValue, when present, are strings: a truthy non-string value (e.g.
+  // `verificationMethod: 1`) otherwise crashes downstream parsing with a raw
+  // TypeError (audit MS-02).
+  const proof = (signedUpdate as Record<string, unknown>).proof;
+  if(proof !== undefined) {
+    if(!proof || typeof proof !== 'object') return false;
+    const vm = (proof as Record<string, unknown>).verificationMethod;
+    const pv = (proof as Record<string, unknown>).proofValue;
+    if(vm !== undefined && typeof vm !== 'string') return false;
+    if(pv !== undefined && typeof pv !== 'string') return false;
+  }
+  return true;
 }
 
 export function isSubmitNonIncludedMessage(m: BaseMessage): m is SubmitNonIncludedMessage {

--- a/packages/aggregation/src/core/signing-session.ts
+++ b/packages/aggregation/src/core/signing-session.ts
@@ -1,4 +1,5 @@
 import { wipe } from '@did-btcr2/keypair';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import type { Transaction } from '@scure/btc-signer';
 import { SigHash } from '@scure/btc-signer';
 import * as musig2 from '@scure/btc-signer/musig2';
@@ -114,6 +115,16 @@ export class BeaconSigningSession {
         'INVALID_NONCE_LENGTH'
       );
     }
+    // Both 33-byte halves of a BIP-327 pubnonce must decode as valid compressed
+    // secp256k1 points: a nonce that passes the length check but carries
+    // non-points throws deep inside musig2 at aggregation time (audit MS-02).
+    if(!secp256k1.utils.isValidPublicKey(nonceContribution.subarray(0, 33))
+      || !secp256k1.utils.isValidPublicKey(nonceContribution.subarray(33, 66))) {
+      throw new SigningSessionError(
+        'Invalid nonce contribution: not two valid compressed secp256k1 points.',
+        'INVALID_NONCE'
+      );
+    }
     if(this.nonceContributions.has(participantDid)) {
       throw new SigningSessionError(
         `Duplicate nonce contribution from ${participantDid}.`,
@@ -156,6 +167,15 @@ export class BeaconSigningSession {
       throw new SigningSessionError(
         `Duplicate partial signature from ${participantDid}.`,
         'DUPLICATE_PARTIAL_SIG'
+      );
+    }
+    // A BIP-327 partial signature is a 32-byte scalar. Without the length check
+    // a wrong-length contribution throws an untyped error out of musig2
+    // partialSigVerify at aggregation time (audit MS-02).
+    if(partialSig.length !== 32) {
+      throw new SigningSessionError(
+        `Invalid partial signature: expected 32 bytes, got ${partialSig.length}.`,
+        'INVALID_PARTIAL_SIG'
       );
     }
     this.partialSignatures.set(participantDid, partialSig);

--- a/packages/aggregation/src/participant/participant-runner.ts
+++ b/packages/aggregation/src/participant/participant-runner.ts
@@ -78,6 +78,18 @@ export interface AggregationParticipantRunnerOptions {
    * {@link AggregationParticipantParams.genesisDocument}).
    */
   genesisDocument?: Record<string, unknown>;
+
+  /**
+   * Cap on cohort states the participant retains at once, forwarded to
+   * {@link AggregationParticipantParams.maxCohorts} (audit MS-08).
+   */
+  maxCohorts?: number;
+
+  /**
+   * Absolute fee ceiling (satoshis) this member signs for, forwarded to
+   * {@link AggregationParticipantParams.maxFeeSats} (audit MS-08).
+   */
+  maxFeeSats?: bigint | number;
 }
 
 /**
@@ -146,6 +158,8 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       did             : options.did,
       signer          : new KeyPairAggregationSigner(options.keys),
       genesisDocument : options.genesisDocument,
+      maxCohorts      : options.maxCohorts,
+      maxFeeSats      : options.maxFeeSats,
     });
   }
 
@@ -278,7 +292,13 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       }
 
       const join = await this.#shouldJoin(advert);
-      if (!join) return;
+      if (!join) {
+        // A rejected advert must not permanently consume a cohort-state slot
+        // (audit MS-08): the state machine stores the entry before shouldJoin
+        // runs, so the runner drops it here.
+        this.session.leaveCohort(advert.cohortId);
+        return;
+      }
 
       await this.#sendAll(this.session.joinCohort(advert.cohortId));
       this.emit('cohort-joined', { cohortId: advert.cohortId });
@@ -363,6 +383,8 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       } else {
         await this.#sendAll(this.session.rejectValidation(cohortId));
         this.emit('cohort-failed', { cohortId, reason: 'Validation rejected by participant' });
+        // Reclaim the cohort slot; dead state must not count against maxCohorts (MS-08).
+        this.session.leaveCohort(cohortId);
       }
     } catch (err) {
       this.emit('error', err as Error);
@@ -393,6 +415,7 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       const decision = await this.#onApproveSigning(req);
       if (!decision.approved) {
         this.emit('cohort-failed', { cohortId, reason: 'Signing rejected by participant' });
+        this.session.leaveCohort(cohortId);
         return;
       }
 
@@ -451,6 +474,7 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       const decision = await this.#onApproveSigning(req);
       if (!decision.approved) {
         this.emit('cohort-failed', { cohortId, reason: 'Fallback signing rejected by participant' });
+        this.session.leaveCohort(cohortId);
         return;
       }
 
@@ -484,6 +508,10 @@ export class AggregationParticipantRunner extends TypedEventEmitter<AggregationP
       casAnnouncement : validation?.casAnnouncement,
       smtProof        : validation?.smtProof,
     });
+    // Reclaim the cohort slot once the member's work is done: completed state
+    // must not count against maxCohorts forever (audit MS-08). The retained
+    // sidecar was handed to the listener in the event above.
+    this.session.leaveCohort(cohortId);
   }
 
   /**

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -180,9 +180,11 @@ export interface AggregationParticipantParams {
   /**
    * Cap on cohort states retained at once. Cohort adverts arrive over broadcast
    * transports from anyone, each minting a state entry; the bound keeps an
-   * advert flood from growing the map without limit (audit M6). New adverts
-   * past the cap are ignored; prune completed cohorts with
-   * {@link AggregationParticipant.leaveCohort}. Defaults to
+   * advert flood from growing the map without limit (audit M6). At capacity the
+   * oldest not-yet-joined (Discovered) entry is evicted to make room (audit
+   * MS-08); joined cohorts are never auto-evicted, so a flood of adverts while
+   * every retained cohort is joined still drops the new advert. Prune completed
+   * cohorts with {@link AggregationParticipant.leaveCohort}. Defaults to
    * {@link DEFAULT_MAX_PARTICIPANT_COHORTS}.
    */
   maxCohorts?: number;
@@ -309,8 +311,19 @@ export class AggregationParticipant {
     const { cohortId, network, communicationPk, ...conditions } = message.body;
     if(this.#cohortStates.has(cohortId)) return;  // Already known
     // Adverts arrive over broadcast from anyone; bound the retained state so an
-    // advert flood cannot grow the map without limit (audit M6).
-    if(this.#cohortStates.size >= this.#maxCohorts) return;
+    // advert flood cannot grow the map without limit (audit M6). At capacity,
+    // evict the oldest not-yet-joined (Discovered) entry to make room - a flood
+    // of minted cohortIds must not permanently starve discovery of new cohorts
+    // (audit MS-08). Joined cohorts are never auto-evicted: when every retained
+    // cohort is joined the new advert is dropped.
+    if(this.#cohortStates.size >= this.#maxCohorts) {
+      let oldestDiscovered: string | undefined;
+      for(const [id, s] of this.#cohortStates) {
+        if(s.phase === ParticipantCohortPhase.Discovered) { oldestDiscovered = id; break; }
+      }
+      if(oldestDiscovered === undefined) return;
+      this.leaveCohort(oldestDiscovered);
+    }
 
     const advert: CohortAdvert = {
       cohortId,

--- a/packages/aggregation/src/service/http-server.ts
+++ b/packages/aggregation/src/service/http-server.ts
@@ -190,6 +190,12 @@ export class HttpServerTransport implements Transport {
     this.#inboxBufferSize = config.inboxBufferSize ?? 100;
     this.#advertTtlMs     = config.advertTtlMs ?? DEFAULT_ADVERT_TTL_MS;
     this.#heartbeatMs     = config.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+    // NOTE (audit MS-08): the rate limiter buckets by verified sender DID (plus
+    // the adapter-supplied remoteAddr hint when present - see #limitKey). A
+    // DID-keyed limit alone can be multiplied by minting fresh k1 DIDs, which
+    // is free; full Sybil resistance needs connection/IP-keyed limits at the
+    // HTTP adapter layer, which owns the socket and is out of this transport's
+    // scope.
     this.#rateLimiter     = config.rateLimiter ?? new RateLimiter();
     this.#nonceCache      = config.nonceCache ?? new NonceCache();
     this.#now             = config.now ?? (() => Date.now());
@@ -402,12 +408,14 @@ export class HttpServerTransport implements Transport {
       if(!bootstrappedPk) return this.#respondJson(401, { error: 'unknown_sender' }, req);
     }
 
+    if(!this.#rateLimiter.consume(this.#limitKey(envelope.from, req), this.#now())) {
+      return this.#respondJson(429, { error: 'rate_limited' }, req);
+    }
+    // Store the nonce only AFTER the rate-limit gate: a 429'd request must not
+    // insert an entry, or flooding past the limit would still grow the cache
+    // (audit MS-10).
     if(!this.#nonceCache.store(envelope.from, envelope.nonce, envelope.timestamp)) {
       return this.#respondJson(409, { error: 'replay' }, req);
-    }
-
-    if(!this.#rateLimiter.consume(envelope.from, this.#now())) {
-      return this.#respondJson(429, { error: 'rate_limited' }, req);
     }
 
     if(!envelope.to) {
@@ -472,11 +480,11 @@ export class HttpServerTransport implements Transport {
       return this.#respondJson(401, { error: 'invalid_envelope' }, req);
     }
 
+    if(!this.#rateLimiter.consume(this.#limitKey(envelope.from, req), this.#now())) {
+      return this.#respondJson(429, { error: 'rate_limited' }, req);
+    }
     if(!this.#nonceCache.store(envelope.from, envelope.nonce, envelope.timestamp)) {
       return this.#respondJson(409, { error: 'replay' }, req);
-    }
-    if(!this.#rateLimiter.consume(envelope.from, this.#now())) {
-      return this.#respondJson(429, { error: 'rate_limited' }, req);
     }
 
     // Only registered actors can publish adverts on this server.
@@ -543,11 +551,11 @@ export class HttpServerTransport implements Transport {
       stream.close();
       return;
     }
-    if(!this.#nonceCache.store(did, parsedNonce, parsedTs)) {
+    if(!this.#rateLimiter.consume(this.#limitKey(did, req), this.#now())) {
       stream.close();
       return;
     }
-    if(!this.#rateLimiter.consume(did, this.#now())) {
+    if(!this.#nonceCache.store(did, parsedNonce, parsedTs)) {
       stream.close();
       return;
     }
@@ -584,6 +592,16 @@ export class HttpServerTransport implements Transport {
       this.#inboxes.set(did, inbox);
     }
     return inbox;
+  }
+
+  /**
+   * Rate-limit bucket key: the verified sender DID, qualified by the adapter's
+   * remoteAddr hint when one is supplied, so the same DID from distinct
+   * connections does not share a bucket (audit MS-08). This is only a hint -
+   * see the construction-site note on DID-minting multiplication.
+   */
+  #limitKey(did: string, req: HttpRequestLike): string {
+    return req.remoteAddr ? `${did}|${req.remoteAddr}` : did;
   }
 
   #resolveSenderPk(

--- a/packages/aggregation/src/service/nonce-cache.ts
+++ b/packages/aggregation/src/service/nonce-cache.ts
@@ -27,11 +27,15 @@ export interface NonceCacheConfig {
  * is outside the clock-skew window *before* consulting the cache, so entries
  * here are always within the protocol's acceptable window.
  *
- * Eviction order (audit L18): expired entries first (they can no longer match a
- * legitimate replay), then the over-limit DID's own oldest entries once it
- * exceeds `maxPerDid`, and only then a global oldest-first backstop at
- * `maxEntries`. A global FIFO alone lets an attacker flush a victim's live
- * entries and replay inside the window; per-DID buckets plus expiry close that.
+ * Capacity policy (audit L18/MS-10): when a DID's bucket reaches `maxPerDid`
+ * or the cache reaches `maxEntries`, expired entries are reclaimed first (they
+ * are outside the replay window and can never match a legitimate retry). If
+ * capacity is still exhausted afterwards, the NEW admission is refused rather
+ * than evicting a live in-window entry: evicting live entries (a global FIFO,
+ * or draining whole buckets) reopens exactly the replay window this cache
+ * exists to close, letting an attacker flush a victim's entries and replay
+ * their requests inside the window. Failing closed means an over-capacity
+ * cache rejects new requests - a liveness cost, never a replay-forgery risk.
  */
 export class NonceCache {
   readonly #maxEntries: number;
@@ -50,51 +54,34 @@ export class NonceCache {
   }
 
   /**
-   * Record a nonce. Returns `true` if it was novel (caller should accept the
-   * request) or `false` if it was a replay (caller should reject).
+   * Record a nonce. Returns `true` if it was novel and admitted (caller should
+   * accept the request) or `false` if it was a replay - or if admitting it
+   * would require evicting a live in-window entry, in which case the caller
+   * must reject the request (fail-closed; audit MS-10).
    */
   store(did: string, nonce: string, timestampSec: number): boolean {
     let bucket = this.#byDid.get(did);
     if(bucket?.has(nonce)) return false;
+
+    const bucketFull = bucket !== undefined && bucket.size >= this.#maxPerDid;
+    if(bucketFull || this.#total >= this.#maxEntries) {
+      // Reclaim expired entries first: they are outside the replay window and
+      // can never match a legitimate retry.
+      this.#sweepExpired();
+      bucket = this.#byDid.get(did);
+      // Still at capacity: reject the new admission instead of evicting a live
+      // in-window entry (which would reopen the replay window).
+      if(this.#total >= this.#maxEntries) return false;
+      if(bucket !== undefined && bucket.size >= this.#maxPerDid) return false;
+    }
+
     if(!bucket) {
       bucket = new Map();
       this.#byDid.set(did, bucket);
     }
     bucket.set(nonce, timestampSec);
     this.#total += 1;
-
-    this.#evict(did, bucket);
     return true;
-  }
-
-  #evict(did: string, bucket: Map<string, number>): void {
-    // 1. Expire stale entries whenever pressure demands it (or the DID's own
-    // bucket is over its cap): they are outside the replay window and can never
-    // match a legitimate retry.
-    if(this.#total > this.#maxEntries || bucket.size > this.#maxPerDid) {
-      this.#sweepExpired();
-    }
-    // 2. Per-DID cap: evict the offending DID's oldest entries only.
-    while(bucket.size > this.#maxPerDid) {
-      const oldest = bucket.keys().next();
-      if(oldest.done) break;
-      bucket.delete(oldest.value);
-      this.#total -= 1;
-    }
-    // 3. Global backstop: evict oldest entries across all DIDs.
-    if(this.#total > this.#maxEntries) {
-      for(const [otherDid, other] of this.#byDid) {
-        while(other.size > 0 && this.#total > this.#maxEntries) {
-          const oldest = other.keys().next();
-          if(oldest.done) break;
-          other.delete(oldest.value);
-          this.#total -= 1;
-        }
-        if(other.size === 0) this.#byDid.delete(otherDid);
-        if(this.#total <= this.#maxEntries) break;
-      }
-    }
-    if(bucket.size === 0) this.#byDid.delete(did);
   }
 
   #sweepExpired(): void {

--- a/packages/aggregation/src/service/service-runner.ts
+++ b/packages/aggregation/src/service/service-runner.ts
@@ -1,4 +1,5 @@
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
+import { DEFAULT_MAX_PARTICIPANTS } from '../core/conditions.js';
 import { AggregationCohortError, AggregationServiceError } from '../core/errors.js';
 import type { BaseMessage } from '../core/messages/base.js';
 import {
@@ -679,14 +680,20 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       }
 
       const decision = await this.#onOptInReceived(optIn);
-      if(!decision.accepted) return;
+      if(!decision.accepted) {
+        // Operator declined: drop the pending entry so the pending-opt-in cap
+        // counts only genuinely-undecided opt-ins (audit MS-08).
+        this.session.rejectParticipant(ctx.cohortId, msg.from);
+        return;
+      }
 
       // Don't accept past the advertised maxParticipants: acceptParticipant
       // would throw COHORT_FULL and fail the cohort. Silently ignore the surplus
-      // opt-in (the cohort is full).
-      const maxParticipants = ctx.config.maxParticipants;
+      // opt-in (the cohort is full). An unadvertised ceiling defaults to
+      // DEFAULT_MAX_PARTICIPANTS (audit MS-08).
+      const maxParticipants = ctx.config.maxParticipants ?? DEFAULT_MAX_PARTICIPANTS;
       const cohortNow = this.session.getCohort(ctx.cohortId);
-      if(maxParticipants !== undefined && cohortNow && cohortNow.participants.length >= maxParticipants) {
+      if(cohortNow && cohortNow.participants.length >= maxParticipants) {
         return;
       }
 
@@ -848,6 +855,15 @@ export class AggregationServiceRunner extends TypedEventEmitter<AggregationServi
       // If the cohort already committed to the fallback path, ignore a late
       // optimistic completion: only one path may finalize the single beacon UTXO.
       if(ctx.committedPath === 'fallback') return;
+
+      // The state machine flagged a defector past the retry budget (or an
+      // unattributable session error): commit to the k-of-n fallback
+      // deliberately rather than letting the optimistic round stall forever
+      // (audit MS-18). triggerFallback latches committedPath synchronously.
+      if(this.session.isFallbackRequired(ctx.cohortId)) {
+        await this.triggerFallback(ctx.cohortId);
+        return;
+      }
 
       // The state machine auto-completes when all partial sigs received.
       const result = this.session.getResult(ctx.cohortId);

--- a/packages/aggregation/src/service/service.ts
+++ b/packages/aggregation/src/service/service.ts
@@ -1,19 +1,21 @@
 import { canonicalize } from '@did-btcr2/common';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import { BIP340Cryptosuite, SchnorrMultikey } from '@did-btcr2/cryptosuite';
-import type { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import type { Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from '../core/beacon-strategy.js';
 import { AggregationCohort } from '../core/cohort.js';
-import { validateCohortConditions, type CohortConditions } from '../core/conditions.js';
+import type { CohortConditions } from '../core/conditions.js';
+import { DEFAULT_MAX_PARTICIPANTS, validateCohortConditions } from '../core/conditions.js';
 import { AggregationCohortError, AggregationServiceError, SigningSessionError } from '../core/errors.js';
 import { buildFallbackSpend, fallbackSighash } from '../core/fallback-spend.js';
 import type { FallbackSignature } from '../core/fallback-spend.js';
 import { buildFallbackLeaf } from '../core/recovery-policy.js';
 import type { BaseMessage } from '../core/messages/base.js';
 import { AGGREGATION_WIRE_VERSION } from '../core/messages/base.js';
+import { isCohortOptInMessage, isSubmitUpdateMessage } from '../core/messages/bodies.js';
 import {
   COHORT_OPT_IN,
   FALLBACK_SIGNATURE,
@@ -94,6 +96,7 @@ export type RejectionReason =
   | 'UPDATE_VERIFICATION_FAILED'
   | 'UPDATE_MALFORMED'
   | 'UNKNOWN_PARTICIPANT'
+  | 'OPT_IN_MALFORMED'
   | 'OPT_IN_OVERFLOW'
   | 'INVALID_NONCE'
   | 'DUPLICATE_NONCE'
@@ -117,6 +120,13 @@ interface ServiceCohortState {
   phase: ServiceCohortPhaseType;
   cohort: AggregationCohort;
   config: CohortConfig;
+  /**
+   * Genuinely-pending opt-ins awaiting an operator decision. Entries are
+   * removed on accept ({@link AggregationService.acceptParticipant}) and on
+   * operator reject ({@link AggregationService.rejectParticipant}), so the
+   * `maxPendingOptIns` cap counts only undecided opt-ins; accepted members'
+   * keys live in `cohort.participantKeys` (audit MS-08).
+   */
   pendingOptIns: Map<string, PendingOptIn>;
   acceptedParticipants: Set<string>;
   signingSession?: BeaconSigningSession;
@@ -127,6 +137,20 @@ interface ServiceCohortState {
    * a verified standalone BIP-340 signature over the fallback script-path sighash.
    */
   fallbackSignatures?: Map<string, FallbackSignature>;
+  /**
+   * Per-participant count of blamed signing contributions this round (audit
+   * MS-18): past {@link PARTIAL_SIG_BLAME_BUDGET} the participant is treated as
+   * a defector and the cohort is flagged for the k-of-n fallback. Reset when a
+   * new signing session starts.
+   */
+  partialSigBlame: Map<string, number>;
+  /**
+   * Set when the signing round can no longer complete optimistically (a
+   * defector exhausted the blame budget, or an unattributable session error
+   * occurred). Read by the runner via {@link AggregationService.isFallbackRequired}
+   * to drive the k-of-n fallback deliberately instead of wedging the cohort.
+   */
+  fallbackRequired: boolean;
   /** Rejections accumulated since last drain. Runner polls via drainRejections(). */
   rejections: Array<Rejection>;
 }
@@ -142,6 +166,16 @@ export const DEFAULT_MAX_UPDATE_SIZE_BYTES = 256 * 1024;
  * the cap are dropped with an OPT_IN_OVERFLOW rejection.
  */
 export const DEFAULT_MAX_PENDING_OPT_INS = 1024;
+
+/**
+ * Per-participant budget of blamed signing contributions before the service
+ * stops rewinding the round for that member and flags the cohort for the
+ * k-of-n fallback (audit MS-18): without a budget a persistent defector
+ * resubmits bad partial signatures forever and the blame-and-retry loop never
+ * terminates. The default n-1 fallback threshold tolerates exactly one
+ * defector.
+ */
+export const PARTIAL_SIG_BLAME_BUDGET = 2;
 
 export interface AggregationServiceParams {
   did: string;
@@ -203,6 +237,35 @@ export class AggregationService {
     state.rejections.push({ from, code, reason });
   }
 
+  /**
+   * Boundary shape validation for inbound messages whose handlers would
+   * otherwise trust attacker-controlled field types (audit MS-02). On failure
+   * the message is dropped with a recorded rejection (when its cohortId
+   * resolves) and the cohort is never touched.
+   */
+  #guardShape(
+    message: BaseMessage,
+    guard: (m: BaseMessage) => boolean,
+    code: RejectionReason,
+    reason: string
+  ): boolean {
+    if(guard(message)) return true;
+    const cohortId = message.body?.cohortId;
+    const state = cohortId ? this.#cohortStates.get(cohortId) : undefined;
+    if(state) this.#reject(state, message.from, code, reason);
+    return false;
+  }
+
+  /** True if `key` is a valid 33-byte compressed secp256k1 point. */
+  #isValidCohortKey(key: Uint8Array): boolean {
+    try {
+      new CompressedSecp256k1PublicKey(key);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
 
   receive(message: BaseMessage): void {
     // Reject messages whose wire version doesn't match what this build speaks.
@@ -222,9 +285,13 @@ export class AggregationService {
     const type = message.type;
     switch(type) {
       case COHORT_OPT_IN:
+        // Shape-validate at the boundary: a malformed body must degrade to a
+        // recorded rejection, never a throw out of receive() (audit MS-02).
+        if(!this.#guardShape(message, isCohortOptInMessage, 'OPT_IN_MALFORMED', 'Malformed COHORT_OPT_IN body')) return;
         this.#handleOptIn(message);
         break;
       case SUBMIT_UPDATE:
+        if(!this.#guardShape(message, isSubmitUpdateMessage, 'UPDATE_MALFORMED', 'Malformed SUBMIT_UPDATE body')) return;
         this.#handleSubmitUpdate(message);
         break;
       case SUBMIT_NONINCLUDED:
@@ -291,6 +358,8 @@ export class AggregationService {
       config,
       pendingOptIns        : new Map(),
       acceptedParticipants : new Set(),
+      partialSigBlame      : new Map(),
+      fallbackRequired     : false,
       rejections           : [],
     });
     return cohort.id;
@@ -331,14 +400,7 @@ export class AggregationService {
   pendingOptIns(cohortId: string): ReadonlyMap<string, PendingOptIn> {
     const state = this.#cohortStates.get(cohortId);
     if(!state) return new Map();
-    // Return only those not yet accepted
-    const map = new Map<string, PendingOptIn>();
-    for(const [did, optIn] of state.pendingOptIns) {
-      if(!state.acceptedParticipants.has(did)) {
-        map.set(did, optIn);
-      }
-    }
-    return map;
+    return new Map(state.pendingOptIns);
   }
 
   #handleOptIn(message: BaseMessage): void {
@@ -352,6 +414,17 @@ export class AggregationService {
     const participantPk = message.body?.participantPk;
     const communicationPk = message.body?.communicationPk;
     if(!participantPk || !communicationPk) return;
+
+    // Cryptographically validate both keys BEFORE the opt-in is stored: the
+    // runner auto-accepts opt-ins by default, and acceptParticipant feeds
+    // participantPk into cohortKeys, whose setter throws on non-33-byte /
+    // off-curve values - a single malformed opt-in would otherwise kill the
+    // cohort via the runner's catch-all (audit MS-02).
+    if(!this.#isValidCohortKey(participantPk) || !this.#isValidCohortKey(communicationPk)) {
+      this.#reject(state, participantDid, 'OPT_IN_MALFORMED',
+        'Opt-in keys must be valid 33-byte compressed secp256k1 points');
+      return;
+    }
 
     // Reject re-opt-in from already-accepted participants. Without this guard a
     // participant could send a second opt-in with a different key, overwriting
@@ -401,9 +474,10 @@ export class AggregationService {
       );
     }
     // Enforce the maxParticipants condition: a cohort cannot grow past its
-    // advertised ceiling (closes the unbounded-growth path; see ADR 039).
-    const maxParticipants = state.config.maxParticipants;
-    if(maxParticipants !== undefined && state.acceptedParticipants.size >= maxParticipants) {
+    // advertised ceiling (closes the unbounded-growth path; see ADR 039). An
+    // unadvertised ceiling defaults to DEFAULT_MAX_PARTICIPANTS (audit MS-08).
+    const maxParticipants = state.config.maxParticipants ?? DEFAULT_MAX_PARTICIPANTS;
+    if(state.acceptedParticipants.size >= maxParticipants) {
       throw new AggregationServiceError(
         `Cohort ${cohortId} is full: ${maxParticipants} participants already accepted.`,
         'COHORT_FULL', { cohortId, maxParticipants }
@@ -414,12 +488,24 @@ export class AggregationService {
     state.cohort.participants.push(participantDid);
     state.cohort.participantKeys.set(participantDid, optIn.participantPk);
     state.cohort.cohortKeys = [...state.cohort.cohortKeys, optIn.participantPk];
+    // Accepted members' keys live on cohort.participantKeys; drop the pending
+    // entry so the pending cap counts only genuinely-undecided opt-ins (MS-08).
+    state.pendingOptIns.delete(participantDid);
 
     return [createCohortOptInAcceptMessage({
       from : this.did,
       to   : participantDid,
       cohortId,
     })];
+  }
+
+  /**
+   * Service operator rejects a pending opt-in. Drops the entry so the
+   * pending-opt-in cap counts only genuinely-pending opt-ins (audit MS-08);
+   * the sender may opt in again later. No-op when nothing is pending.
+   */
+  rejectParticipant(cohortId: string, participantDid: string): void {
+    this.#cohortStates.get(cohortId)?.pendingOptIns.delete(participantDid);
   }
 
   /**
@@ -445,8 +531,8 @@ export class AggregationService {
     }
     // Ceiling defense: acceptParticipant already rejects past max, so reaching
     // here over max means state was mutated out-of-band.
-    const maxParticipants = state.config.maxParticipants;
-    if(maxParticipants !== undefined && state.acceptedParticipants.size > maxParticipants) {
+    const maxParticipants = state.config.maxParticipants ?? DEFAULT_MAX_PARTICIPANTS;
+    if(state.acceptedParticipants.size > maxParticipants) {
       throw new AggregationServiceError(
         `Cohort ${cohortId} has ${state.acceptedParticipants.size} accepted participants, exceeds max ${maxParticipants}.`,
         'TOO_MANY_PARTICIPANTS', { cohortId, maxParticipants }
@@ -504,6 +590,16 @@ export class AggregationService {
     if(canonicalSize > this.maxUpdateSizeBytes) {
       this.#reject(state, message.from, 'UPDATE_TOO_LARGE',
         `Canonicalized update is ${canonicalSize} bytes; max allowed is ${this.maxUpdateSizeBytes}`);
+      return;
+    }
+
+    // Membership gate before any verification work: only accepted members may
+    // submit. A non-member's update is dropped as a rejection, never thrown:
+    // addUpdate would otherwise throw UNKNOWN_PARTICIPANT out of receive() and
+    // fail the whole cohort, a DoS any non-member could trigger (audit H6).
+    // Mirrors #handleSubmitNonInclusion.
+    if(!state.cohort.participants.includes(message.from)) {
+      this.#reject(state, message.from, 'UNKNOWN_PARTICIPANT', 'Sender is not a member of this cohort');
       return;
     }
 
@@ -597,10 +693,10 @@ export class AggregationService {
 
   /**
    * Verify the BIP-340 Schnorr Data Integrity proof on a submitted update using the
-   * participant's public key from their cohort opt-in. Returns `false` (and the
-   * update is silently dropped) if the proof is missing, the verificationMethod does
+   * participant's accepted cohort key. Returns `false` (and the update is silently
+   * dropped) if the proof is missing or malformed, the verificationMethod does
    * not name the sender's DID, the update document carries an `id` naming a DID
-   * other than the sender's (audit L19), the participant has no opt-in on record,
+   * other than the sender's (audit L19), the sender has no accepted key on record,
    * or the signature fails verification.
    * @param {ServiceCohortState} state - the current state of the cohort to which the update was submitted
    * @param {string} sender - the DID of the participant who submitted the update
@@ -614,6 +710,10 @@ export class AggregationService {
   ): boolean {
     const proof = signedUpdate.proof;
     if(!proof?.verificationMethod || !proof.proofValue) return false;
+    // Defense in depth (audit MS-02): the receive()-boundary guard already
+    // rejects non-string proof fields, but this method must never throw on
+    // attacker-controlled JSON regardless of how it is reached.
+    if(typeof proof.verificationMethod !== 'string' || typeof proof.proofValue !== 'string') return false;
 
     // The proof must be signed by the sender's own key. Reject if the
     // verificationMethod references a different DID.
@@ -628,14 +728,16 @@ export class AggregationService {
     const docId = (signedUpdate as { id?: unknown }).id;
     if(typeof docId === 'string' && docId !== sender) return false;
 
-    const optIn = state.pendingOptIns.get(sender);
-    if(!optIn) return false;
+    // The sender's key is the one accepted into the cohort (audit MS-08):
+    // pending-but-unaccepted opt-ins no longer authenticate submissions.
+    const participantPk = state.cohort.participantKeys.get(sender);
+    if(!participantPk) return false;
 
     try {
       const multikey = SchnorrMultikey.fromPublicKey({
         id             : proof.verificationMethod,
         controller     : sender,
-        publicKeyBytes : optIn.participantPk,
+        publicKeyBytes : participantPk,
       }) as SchnorrMultikey;
       const suite = new BIP340Cryptosuite(multikey);
       return suite.verifyProof(signedUpdate).verified === true;
@@ -773,6 +875,9 @@ export class AggregationService {
       prevOutValues  : txData.prevOutValues,
     });
     state.signingSession = session;
+    // A new signing round resets the defector bookkeeping (audit MS-18).
+    state.partialSigBlame.clear();
+    state.fallbackRequired = false;
     state.phase = ServiceCohortPhase.SigningStarted;
 
     const prevOutScript = txData.prevOutScripts[0];
@@ -909,22 +1014,34 @@ export class AggregationService {
       // participantDid): blame-and-exclude instead of failing the cohort. The
       // bad signature is discarded and the session returns to
       // AwaitingPartialSignatures so the blamed member can resubmit a corrected
-      // signature; if they do not, the runner's stall machinery (or an explicit
-      // triggerFallback) routes around them via the k-of-n script path, whose
-      // default n-1 threshold tolerates exactly one defector (audit M3).
+      // signature - but only up to PARTIAL_SIG_BLAME_BUDGET times per member per
+      // round, after which the member is treated as a defector and the cohort is
+      // flagged for the k-of-n fallback (whose default n-1 threshold tolerates
+      // exactly one defector) so a persistent defector cannot hold the round
+      // open indefinitely (audit MS-18).
       let signature: Uint8Array;
       try {
         signature = state.signingSession.generateFinalSignature();
       } catch(err) {
         if(err instanceof SigningSessionError && err.type === 'BAD_PARTIAL_SIG') {
           const blamed = (err.data?.participantDid as string | undefined) ?? 'unknown';
-          state.signingSession.discardPartialSignature(blamed);
-          this.#reject(state, blamed, 'BAD_PARTIAL_SIG',
-            `Partial signature from ${blamed} failed BIP-327 verification; signature discarded, awaiting a corrected resubmission or fallback`);
+          this.#blameSigningContribution(state, blamed, 'BAD_PARTIAL_SIG',
+            `Partial signature from ${blamed} failed BIP-327 verification`);
           return;
         }
         if(err instanceof SigningSessionError) {
-          this.#reject(state, message.from, 'SESSION_ERROR', err.message);
+          // A session error that is not a blamed partial signature must not
+          // wedge the round in PartialSignaturesReceived (audit MS-18): when a
+          // culprit is identifiable, discard their contribution and count it
+          // against the same budget so the round can complete on resubmission;
+          // otherwise flag the cohort for the fallback path deliberately.
+          const culprit = err.data?.participantDid as string | undefined;
+          if(culprit && state.signingSession.partialSignatures.has(culprit)) {
+            this.#blameSigningContribution(state, culprit, 'SESSION_ERROR', err.message);
+          } else {
+            this.#reject(state, message.from, 'SESSION_ERROR', err.message);
+            state.fallbackRequired = true;
+          }
           return;
         }
         throw err;
@@ -941,6 +1058,44 @@ export class AggregationService {
       };
       state.phase = ServiceCohortPhase.Complete;
     }
+  }
+
+
+  /**
+   * Blame a named participant for a failed signing-round contribution (audit
+   * MS-18): discard their partial signature and rewind the session to
+   * AwaitingPartialSignatures so they can resubmit, up to
+   * {@link PARTIAL_SIG_BLAME_BUDGET} blamed contributions per member per round.
+   * Past the budget no further rewinds are granted: the member is treated as a
+   * defector and the cohort is flagged for the k-of-n fallback.
+   */
+  #blameSigningContribution(
+    state: ServiceCohortState,
+    blamed: string,
+    code: 'BAD_PARTIAL_SIG' | 'SESSION_ERROR',
+    detail: string
+  ): void {
+    state.signingSession?.discardPartialSignature(blamed);
+    const count = (state.partialSigBlame.get(blamed) ?? 0) + 1;
+    state.partialSigBlame.set(blamed, count);
+    if(count > PARTIAL_SIG_BLAME_BUDGET) {
+      this.#reject(state, blamed, code,
+        `${detail}; retry budget of ${PARTIAL_SIG_BLAME_BUDGET} exhausted - treating ${blamed} as a defector; the k-of-n fallback is required`);
+      state.fallbackRequired = true;
+      return;
+    }
+    this.#reject(state, blamed, code,
+      `${detail}; contribution discarded, awaiting a corrected resubmission (${count}/${PARTIAL_SIG_BLAME_BUDGET})`);
+  }
+
+  /**
+   * True when the signing round for a cohort can no longer complete
+   * optimistically and the runner should drive the k-of-n fallback (via
+   * `triggerFallback`) instead of letting the cohort stall (audit MS-18).
+   * Polled by runners after `receive()`, mirroring {@link drainRejections}.
+   */
+  isFallbackRequired(cohortId: string): boolean {
+    return this.#cohortStates.get(cohortId)?.fallbackRequired === true;
   }
 
 
@@ -995,6 +1150,7 @@ export class AggregationService {
     });
 
     state.fallbackSignatures = new Map();
+    state.fallbackRequired = false;
     state.phase = ServiceCohortPhase.FallbackRequested;
 
     const messages: BaseMessage[] = [];

--- a/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
@@ -15,6 +15,8 @@ import {
   ServiceCohortPhase,
   SILENT_LOGGER,
   authenticateEnvelopeContent,
+  createAggregatedNonceMessage,
+  createAuthorizationRequestMessage,
   createFallbackAuthorizationRequestMessage,
   createCohortOptInMessage,
   createValidationAckMessage,
@@ -344,6 +346,61 @@ describe('Aggregation transport + message auth hardening', () => {
       expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
     });
 
+    it('H7: ignores an AUTHORIZATION_REQUEST from a sender that is not the service', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToValidation(ctx, cohortId);
+      route(ctx.aliceP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+
+      const attacker = makeIdentity();
+      ctx.aliceP.receive(createAuthorizationRequestMessage({
+        from             : attacker.did,
+        to               : ctx.alice.did,
+        cohortId,
+        sessionId        : 'attacker-session',
+        pendingTx        : 'aa',
+        prevOutScriptHex : 'bb',
+        prevOutValue     : '1000',
+      }));
+      expect(ctx.aliceP.pendingSigningRequests.has(cohortId)).to.be.false;
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+    });
+
+    it('H7: ignores an AGGREGATED_NONCE from a sender that is not the service', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToValidation(ctx, cohortId);
+      route(ctx.aliceP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+      route(ctx.bobP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+
+      const cohort = ctx.service.getCohort(cohortId)!;
+      const script = beaconOutputScript(cohort);
+      const tx = buildSignalTx(script, 100000n, cohort.signalBytes!);
+      route(ctx.service.startSigning(cohortId, {
+        tx,
+        prevOutScripts : [script],
+        prevOutValues  : [100000n],
+      }), { [ctx.alice.did]: ctx.aliceP, [ctx.bob.did]: ctx.bobP });
+      route(ctx.aliceP.approveNonce(cohortId), { [ctx.svc.did]: ctx.service });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      const attacker = makeIdentity();
+      ctx.aliceP.receive(createAggregatedNonceMessage({
+        from            : attacker.did,
+        to              : ctx.alice.did,
+        cohortId,
+        sessionId       : ctx.service.getSigningSessionId(cohortId)!,
+        aggregatedNonce : new Uint8Array(66),
+      }));
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      // Control: the genuine service aggregated nonce advances the phase
+      route(ctx.bobP.approveNonce(cohortId), { [ctx.svc.did]: ctx.service });
+      route(ctx.service.sendAggregatedNonce(cohortId), { [ctx.alice.did]: ctx.aliceP });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingPartialSig);
+    });
+
     it('L21: ignores a fallback request naming a foreign session id when a session exists', () => {
       const ctx = setup();
       const cohortId = driveToOptedIn(ctx);
@@ -424,6 +481,51 @@ describe('Aggregation transport + message auth hardening', () => {
       expect(service.validationProgress(cohortId).approved.size).to.equal(0);
 
       // Genuine acks commit to the distributed signal and drive the phase forward
+      route(aliceP.approveValidation(cohortId), parties);
+      route(bobP.approveValidation(cohortId), parties);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
+    });
+
+    it('service drops an ack that carries no signalBytesHex', () => {
+      const svc = makeIdentity();
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      const service = new AggregationService({ did: svc.did, publicKey: svc.keys.publicKey });
+      const aliceP = new AggregationParticipant({ did: alice.did, signer: new KeyPairAggregationSigner(alice.keys) });
+      const bobP = new AggregationParticipant({ did: bob.did, signer: new KeyPairAggregationSigner(bob.keys) });
+      const parties = { [svc.did]: service, [alice.did]: aliceP, [bob.did]: bobP };
+
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      route(service.advertise(cohortId), parties);
+      route(aliceP.joinCohort(cohortId), parties);
+      route(bobP.joinCohort(cohortId), parties);
+      route(service.acceptParticipant(cohortId, alice.did), parties);
+      route(service.acceptParticipant(cohortId, bob.did), parties);
+      route(service.finalizeKeygen(cohortId), parties);
+      route(aliceP.submitUpdate(cohortId, createSignedUpdate(alice.did, alice.keys)), parties);
+      route(bobP.submitUpdate(cohortId, createSignedUpdate(bob.did, bob.keys)), parties);
+      route(service.buildAndDistribute(cohortId), parties);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      // An ack with the field absent entirely (not merely a wrong hash) is not
+      // consent to the current distribution and must be dropped.
+      service.receive(createValidationAckMessage({
+        from           : alice.did,
+        to             : svc.did,
+        cohortId,
+        approved       : true,
+        signalBytesHex : undefined as unknown as string,
+      }));
+      expect(service.validationProgress(cohortId).approved.size).to.equal(0);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      // Genuine acks still advance the cohort.
       route(aliceP.approveValidation(cohortId), parties);
       route(bobP.approveValidation(cohortId), parties);
       expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);

--- a/packages/aggregation/tests/aggregation-dos-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-dos-hardening.spec.ts
@@ -2,22 +2,31 @@ import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { getNetwork } from '@did-btcr2/bitcoin';
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
-import { DidBtcr2 } from '@did-btcr2/method';
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
-import { p2tr, SigHash, Transaction } from '@scure/btc-signer';
+import { p2tr, Script, SigHash, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 
 import {
+  AGGREGATION_WIRE_VERSION,
   AggregationParticipant,
+  AggregationParticipantRunner,
   AggregationService,
+  AggregationServiceRunner,
+  BaseMessage,
   BeaconSigningSession,
+  COHORT_OPT_IN,
   DEFAULT_FUNDING_MODEL,
+  DEFAULT_MAX_PARTICIPANTS,
   HttpServerTransport,
   InMemoryRateLimitStore,
   KeyPairAggregationSigner,
   NonceCache,
+  ParticipantCohortPhase,
   RateLimiter,
+  SILENT_LOGGER,
+  SUBMIT_UPDATE,
   ServiceCohortPhase,
   buildRecoveryLeaves,
   buildRecoverySpend,
@@ -27,7 +36,11 @@ import {
   createSignatureAuthorizationMessage,
   createSubmitUpdateMessage,
   createValidationAckMessage,
+  signEnvelope,
 } from '../src/index.js';
+import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+import { beaconOutputScript } from './helpers/beacon-script.js';
+import type { AggregationCohort, CohortConfig } from '../src/index.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
@@ -167,6 +180,67 @@ function driveToSigningStarted(fx: Fixture): { tx: Transaction; script: Uint8Arr
   return { tx, script, value };
 }
 
+/** A minimal cohort config (CAS, mutinynet) for runner-driven tests. */
+const CAS_CONFIG = (minParticipants = 1): CohortConfig => ({
+  minParticipants,
+  network          : 'mutinynet',
+  beaconType       : 'CASBeacon',
+  recoveryKey      : TEST_RECOVERY_KEY,
+  recoverySequence : TEST_RECOVERY_SEQUENCE,
+});
+
+/** The well-formed beacon spend for a cohort (self-change + OP_RETURN signal). */
+function dummyTxData(cohort: AggregationCohort): { tx: Transaction; prevOutScripts: Uint8Array[]; prevOutValues: bigint[] } {
+  const script = beaconOutputScript(cohort);
+  const prevOutValue = 100000n;
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: prevOutValue, script } });
+  tx.addOutput({ script, amount: prevOutValue - 500n });
+  if(cohort.signalBytes) tx.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes ]), amount: 0n });
+  return { tx, prevOutScripts: [ script ], prevOutValues: [ prevOutValue ] };
+}
+
+/** A service runner over the in-memory bus, driven via advertiseCohort. */
+function makeServiceRunner(
+  bus: MessageBus,
+  opts: Partial<ConstructorParameters<typeof AggregationServiceRunner>[0]> = {},
+): AggregationServiceRunner {
+  const keys = SchnorrKeyPair.generate();
+  const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+  const transport = new MockTransport(bus);
+  transport.registerActor(did, keys);
+  // `runner` is referenced inside onProvideTxData, which only runs mid-protocol
+  // (long after assignment), so the self-reference is safe.
+  const runner: AggregationServiceRunner = new AggregationServiceRunner({
+    transport,
+    did,
+    keys,
+    advertRepeatIntervalMs : 0,
+    onProvideTxData        : async ({ cohortId }) => dummyTxData(runner.session.getCohort(cohortId)!),
+    ...opts,
+  });
+  return runner;
+}
+
+/** A participant runner over the in-memory bus that joins and approves everything by default. */
+function makeParticipantRunner(
+  bus: MessageBus,
+  overrides: Partial<ConstructorParameters<typeof AggregationParticipantRunner>[0]> = {},
+): AggregationParticipantRunner {
+  const keys = SchnorrKeyPair.generate();
+  const did = DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+  const transport = new MockTransport(bus);
+  transport.registerActor(did, keys);
+  return new AggregationParticipantRunner({
+    transport,
+    did,
+    keys,
+    shouldJoin      : async () => true,
+    onProvideUpdate : async () => createSignedUpdate(did, keys),
+    ...overrides,
+  });
+}
+
 describe('Aggregation DoS + liveness hardening', () => {
 
   describe('H6: non-member SUBMIT_UPDATE degrades to a rejection, not a cohort kill', () => {
@@ -216,9 +290,15 @@ describe('Aggregation DoS + liveness hardening', () => {
   describe('H6: bad nonce contributions degrade to rejections', () => {
     it('duplicate nonce from a member records DUPLICATE_NONCE without throwing', () => {
       const fx = driveToCohortSet();
-      driveToSigningStarted(fx);
+      const { tx, script, value } = driveToSigningStarted(fx);
+      const cohort = fx.service.getCohort(fx.cohortId)!;
       const sessionId = fx.service.getSigningSessionId(fx.cohortId)!;
-      const nonce = randomBytes(66);
+      // A cryptographically real nonce: nonce points are validated at ingestion
+      // (audit MS-02), so random bytes no longer reach the duplicate check.
+      const pAlice = new BeaconSigningSession({
+        id : sessionId, cohort, pendingTx : tx, prevOutScripts : [script], prevOutValues : [value],
+      });
+      const nonce = pAlice.generateNonceContribution(fx.alice.keys.publicKey.compressed, fx.alice.keys.secretKey.bytes);
       const mk = (): ReturnType<typeof createNonceContributionMessage> => createNonceContributionMessage({
         from              : fx.alice.did,
         to                : fx.serviceId.did,
@@ -401,6 +481,509 @@ describe('Aggregation DoS + liveness hardening', () => {
     });
   });
 
+  describe('MS-02: single-message cohort-kill vectors degrade to recorded rejections', () => {
+    it('malformed SUBMIT_UPDATE proof (truthy non-string verificationMethod) records UPDATE_MALFORMED', () => {
+      const fx = driveToCohortSet();
+      const attacker = makeIdentity();
+      // The exact Opus-reproduced vector: previously a raw TypeError out of
+      // receive() -> failCohort. The boundary guard must drop it instead.
+      expect(() => fx.service.receive(new BaseMessage({
+        type : SUBMIT_UPDATE,
+        from : attacker.did,
+        to   : fx.serviceId.did,
+        body : {
+          cohortId     : fx.cohortId,
+          signedUpdate : { proof: { verificationMethod: 1, proofValue: 1 } },
+        },
+      }))).to.not.throw();
+      const rejections = fx.service.drainRejections(fx.cohortId);
+      expect(rejections).to.have.lengthOf(1);
+      expect(rejections[0]!.code).to.equal('UPDATE_MALFORMED');
+      expect(rejections[0]!.from).to.equal(attacker.did);
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+    });
+
+    it('COHORT_OPT_IN with a valid communicationPk but malformed participantPk records OPT_IN_MALFORMED', () => {
+      const serviceId = makeIdentity();
+      const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      service.advertise(cohortId);
+      const attacker = makeIdentity();
+      // A non-33-byte participantPk previously reached sortKeys via the
+      // auto-accept path and threw the cohort into failure.
+      expect(() => service.receive(createCohortOptInMessage({
+        from            : attacker.did,
+        to              : serviceId.did,
+        cohortId,
+        participantPk   : new Uint8Array([1, 2, 3]),
+        communicationPk : attacker.keys.publicKey.compressed,
+      }))).to.not.throw();
+      expect(service.pendingOptIns(cohortId).size).to.equal(0);
+      const rejections = service.drainRejections(cohortId);
+      expect(rejections).to.have.lengthOf(1);
+      expect(rejections[0]!.code).to.equal('OPT_IN_MALFORMED');
+      expect(rejections[0]!.from).to.equal(attacker.did);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Advertised);
+    });
+
+    it('COHORT_OPT_IN with a 33-byte off-curve participantPk records OPT_IN_MALFORMED', () => {
+      const serviceId = makeIdentity();
+      const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      service.advertise(cohortId);
+      const attacker = makeIdentity();
+      expect(() => service.receive(createCohortOptInMessage({
+        from            : attacker.did,
+        to              : serviceId.did,
+        cohortId,
+        participantPk   : new Uint8Array(33).fill(0xff),
+        communicationPk : attacker.keys.publicKey.compressed,
+      }))).to.not.throw();
+      expect(service.pendingOptIns(cohortId).size).to.equal(0);
+      const rejections = service.drainRejections(cohortId);
+      expect(rejections.map(r => r.code)).to.include('OPT_IN_MALFORMED');
+    });
+
+    it('COHORT_OPT_IN with non-byte keys is dropped at the boundary as OPT_IN_MALFORMED', () => {
+      const serviceId = makeIdentity();
+      const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      service.advertise(cohortId);
+      const attacker = makeIdentity();
+      expect(() => service.receive(createCohortOptInMessage({
+        from            : attacker.did,
+        to              : serviceId.did,
+        cohortId,
+        participantPk   : 'not-bytes' as unknown as Uint8Array,
+        communicationPk : attacker.keys.publicKey.compressed,
+      }))).to.not.throw();
+      expect(service.pendingOptIns(cohortId).size).to.equal(0);
+      const rejections = service.drainRejections(cohortId);
+      expect(rejections.map(r => r.code)).to.include('OPT_IN_MALFORMED');
+    });
+
+    it('wrong-length partial signature records INVALID_PARTIAL_SIG without throwing', () => {
+      const fx = driveToCohortSet();
+      const { tx, script, value } = driveToSigningStarted(fx);
+      const cohort = fx.service.getCohort(fx.cohortId)!;
+      const sessionId = fx.service.getSigningSessionId(fx.cohortId)!;
+      // Real nonces move the service session to AwaitingPartialSigs.
+      const mkSession = (): BeaconSigningSession => new BeaconSigningSession({
+        id : sessionId, cohort, pendingTx : tx, prevOutScripts : [script], prevOutValues : [value],
+      });
+      const n1 = mkSession().generateNonceContribution(fx.alice.keys.publicKey.compressed, fx.alice.keys.secretKey.bytes);
+      const n2 = mkSession().generateNonceContribution(fx.bob.keys.publicKey.compressed, fx.bob.keys.secretKey.bytes);
+      fx.service.receive(createNonceContributionMessage({ from: fx.alice.did, to: fx.serviceId.did, cohortId: fx.cohortId, sessionId, nonceContribution: n1 }));
+      fx.service.receive(createNonceContributionMessage({ from: fx.bob.did, to: fx.serviceId.did, cohortId: fx.cohortId, sessionId, nonceContribution: n2 }));
+      fx.service.sendAggregatedNonce(fx.cohortId);
+
+      // A 64-byte partial previously escaped musig2 as an untyped throw.
+      expect(() => fx.service.receive(createSignatureAuthorizationMessage({
+        from             : fx.alice.did,
+        to               : fx.serviceId.did,
+        cohortId         : fx.cohortId,
+        sessionId,
+        partialSignature : randomBytes(64),
+      }))).to.not.throw();
+      const rejections = fx.service.drainRejections(fx.cohortId);
+      expect(rejections.map(r => r.code)).to.include('INVALID_PARTIAL_SIG');
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.AwaitingPartialSigs);
+    });
+
+    it('a 66-byte nonce that is not valid curve points records INVALID_NONCE without throwing', () => {
+      const fx = driveToCohortSet();
+      driveToSigningStarted(fx);
+      const sessionId = fx.service.getSigningSessionId(fx.cohortId)!;
+      // Passes the 66-byte length check but decodes to non-points: previously
+      // threw raw out of musig2 nonceAggregate at aggregation time.
+      const notPoints = new Uint8Array(66).fill(0xff);
+      expect(() => fx.service.receive(createNonceContributionMessage({
+        from              : fx.alice.did,
+        to                : fx.serviceId.did,
+        cohortId          : fx.cohortId,
+        sessionId,
+        nonceContribution : notPoints,
+      }))).to.not.throw();
+      const rejections = fx.service.drainRejections(fx.cohortId);
+      expect(rejections.map(r => r.code)).to.include('INVALID_NONCE');
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.SigningStarted);
+    });
+  });
+
+  describe('MS-02: correctly-signed envelopes carrying malformed bodies (HTTP runner path)', () => {
+    /** A service runner wired to an HTTP server transport with DID-aware sender resolution. */
+    function makeHttpServiceRunner(): {
+      serviceId: { keys: SchnorrKeyPair; did: string };
+      transport: HttpServerTransport;
+      runner: AggregationServiceRunner;
+      } {
+      const serviceId = makeIdentity();
+      const transport = new HttpServerTransport({
+        logger              : SILENT_LOGGER,
+        heartbeatIntervalMs : 0,
+        resolveSenderPk     : resolveBtcr2SenderPk,
+      });
+      transport.registerActor(serviceId.did, serviceId.keys);
+      const runner = new AggregationServiceRunner({
+        transport,
+        did             : serviceId.did,
+        keys            : serviceId.keys,
+        onProvideTxData : async () => { throw new Error('tx data not needed in this test'); },
+      });
+      return { serviceId, transport, runner };
+    }
+
+    /** Post a signed envelope to the transport's messages route. */
+    async function postSigned(
+      transport: HttpServerTransport,
+      sender: { keys: SchnorrKeyPair; did: string },
+      message: Record<string, unknown>,
+      to: string,
+    ): Promise<number> {
+      const envelope = signEnvelope(message as never, { did: sender.did, keys: sender.keys }, { to });
+      const res = await transport.handleRequest({
+        method  : 'POST',
+        url     : '/v1/messages',
+        headers : {},
+        body    : JSON.stringify(envelope),
+      });
+      return res.status;
+    }
+
+    it('malformed SUBMIT_UPDATE body: recorded rejection, cohort survives, runner never fails', async () => {
+      const { serviceId, transport, runner } = makeHttpServiceRunner();
+      const { cohortId, completion } = runner.advertiseCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      let settled = false;
+      void completion.then(() => { settled = true; }, () => { settled = true; });
+
+      // Drive the cohort to CohortSet on the state machine (two honest members).
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      for(const p of [alice, bob]) {
+        runner.session.receive(createCohortOptInMessage({
+          from            : p.did,
+          to              : serviceId.did,
+          cohortId,
+          participantPk   : p.keys.publicKey.compressed,
+          communicationPk : p.keys.publicKey.compressed,
+        }));
+      }
+      runner.session.acceptParticipant(cohortId, alice.did);
+      runner.session.acceptParticipant(cohortId, bob.did);
+      runner.session.finalizeKeygen(cohortId);
+
+      const errors: Error[] = [];
+      const rejected: Array<{ code: string }> = [];
+      runner.on('error', e => errors.push(e));
+      runner.on('message-rejected', r => rejected.push(r));
+
+      // The attacker's envelope is correctly signed and authenticates (k1 DID);
+      // the carried body is the malformed MS-02 payload.
+      const attacker = makeIdentity();
+      const status = await postSigned(transport, attacker, {
+        type    : SUBMIT_UPDATE,
+        version : AGGREGATION_WIRE_VERSION,
+        from    : attacker.did,
+        to      : serviceId.did,
+        body    : { cohortId, signedUpdate: { proof: { verificationMethod: 1, proofValue: 1 } } },
+      }, serviceId.did);
+
+      expect(status, 'envelope verified and accepted by the transport').to.equal(202);
+      expect(errors, 'runner never surfaced an error').to.have.lengthOf(0);
+      expect(rejected.map(r => r.code)).to.include('UPDATE_MALFORMED');
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+      expect(settled, 'cohort completion never settled').to.be.false;
+      runner.stop();
+      transport.stop();
+    });
+
+    it('malformed COHORT_OPT_IN participantPk: recorded rejection, auto-accept never fires', async () => {
+      const { serviceId, transport, runner } = makeHttpServiceRunner();
+      const { cohortId, completion } = runner.advertiseCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      let settled = false;
+      void completion.then(() => { settled = true; }, () => { settled = true; });
+
+      const errors: Error[] = [];
+      const rejected: Array<{ code: string }> = [];
+      runner.on('error', e => errors.push(e));
+      runner.on('message-rejected', r => rejected.push(r));
+
+      const attacker = makeIdentity();
+      const status = await postSigned(transport, attacker, {
+        type    : COHORT_OPT_IN,
+        version : AGGREGATION_WIRE_VERSION,
+        from    : attacker.did,
+        to      : serviceId.did,
+        body    : {
+          cohortId,
+          participantPk   : new Uint8Array([1, 2, 3]),
+          communicationPk : attacker.keys.publicKey.compressed,
+        },
+      }, serviceId.did);
+
+      expect(status).to.equal(202);
+      expect(errors).to.have.lengthOf(0);
+      expect(rejected.map(r => r.code)).to.include('OPT_IN_MALFORMED');
+      expect(runner.session.pendingOptIns(cohortId).size).to.equal(0);
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Advertised);
+      expect(settled).to.be.false;
+      runner.stop();
+      transport.stop();
+    });
+  });
+
+  describe('MS-18: blame budget bounds the retry loop; session errors never wedge', () => {
+    /** CohortSet -> AwaitingPartialSigs with real nonces; returns the participant-side sessions. */
+    function driveToAwaitingPartialSigs(fx: Fixture): {
+      sessionId: string;
+      pAlice: BeaconSigningSession;
+      pBob: BeaconSigningSession;
+    } {
+      const { tx, script, value } = driveToSigningStarted(fx);
+      const cohort = fx.service.getCohort(fx.cohortId)!;
+      const sessionId = fx.service.getSigningSessionId(fx.cohortId)!;
+      const mkSession = (): BeaconSigningSession => new BeaconSigningSession({
+        id : sessionId, cohort, pendingTx : tx, prevOutScripts : [script], prevOutValues : [value],
+      });
+      const pAlice = mkSession();
+      const pBob = mkSession();
+      const nonceAlice = pAlice.generateNonceContribution(fx.alice.keys.publicKey.compressed, fx.alice.keys.secretKey.bytes);
+      const nonceBob = pBob.generateNonceContribution(fx.bob.keys.publicKey.compressed, fx.bob.keys.secretKey.bytes);
+      for(const [p, nonce] of [[fx.alice, nonceAlice], [fx.bob, nonceBob]] as const) {
+        fx.service.receive(createNonceContributionMessage({
+          from              : p.did,
+          to                : fx.serviceId.did,
+          cohortId          : fx.cohortId,
+          sessionId,
+          nonceContribution : nonce,
+        }));
+      }
+      const aggNonceMsgs = fx.service.sendAggregatedNonce(fx.cohortId);
+      const aggregatedNonce = aggNonceMsgs[0]!.body!.aggregatedNonce as Uint8Array;
+      pAlice.aggregatedNonce = aggregatedNonce;
+      pBob.aggregatedNonce = aggregatedNonce;
+      return { sessionId, pAlice, pBob };
+    }
+
+    function partialMsg(
+      fx: Fixture,
+      from: string,
+      sessionId: string,
+      partialSignature: Uint8Array,
+    ): ReturnType<typeof createSignatureAuthorizationMessage> {
+      return createSignatureAuthorizationMessage({
+        from,
+        to       : fx.serviceId.did,
+        cohortId : fx.cohortId,
+        sessionId,
+        partialSignature,
+      });
+    }
+
+    it('a persistent defector exhausts the blame budget and the cohort escalates to fallback', () => {
+      const fx = driveToCohortSet();
+      const { sessionId, pBob } = driveToAwaitingPartialSigs(fx);
+
+      // Bob contributes a genuine partial once; it is retained across rewinds.
+      const bobPartial = pBob.generatePartialSignature(fx.bob.keys.secretKey.bytes);
+      fx.service.receive(partialMsg(fx, fx.bob.did, sessionId, bobPartial));
+
+      // Alice (the defector) resubmits garbage: blamed and rewound twice, then
+      // treated as a defector - no fourth rewind, no unbounded loop (MS-18).
+      const garbage = randomBytes(32);
+      for(let round = 0; round < 3; round++) {
+        expect(() => fx.service.receive(partialMsg(fx, fx.alice.did, sessionId, garbage))).to.not.throw();
+      }
+
+      const rejections = fx.service.drainRejections(fx.cohortId);
+      const blames = rejections.filter(r => r.code === 'BAD_PARTIAL_SIG');
+      expect(blames).to.have.lengthOf(3);
+      expect(blames.every(r => r.from === fx.alice.did)).to.be.true;
+      expect(blames[2]!.reason).to.match(/defector/);
+
+      // The round is flagged for fallback rather than stalling open-ended.
+      expect(fx.service.isFallbackRequired(fx.cohortId)).to.be.true;
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.AwaitingPartialSigs);
+      expect(fx.service.getResult(fx.cohortId)).to.be.undefined;
+
+      // The deliberate way out engages and clears the flag.
+      const fallbackMsgs = fx.service.startFallbackSigning(fx.cohortId);
+      expect(fallbackMsgs.length).to.be.greaterThan(0);
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.FallbackRequested);
+      expect(fx.service.isFallbackRequired(fx.cohortId)).to.be.false;
+    });
+
+    it('a non-BAD_PARTIAL_SIG session error discards the culprit and never wedges the round', () => {
+      const fx = driveToCohortSet();
+      const { sessionId, pAlice, pBob } = driveToAwaitingPartialSigs(fx);
+      const cohort = fx.service.getCohort(fx.cohortId)!;
+      // Corrupt the cohort view: Bob's accepted key goes missing, so final
+      // aggregation fails with UNKNOWN_PARTICIPANT_KEY (a SigningSessionError
+      // that is not BAD_PARTIAL_SIG) naming Bob.
+      cohort.participantKeys.delete(fx.bob.did);
+
+      const alicePartial = pAlice.generatePartialSignature(fx.alice.keys.secretKey.bytes);
+      const bobPartial = pBob.generatePartialSignature(fx.bob.keys.secretKey.bytes);
+      fx.service.receive(partialMsg(fx, fx.alice.did, sessionId, alicePartial));
+      expect(() => fx.service.receive(partialMsg(fx, fx.bob.did, sessionId, bobPartial))).to.not.throw();
+
+      let rejections = fx.service.drainRejections(fx.cohortId);
+      expect(rejections.map(r => r.code)).to.include('SESSION_ERROR');
+      expect(rejections.find(r => r.code === 'SESSION_ERROR')!.from).to.equal(fx.bob.did);
+      // No wedge: Bob's contribution was discarded and the session rewound.
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.AwaitingPartialSigs);
+      expect(fx.service.getResult(fx.cohortId)).to.be.undefined;
+
+      // Proof the session is not stuck in PartialSignaturesReceived: Alice's
+      // resubmission is a typed DUPLICATE (pre-fix it hit INVALID_PHASE).
+      fx.service.receive(partialMsg(fx, fx.alice.did, sessionId, alicePartial));
+      rejections = fx.service.drainRejections(fx.cohortId);
+      expect(rejections.map(r => r.code)).to.include('DUPLICATE_PARTIAL_SIG');
+
+      // Bob's retries keep failing against the same budget and then escalate.
+      fx.service.receive(partialMsg(fx, fx.bob.did, sessionId, bobPartial));
+      fx.service.receive(partialMsg(fx, fx.bob.did, sessionId, bobPartial));
+      expect(fx.service.isFallbackRequired(fx.cohortId)).to.be.true;
+      expect(fx.service.getCohortPhase(fx.cohortId)).to.equal(ServiceCohortPhase.AwaitingPartialSigs);
+    });
+
+    it('the service runner auto-commits to the fallback path once the blame budget is exhausted', async () => {
+      const bus = new MessageBus();
+      const serviceId = makeIdentity();
+      const serviceTransport = new MockTransport(bus);
+      serviceTransport.registerActor(serviceId.did, serviceId.keys);
+      const runner = new AggregationServiceRunner({
+        transport              : serviceTransport,
+        did                    : serviceId.did,
+        keys                   : serviceId.keys,
+        advertRepeatIntervalMs : 0,
+        onProvideTxData        : async () => { throw new Error('tx data not needed in this test'); },
+      });
+      const { cohortId, completion } = runner.advertiseCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      void completion.catch(() => undefined);
+
+      // Drive the runner's state machine to AwaitingPartialSigs directly.
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      for(const p of [alice, bob]) {
+        runner.session.receive(createCohortOptInMessage({
+          from            : p.did,
+          to              : serviceId.did,
+          cohortId,
+          participantPk   : p.keys.publicKey.compressed,
+          communicationPk : p.keys.publicKey.compressed,
+        }));
+      }
+      runner.session.acceptParticipant(cohortId, alice.did);
+      runner.session.acceptParticipant(cohortId, bob.did);
+      runner.session.finalizeKeygen(cohortId);
+      for(const p of [alice, bob]) {
+        runner.session.receive(createSubmitUpdateMessage({
+          from         : p.did,
+          to           : serviceId.did,
+          cohortId,
+          signedUpdate : createSignedUpdate(p.did, p.keys) as unknown as Record<string, unknown>,
+        }));
+      }
+      runner.session.buildAndDistribute(cohortId);
+      const signalBytesHex = bytesToHex(runner.session.getCohort(cohortId)!.signalBytes!);
+      for(const p of [alice, bob]) {
+        runner.session.receive(createValidationAckMessage({
+          from : p.did, to : serviceId.did, cohortId, approved : true, signalBytesHex,
+        }));
+      }
+      const cohort = runner.session.getCohort(cohortId)!;
+      const script = beaconOutputScript(cohort);
+      const value = 100000n;
+      const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+      tx.addInput({ txid: '11'.repeat(32), index: 0, witnessUtxo: { amount: value, script } });
+      tx.addOutput({ script, amount: value - 500n });
+      runner.session.startSigning(cohortId, { tx, prevOutScripts: [script], prevOutValues: [value] });
+      const sessionId = runner.session.getSigningSessionId(cohortId)!;
+      const mkSession = (): BeaconSigningSession => new BeaconSigningSession({
+        id : sessionId, cohort, pendingTx : tx, prevOutScripts : [script], prevOutValues : [value],
+      });
+      const pAlice = mkSession();
+      const pBob = mkSession();
+      const nonceAlice = pAlice.generateNonceContribution(alice.keys.publicKey.compressed, alice.keys.secretKey.bytes);
+      const nonceBob = pBob.generateNonceContribution(bob.keys.publicKey.compressed, bob.keys.secretKey.bytes);
+      for(const [p, nonce] of [[alice, nonceAlice], [bob, nonceBob]] as const) {
+        runner.session.receive(createNonceContributionMessage({
+          from : p.did, to : serviceId.did, cohortId, sessionId, nonceContribution : nonce,
+        }));
+      }
+      const aggNonceMsgs = runner.session.sendAggregatedNonce(cohortId);
+      pBob.aggregatedNonce = aggNonceMsgs[0]!.body!.aggregatedNonce as Uint8Array;
+
+      // From here on, partial signatures arrive over the bus so the runner's
+      // handlers - and its auto-fallback wiring - execute.
+      const aliceTransport = new MockTransport(bus);
+      aliceTransport.registerActor(alice.did, alice.keys);
+      const bobTransport = new MockTransport(bus);
+      bobTransport.registerActor(bob.did, bob.keys);
+      const fallbackStarted = new Promise<string>(resolve => {
+        runner.once('fallback-started', ({ cohortId: id }) => resolve(id));
+      });
+
+      const bobPartial = pBob.generatePartialSignature(bob.keys.secretKey.bytes);
+      await bobTransport.sendMessage(
+        createSignatureAuthorizationMessage({ from: bob.did, to: serviceId.did, cohortId, sessionId, partialSignature: bobPartial }),
+        bob.did,
+        serviceId.did,
+      );
+      const garbage = randomBytes(32);
+      for(let round = 0; round < 3; round++) {
+        await aliceTransport.sendMessage(
+          createSignatureAuthorizationMessage({ from: alice.did, to: serviceId.did, cohortId, sessionId, partialSignature: garbage }),
+          alice.did,
+          serviceId.did,
+        );
+      }
+
+      const flaggedCohort = await fallbackStarted;
+      expect(flaggedCohort).to.equal(cohortId);
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.FallbackRequested);
+      runner.stop();
+    });
+  });
+
+
   describe('M6: pending opt-ins are bounded per cohort', () => {
     it('drops opt-ins past maxPendingOptIns with OPT_IN_OVERFLOW', () => {
       const serviceId = makeIdentity();
@@ -432,6 +1015,80 @@ describe('Aggregation DoS + liveness hardening', () => {
       expect(rejections).to.have.lengthOf(1);
       expect(rejections[0]!.code).to.equal('OPT_IN_OVERFLOW');
     });
+
+    it('accepted and operator-rejected opt-ins free pending capacity (MS-08)', () => {
+      const serviceId = makeIdentity();
+      const service = new AggregationService({
+        did              : serviceId.did,
+        publicKey        : serviceId.keys.publicKey,
+        maxPendingOptIns : 2,
+      });
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      service.advertise(cohortId);
+      const [a, b, c, d, e] = Array.from({ length: 5 }, () => makeIdentity());
+      const optIn = (p: { keys: SchnorrKeyPair; did: string }): void => {
+        service.receive(createCohortOptInMessage({
+          from            : p.did,
+          to              : serviceId.did,
+          cohortId,
+          participantPk   : p.keys.publicKey.compressed,
+          communicationPk : p.keys.publicKey.compressed,
+        }));
+      };
+      optIn(a);
+      optIn(b);                                   // pending: a, b (at cap)
+      service.acceptParticipant(cohortId, a.did); // accept frees a's slot -> pending: b
+      optIn(c);                                   // admitted -> pending: b, c
+      service.rejectParticipant(cohortId, b.did); // operator reject frees b's slot -> pending: c
+      optIn(d);                                   // admitted -> pending: c, d
+      optIn(e);                                   // genuinely at cap -> overflow
+      expect(service.pendingOptIns(cohortId).size).to.equal(2);
+      expect(service.pendingOptIns(cohortId).has(c.did)).to.be.true;
+      expect(service.pendingOptIns(cohortId).has(d.did)).to.be.true;
+      const rejections = service.drainRejections(cohortId);
+      expect(rejections).to.have.lengthOf(1);
+      expect(rejections[0]!.code).to.equal('OPT_IN_OVERFLOW');
+      expect(rejections[0]!.from).to.equal(e.did);
+    });
+
+    it('acceptParticipant enforces the default participant ceiling when none is advertised (MS-08)', () => {
+      const serviceId = makeIdentity();
+      const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      service.advertise(cohortId);
+      const optInAndAccept = (p: { keys: SchnorrKeyPair; did: string }): void => {
+        service.receive(createCohortOptInMessage({
+          from            : p.did,
+          to              : serviceId.did,
+          cohortId,
+          participantPk   : p.keys.publicKey.compressed,
+          communicationPk : p.keys.publicKey.compressed,
+        }));
+        service.acceptParticipant(cohortId, p.did);
+      };
+      for(let i = 0; i < DEFAULT_MAX_PARTICIPANTS; i++) optInAndAccept(makeIdentity());
+      const extra = makeIdentity();
+      service.receive(createCohortOptInMessage({
+        from            : extra.did,
+        to              : serviceId.did,
+        cohortId,
+        participantPk   : extra.keys.publicKey.compressed,
+        communicationPk : extra.keys.publicKey.compressed,
+      }));
+      expect(() => service.acceptParticipant(cohortId, extra.did)).to.throw(/full/);
+    });
   });
 
   describe('M6: participant cohort-state map is bounded and prunable', () => {
@@ -447,7 +1104,7 @@ describe('Aggregation DoS + liveness hardening', () => {
       communicationPk  : serviceId.keys.publicKey.compressed,
     });
 
-    it('ignores new adverts past maxCohorts', () => {
+    it('at capacity, evicts the oldest Discovered-phase entry to make room (MS-08)', () => {
       const me = makeIdentity();
       const participant = new AggregationParticipant({
         did        : me.did,
@@ -456,9 +1113,36 @@ describe('Aggregation DoS + liveness hardening', () => {
       });
       participant.receive(mkAdvert('c1'));
       participant.receive(mkAdvert('c2'));
+      // At capacity: c1 (the oldest not-yet-joined entry) is evicted for c3,
+      // so an advert flood cannot permanently starve discovery of new cohorts.
       participant.receive(mkAdvert('c3'));
       expect(participant.discoveredCohorts.size).to.equal(2);
-      expect(participant.discoveredCohorts.has('c3')).to.be.false;
+      expect(participant.discoveredCohorts.has('c1')).to.be.false;
+      expect(participant.discoveredCohorts.has('c2')).to.be.true;
+      expect(participant.discoveredCohorts.has('c3')).to.be.true;
+    });
+
+    it('never evicts a joined cohort; drops the new advert when every retained cohort is joined', () => {
+      const me = makeIdentity();
+      const participant = new AggregationParticipant({
+        did        : me.did,
+        signer     : new KeyPairAggregationSigner(me.keys),
+        maxCohorts : 2,
+      });
+      participant.receive(mkAdvert('c1'));
+      participant.receive(mkAdvert('c2'));
+      participant.joinCohort('c1');
+      // c2 is the only Discovered entry: evicted for c3; the joined c1 survives.
+      participant.receive(mkAdvert('c3'));
+      expect(participant.getCohortPhase('c1')).to.equal(ParticipantCohortPhase.OptedIn);
+      expect(participant.discoveredCohorts.has('c2')).to.be.false;
+      expect(participant.discoveredCohorts.has('c3')).to.be.true;
+      // With every retained cohort joined, a new advert is still dropped.
+      participant.joinCohort('c3');
+      participant.receive(mkAdvert('c4'));
+      expect(participant.getCohortPhase('c4')).to.be.undefined;
+      expect(participant.getCohortPhase('c1')).to.equal(ParticipantCohortPhase.OptedIn);
+      expect(participant.getCohortPhase('c3')).to.equal(ParticipantCohortPhase.OptedIn);
     });
 
     it('leaveCohort frees capacity and is a no-op for unknown cohorts', () => {
@@ -476,6 +1160,100 @@ describe('Aggregation DoS + liveness hardening', () => {
       expect(participant.discoveredCohorts.size).to.equal(2);
       expect(participant.discoveredCohorts.has('c3')).to.be.true;
       expect(participant.discoveredCohorts.has('c1')).to.be.false;
+    });
+  });
+
+  describe('MS-08: participant runner reclaims cohort-state slots', () => {
+    it('drops the cohort state when shouldJoin rejects the advert', async () => {
+      const bus = new MessageBus();
+      const service = makeServiceRunner(bus);
+      const participant = makeParticipantRunner(bus, { shouldJoin: async () => false });
+      await participant.start();
+      const { cohortId, completion } = service.advertiseCohort(CAS_CONFIG());
+      void completion.catch(() => undefined);
+      // Let the advert propagate and the async shouldJoin decision land.
+      await new Promise(resolve => setTimeout(resolve, 25));
+      expect(participant.session.getCohortPhase(cohortId), 'rejected advert leaves no cohort state').to.be.undefined;
+      expect(participant.session.discoveredCohorts.size).to.equal(0);
+      participant.stop();
+      service.stop();
+    });
+
+    it('drops the cohort state once the cohort completes', async () => {
+      const bus = new MessageBus();
+      const service = makeServiceRunner(bus);
+      const participant = makeParticipantRunner(bus);
+      await participant.start();
+      const completed = new Promise<void>(resolve => participant.once('cohort-complete', () => resolve()));
+      const { cohortId } = service.advertiseCohort(CAS_CONFIG());
+      await completed;
+      // leaveCohort runs synchronously after the cohort-complete emission.
+      expect(participant.session.getCohortPhase(cohortId), 'completed cohort state reclaimed').to.be.undefined;
+      participant.stop();
+      service.stop();
+    });
+
+    it('drops the cohort state when the member rejects the aggregated data', async () => {
+      const bus = new MessageBus();
+      const service = makeServiceRunner(bus);
+      const participant = makeParticipantRunner(bus, { onValidateData: async () => ({ approved: false }) });
+      await participant.start();
+      const failed = new Promise<void>(resolve => participant.once('cohort-failed', () => resolve()));
+      const { cohortId, completion } = service.advertiseCohort(CAS_CONFIG());
+      void completion.catch(() => undefined);
+      await failed;
+      // leaveCohort runs synchronously after the cohort-failed emission.
+      expect(participant.session.getCohortPhase(cohortId), 'failed cohort state reclaimed').to.be.undefined;
+      participant.stop();
+      service.stop();
+    });
+  });
+
+  describe('MS-08: participant runner forwards bounds to the state machine', () => {
+    const svc = makeIdentity();
+    const mkAdvert = (cohortId: string): ReturnType<typeof createCohortAdvertMessage> => createCohortAdvertMessage({
+      from             : svc.did,
+      cohortId,
+      network          : 'mutinynet',
+      minParticipants  : 2,
+      beaconType       : 'CASBeacon',
+      recoveryKey      : TEST_RECOVERY_KEY,
+      recoverySequence : TEST_RECOVERY_SEQUENCE,
+      communicationPk  : svc.keys.publicKey.compressed,
+    });
+
+    it('forwards maxCohorts', () => {
+      const me = makeIdentity();
+      const transport = new MockTransport(new MessageBus());
+      transport.registerActor(me.did, me.keys);
+      const runner = new AggregationParticipantRunner({
+        transport,
+        did             : me.did,
+        keys            : me.keys,
+        maxCohorts      : 1,
+        onProvideUpdate : async () => null,
+      });
+      runner.session.receive(mkAdvert('c1'));
+      runner.session.receive(mkAdvert('c2'));
+      expect(runner.session.discoveredCohorts.size).to.equal(1);
+      expect(runner.session.discoveredCohorts.has('c2'), 'oldest Discovered evicted').to.be.true;
+      runner.stop();
+    });
+
+    it('forwards maxFeeSats (the member refuses a fee above the ceiling)', async () => {
+      const bus = new MessageBus();
+      const service = makeServiceRunner(bus, { phaseTimeoutMs: 5_000 });
+      // The dummy tx pays a 500-sat fee; cap the member at 100 sats.
+      const participant = makeParticipantRunner(bus, { maxFeeSats: 100n });
+      await participant.start();
+      const feeError = new Promise<Error>(resolve => participant.on('error', e => {
+        if((e as { type?: string }).type === 'FEE_TOO_HIGH') resolve(e);
+      }));
+      const { completion } = service.advertiseCohort(CAS_CONFIG());
+      void completion.catch(() => undefined);
+      await feeError;
+      participant.stop();
+      service.stop();
     });
   });
 
@@ -506,18 +1284,23 @@ describe('Aggregation DoS + liveness hardening', () => {
   });
 
   describe('L18: nonce cache per-DID buckets + timestamp expiry', () => {
-    it('a flooding DID evicts only its own entries, never another DID\'s live entries', () => {
+    it('a flooding DID is refused past its own bucket; no DID evicts another\'s live entries', () => {
       const cache = new NonceCache({ maxPerDid: 2, maxEntries: 100, nowSec: () => 1000 });
       cache.store('victim', 'v1', 1000);
       cache.store('victim', 'v2', 1000);
-      // Flooder churns well past its per-DID cap.
-      for(let i = 0; i < 10; i++) cache.store('flooder', `f${i}`, 1000);
+      // Flooder churns well past its per-DID cap: the first two admissions
+      // succeed, the rest are refused (fail-closed) rather than evicting live
+      // entries (audit MS-10).
+      const admissions: boolean[] = [];
+      for(let i = 0; i < 10; i++) admissions.push(cache.store('flooder', `f${i}`, 1000));
+      expect(admissions.slice(0, 2)).to.deep.equal([true, true]);
+      expect(admissions.slice(2).every(a => !a), 'past-cap admissions refused').to.be.true;
       // Victim entries survive; their replay protection is intact.
       expect(cache.store('victim', 'v1', 1000)).to.be.false;
       expect(cache.store('victim', 'v2', 1000)).to.be.false;
-      // Flooder retained only its most recent 2.
-      expect(cache.store('flooder', 'f0', 1000), 'oldest flooder entry evicted').to.be.true;
-      expect(cache.store('flooder', 'f9', 1000), 'newest flooder entry retained').to.be.false;
+      // The flooder's own live entries were never evicted either.
+      expect(cache.store('flooder', 'f0', 1000), 'flooder entry retained').to.be.false;
+      expect(cache.store('flooder', 'f1', 1000), 'flooder entry retained').to.be.false;
     });
 
     it('expired entries are purged before any live entry is evicted under global pressure', () => {
@@ -529,16 +1312,18 @@ describe('Aggregation DoS + liveness hardening', () => {
       expect(cache.size()).to.equal(2);
     });
 
-    it('global FIFO backstop still applies when nothing is expired', () => {
+    it('new admissions are rejected at maxEntries when nothing is expired (never evict live entries)', () => {
       const cache = new NonceCache({ maxEntries: 2, windowSec: 10_000, nowSec: () => 1000 });
-      cache.store('a', 'n1', 1000);
-      cache.store('b', 'n2', 1000);
-      cache.store('c', 'n3', 1000);
+      expect(cache.store('a', 'n1', 1000)).to.be.true;
+      expect(cache.store('b', 'n2', 1000)).to.be.true;
+      // Full of live in-window entries: the novel admission is refused
+      // (fail-closed) instead of evicting a victim's entry and reopening its
+      // replay window (audit MS-10).
+      expect(cache.store('c', 'n3', 1000)).to.be.false;
       expect(cache.size()).to.equal(2);
-      // Check retention BEFORE probing the evicted entry: a replay probe
-      // re-inserts and would itself force an eviction.
+      // Both live entries retain their replay protection.
+      expect(cache.store('a', 'n1', 1000), 'oldest entry retained').to.be.false;
       expect(cache.store('b', 'n2', 1000), 'younger entry retained').to.be.false;
-      expect(cache.store('a', 'n1', 1000), 'oldest entry was evicted').to.be.true;
     });
   });
 

--- a/packages/aggregation/tests/aggregation-http-envelope.spec.ts
+++ b/packages/aggregation/tests/aggregation-http-envelope.spec.ts
@@ -2,6 +2,7 @@ import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { expect } from 'chai';
 
 import {
+  AGGREGATION_WIRE_VERSION,
   BaseMessage,
   COHORT_ADVERT,
   COHORT_OPT_IN,
@@ -72,12 +73,12 @@ describe('HTTP transport envelope', () => {
 
       // Plain record, no class-instance methods leaked onto the wire shape.
       expect(env.message).to.not.have.property('toJSON');
-      expect(env.message.version).to.equal(1);
+      expect(env.message.version).to.equal(AGGREGATION_WIRE_VERSION);
     });
 
     it('accepts a plain record as the message payload', () => {
       const env = signEnvelope(
-        { type: COHORT_ADVERT, from: senderDid, version: 1 },
+        { type: COHORT_ADVERT, from: senderDid, version: AGGREGATION_WIRE_VERSION },
         { did: senderDid, keys: senderKeys },
       );
 

--- a/packages/aggregation/tests/aggregation-http-nonce-cache.spec.ts
+++ b/packages/aggregation/tests/aggregation-http-nonce-cache.spec.ts
@@ -26,19 +26,19 @@ describe('HTTP transport nonce cache', () => {
     expect(cache.store('did:btcr2:k.a', 'n2', 1000)).to.be.true;
   });
 
-  it('evicts the oldest entry past maxEntries (FIFO backstop)', () => {
+  it('rejects new admissions past maxEntries when nothing is expired (never evicts live entries)', () => {
     // Pin the clock near the test timestamps so nothing falls outside the
-    // expiry window: this exercises the global oldest-first backstop, which now
-    // runs only after expiry and per-DID eviction find nothing to reclaim.
+    // expiry window: at capacity the cache fails closed (refuses the new
+    // admission) rather than evicting a live in-window entry and reopening its
+    // replay window (audit MS-10).
     const cache = new NonceCache({ maxEntries: 3, windowSec: 10_000, nowSec: () => 10 });
     cache.store('d', 'a', 1);
     cache.store('d', 'b', 2);
     cache.store('d', 'c', 3);
-    cache.store('d', 'e', 4); // forces eviction of 'a', cache is now [b, c, e]
+    expect(cache.store('d', 'e', 4), 'novel admission refused at capacity').to.be.false;
     expect(cache.size()).to.equal(3);
-    // 'a' was evicted; replaying it now succeeds (and evicts 'b' as the new oldest).
-    expect(cache.store('d', 'a', 5)).to.be.true;
-    // 'c' is still present, replay rejected.
+    // Every live entry retained its replay protection.
+    expect(cache.store('d', 'a', 5)).to.be.false;
     expect(cache.store('d', 'c', 5)).to.be.false;
   });
 


### PR DESCRIPTION
* fix(aggregation-service): shape guards, opt-in validation and pruning, participant ceiling, bounded blame retry (audit H6, M6; review MS-02, MS-08, MS-18)
* fix(aggregation): nonce point and partial-sig validation, fail-closed nonce cache after rate limiting, wire version 2 (audit H6, L18; review MS-02, MS-10, MS-44)
* fix(aggregation-participant): Discovered-phase eviction, leaveCohort wiring, runner option forwarding (audit M6; review MS-08)
* test(aggregation): cohort-kill vectors, blame-loop fallback, cache eviction, missing H7/H8 guard cases (review MS-47.2, MS-47.3, MS-47.7)