### PR TITLE
confirm exact broadcast fees and harden cli credential handling

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -11,7 +11,7 @@ import { CryptoApi } from './crypto.js';
 import { DidApi } from './did.js';
 import { assertString, NOOP_LOGGER } from './helpers.js';
 import { KeyManagerApi } from './key-manager.js';
-import { DidMethodApi, type DidUpdateResult, type PublishToCasMode } from './method.js';
+import { DidMethodApi, type BuiltBroadcastTx, type DidUpdateResult, type PublishToCasMode } from './method.js';
 import type { ApiConfig, BitcoinApiConfig, Logger, ResolutionResult } from './types.js';
 
 /**
@@ -214,6 +214,7 @@ export class DidBtcr2Api {
     sourceVersionId,
     publishToCas,
     broadcastOptions,
+    confirmBroadcast,
   }: {
     did: string;
     patches: PatchOperation[];
@@ -224,6 +225,7 @@ export class DidBtcr2Api {
     sourceVersionId?: number;
     publishToCas?: PublishToCasMode;
     broadcastOptions?: BroadcastOptions;
+    confirmBroadcast?: (tx: BuiltBroadcastTx) => void | Promise<void>;
   }): Promise<DidUpdateResult> {
     this.#assertNotDisposed();
     assertString(did, 'did');
@@ -281,6 +283,7 @@ export class DidBtcr2Api {
       signer,
       publishToCas,
       broadcastOptions,
+      confirmBroadcast,
     });
   }
 

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -30,6 +30,22 @@ import type { Logger } from './types.js';
 export type PublishToCasMode = 'auto' | 'always' | 'never';
 
 /**
+ * The built beacon signal transaction, presented to the `confirmBroadcast`
+ * callback during {@link DidMethodApi.update} after the transaction is built
+ * and before it is signed and broadcast. The fee is the exact amount the built
+ * transaction pays, not an estimate.
+ * @public
+ */
+export interface BuiltBroadcastTx {
+  /** The beacon service id whose address funds the transaction. */
+  beaconId: string;
+  /** The exact fee (sats) the built transaction pays (input value minus outputs). */
+  feeSats: bigint;
+  /** The vsize (vbytes) the fee was computed from; the signed transaction is this or smaller. */
+  vsize: number;
+}
+
+/**
  * Result of {@link DidMethodApi.update}: the signed update plus every broadcast
  * artifact a resolver (or a sidecar distributor) needs afterwards.
  * @public
@@ -236,8 +252,10 @@ export class DidMethodApi {
    *   announcement) to the configured CAS per the `publishToCas` policy,
    *   **before** the on-chain broadcast, so any OP_RETURN update hash is
    *   fetchable from CAS at resolution time without sidecar data.
-   * - Broadcast: establishes a beacon via {@link BeaconFactory} and calls
-   *   `broadcastSignal()` with the bitcoin connection configured on the API.
+   * - Broadcast: establishes a beacon via {@link BeaconFactory}, builds the
+   *   signal transaction, invokes the optional `confirmBroadcast` callback with
+   *   the built transaction's exact fee, then signs and broadcasts with the
+   *   bitcoin connection configured on the API.
    *
    * For multi-party aggregation of SMT/CAS beacons, the caller should drive the
    * Updater directly and delegate `NeedBroadcast` to the aggregation runner
@@ -257,6 +275,7 @@ export class DidMethodApi {
     bitcoin,
     publishToCas = 'never',
     broadcastOptions,
+    confirmBroadcast,
   }: {
     sourceDocument: Btcr2DidDocument;
     patches: PatchOperation[];
@@ -267,6 +286,13 @@ export class DidMethodApi {
     bitcoin?: BitcoinConnection;
     publishToCas?: PublishToCasMode;
     broadcastOptions?: BroadcastOptions;
+    /**
+     * Called once the beacon transaction is built and before it is signed and
+     * broadcast, with the exact fee and size of the built transaction. Throw
+     * (or return a rejected promise) to abort: the beacon UTXO stays unspent.
+     * When omitted, the broadcast proceeds without confirmation.
+     */
+    confirmBroadcast?: (tx: BuiltBroadcastTx) => void | Promise<void>;
   }): Promise<DidUpdateResult> {
     // Bitcoin connection resolution order: per-call `bitcoin` param wins over the
     // BitcoinApi injected at DidBtcr2Api construction time. One of the two must
@@ -359,9 +385,16 @@ export class DidMethodApi {
               'Broadcasting signed update via %s beacon', need.beaconService.type
             );
             const beacon = BeaconFactory.establish(need.beaconService);
-            broadcastResult = await beacon.broadcastSignal(
+            // Build first, then let the caller confirm the exact fee of the
+            // built transaction, then sign and send. A confirmation abort leaves
+            // the beacon UTXO unspent.
+            const prepared = await beacon.prepareBroadcast(
               need.signedUpdate, signer, btcConnection, options
             );
+            if(confirmBroadcast) {
+              await confirmBroadcast({ beaconId, feeSats: prepared.feeSats, vsize: prepared.vsize });
+            }
+            broadcastResult = await prepared.broadcast();
             updater.provide(need);
             break;
           }
@@ -489,6 +522,7 @@ export class UpdateBuilder {
   #bitcoin?: BitcoinConnection;
   #publishToCas?: PublishToCasMode;
   #broadcastOptions?: BroadcastOptions;
+  #confirmBroadcast?: (tx: BuiltBroadcastTx) => void | Promise<void>;
 
   /** @internal */
   constructor(methodApi: DidMethodApi, sourceDocument: Btcr2DidDocument) {
@@ -557,6 +591,15 @@ export class UpdateBuilder {
   }
 
   /**
+   * Set a confirmation callback invoked with the built beacon transaction's
+   * exact fee and size before signing and broadcast. Throw to abort.
+   */
+  confirmBroadcast(callback: (tx: BuiltBroadcastTx) => void | Promise<void>): this {
+    this.#confirmBroadcast = callback;
+    return this;
+  }
+
+  /**
    * Execute the update.
    * @throws {Error} If required fields (version, verificationMethodId, beacon, signer) are missing.
    */
@@ -587,6 +630,7 @@ export class UpdateBuilder {
       bitcoin              : this.#bitcoin,
       publishToCas         : this.#publishToCas,
       broadcastOptions     : this.#broadcastOptions,
+      confirmBroadcast     : this.#confirmBroadcast,
     });
   }
 }

--- a/packages/cli/docs/config.md
+++ b/packages/cli/docs/config.md
@@ -172,6 +172,18 @@ Resolution notes:
 - An RPC password given as a secret reference (`env:<VAR>` or `file:<path>`, via flag,
   environment variable, or profile) is resolved to its literal value; a password taken from the file named by
   `BTCR2_BTC_RPC_PASS_FILE` reports `source: "env"`.
+  - An `env:` reference naming a variable that is not set **throws** (`CONFIG_READ_ERROR`)
+    rather than resolving to nothing, so a networked command (one that resolves an RPC host)
+    fails fast naming the variable instead of surfacing later as an opaque RPC auth failure.
+    Offline commands (create, key management) never resolve a connection and are unaffected.
+  - The `env:` and `file:` prefixes are reserved: a value starting with either is ALWAYS treated
+    as a reference and there is no escape syntax, so a literal password cannot begin with `env:`
+    or `file:`. If a real password starts with one of those prefixes, store it in a file and use
+    a `file:<path>` reference (the file's contents are used verbatim).
+  - A `file:` reference, and the file named by `BTCR2_BTC_RPC_PASS_FILE`, must satisfy the
+    shared secret-file permission policy: mode `0600`, `0400`, `0440`, or `0640` (owner
+    read/write, group read at most, no access for others, no execute bits). Anything
+    group/world-writable or more open is rejected. Not enforceable on Windows.
 - `default`-sourced endpoint values are the SDK per-network defaults: REST
   `https://mempool.space/api` (bitcoin), `https://mempool.space/testnet/api` (testnet3),
   `https://mempool.space/testnet4/api` (testnet4), `https://mempool.space/signet/api` (signet),
@@ -226,7 +238,9 @@ writes or broadcasts. Each probe has a 5000 ms timeout. Checks performed:
   `https://ipfs.io`).
 
 Prints `{ "checks": [ { "endpoint", "target", "ok", "detail"? }, ... ] }` where `detail` carries
-the HTTP status or error message for a failed check. When the active profile declares a network
+the HTTP status or error message for a failed check. Credentials embedded in endpoint URLs
+(`scheme://user:pass@host`) are masked as `********` in both `target` and `detail`, matching the
+redaction `config get`/`list`/`effective` apply. When the active profile declares a network
 different from the one being probed, a `coherence` object
 (`{ "profile", "declared", "encoding" }`) is included. Exit code is 1 when any check fails.
 
@@ -264,8 +278,8 @@ Environment variables consulted:
 | `BTCR2_BTC_REST` | `effective`, `doctor` | Bitcoin REST endpoint override (as `--btc-rest`). |
 | `BTCR2_BTC_RPC_URL` | `effective`, `doctor` | Bitcoin Core RPC endpoint override (as `--btc-rpc-url`). |
 | `BTCR2_BTC_RPC_USER` | `effective`, `doctor` | RPC username (as `--btc-rpc-user`). |
-| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (as `--btc-rpc-pass`; accepts `env:<VAR>` / `file:<path>` secret references). |
-| `BTCR2_BTC_RPC_PASS_FILE` | `effective`, `doctor` | Path to a file whose contents are the RPC password; consulted only when no layer supplies a password and an RPC config is being built. |
+| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (as `--btc-rpc-pass`; accepts `env:<VAR>` / `file:<path>` secret references). Ignored (with a stderr warning) when a flag or profile layer supplies the RPC url or user, because credentials resolve as one atomic unit per layer. |
+| `BTCR2_BTC_RPC_PASS_FILE` | `effective`, `doctor` | Path to a file whose contents are the RPC password; consulted only when no layer supplies a password and an RPC config is being built. Subject to the secret-file permission policy (0600/0400/0440/0640). |
 | `BTCR2_CAS_GATEWAY` | `effective`, `doctor` | IPFS HTTP gateway for CAS reads (as `--cas-gateway`). |
 | `BTCR2_CAS_RPC_URL` | `effective`, `doctor` | IPFS HTTP RPC endpoint for a writable CAS (as `--cas-rpc-url`). |
 | `BTCR2_BTC_TIMEOUT` | `effective`, `doctor` | Bitcoin request timeout in ms, >= 1 (as `--btc-timeout`). |

--- a/packages/cli/docs/deactivate.md
+++ b/packages/cli/docs/deactivate.md
@@ -48,6 +48,11 @@ Notes on behavior not visible in `--help`:
 - Funding prerequisite: the beacon address must hold at least one spendable UTXO. An unfunded
   address aborts with `Beacon address <addr> is unfunded. Send BTC to this address before
   broadcasting the update.` after signing but before any coins move.
+- Broadcast confirmation: on every network except regtest, the beacon transaction is built first
+  and the operator must confirm it. The prompt shows the DID, network, beacon, the exact fee of
+  the built transaction, and a permanence warning; only `yes` proceeds. Declining, or a
+  non-interactive invocation without `-y/--yes`, aborts before the transaction is signed or
+  broadcast; the beacon UTXO stays unspent.
 - CAS publication (when enabled) happens before the on-chain broadcast, so a CAS failure aborts
   while the beacon UTXO is still intact; content addressing makes a retry idempotent.
 

--- a/packages/cli/docs/key.md
+++ b/packages/cli/docs/key.md
@@ -87,7 +87,10 @@ fails with `Provide exactly one of --secret-file or --public.`
 
 - `--secret-file <path>`: the file's contents (surrounding whitespace ignored) must be the hex
   encoding of a 32-byte secret key (64 hex chars). Unreadable file, invalid hex, or a wrong length
-  each fail with a specific message. The secret is sealed into the keystore, which requires the
+  each fail with a specific message. The file must satisfy the shared secret-file permission
+  policy: mode `0600`, `0400`, `0440`, or `0640` (owner read/write, group read at most, no access
+  for others, no execute bits); anything group/world-writable or more open is rejected (not
+  enforceable on Windows). The secret is sealed into the keystore, which requires the
   passphrase on an encrypted keystore (and establishes it, with confirmation, on a fresh one).
 - `--public <hex>`: a 33-byte compressed secp256k1 public key as 66 hex chars, imported watch-only
   (no secret stored). Watch-only import never prompts for a passphrase.

--- a/packages/cli/docs/keystore.md
+++ b/packages/cli/docs/keystore.md
@@ -229,6 +229,12 @@ bound to a different keystore is left in place. A `bitcoin` operation never cons
 that was not unlocked with `--allow-mainnet`. The passphrase-establishing path (a fresh keystore's
 first seal) never consults the session.
 
+Every file a secret is read from (the keystore, the session file, a `--passphrase-file`, a
+`key import --secret-file`, an RPC-password file) must satisfy one shared permission policy:
+mode `0600`, `0400`, `0440`, or `0640` (owner read/write, group read at most, no access for
+others, no execute bits). Anything group/world-writable or more open is rejected (POSIX only;
+mode bits are not enforceable on Windows).
+
 ## Global options
 
 Shared global flags are documented in the [docs README](./README.md#global-options). Globals this command notably

--- a/packages/cli/docs/update.md
+++ b/packages/cli/docs/update.md
@@ -50,6 +50,11 @@ go before the `update` keyword.
 - **Funding checkpoint.** Before broadcasting, the beacon address is checked for spendable UTXOs
   via the Bitcoin REST endpoint. An unfunded beacon aborts after signing but before any spend:
   `Beacon address ... is unfunded. Send BTC to this address before broadcasting the update.`
+- **Broadcast confirmation.** On every network except regtest, the beacon transaction is built
+  first and the operator must confirm it: the prompt shows the DID, network, beacon, and the
+  exact fee (in sats and BTC) of the built transaction, and only `yes` proceeds. Declining, or a
+  non-interactive invocation without `-y/--yes`, aborts before the transaction is signed or
+  broadcast; the beacon UTXO stays unspent.
 - **CAS-before-chain ordering.** Under `auto`/`always` with a writable CAS, the signed update
   (and, for CAS beacons, the announcement) is published to CAS before the transaction broadcast,
   so a CAS failure aborts while the beacon UTXO is intact and a retry is idempotent.

--- a/packages/cli/src/commands/deactivate.ts
+++ b/packages/cli/src/commands/deactivate.ts
@@ -3,7 +3,7 @@ import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
-import { confirmBroadcast, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
+import { broadcastConfirmer, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
 import { CLIError } from '../error.js';
 import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
@@ -109,11 +109,12 @@ export function registerDeactivateCommand(
         feeRate       : options.feeRate,
         changeAddress : options.changeAddress,
       });
-      // Deactivation is irreversible and spends the beacon UTXO on-chain:
-      // require explicit operator confirmation unless --yes was given.
-      // Skipped on regtest.
+      // Deactivation is irreversible and spends the beacon UTXO on-chain: the
+      // SDK builds the beacon transaction first, then this callback displays
+      // the exact fee of the built transaction and requires explicit operator
+      // confirmation, unless --yes was given. Skipped on regtest.
       const feeEstimator = broadcastOptions?.feeEstimator;
-      confirmBroadcast({
+      const confirmBroadcast = broadcastConfirmer({
         action              : 'deactivate',
         did,
         network,
@@ -136,6 +137,7 @@ export function registerDeactivateCommand(
         beaconId             : parsed.beaconId,
         signer,
         publishToCas         : options.publishToCas,
+        confirmBroadcast,
         ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'deactivate', data }, globals()));

--- a/packages/cli/src/commands/key.ts
+++ b/packages/cli/src/commands/key.ts
@@ -5,6 +5,7 @@ import type { Command } from 'commander';
 import { closeSync, openSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import type { ApiFactory } from '../config.js';
 import { CLIError } from '../error.js';
+import { isSecretFileModeAllowed } from '../keystore/atomic.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
 import { formatResult } from '../output.js';
 import type { CommandResult, GlobalOptions } from '../types.js';
@@ -162,15 +163,14 @@ function parseHex(hex: string, expectedBytes: number, label: string): Uint8Array
 function readHexFile(path: string, expectedBytes: number, label: string): Uint8Array {
   let content: string;
   try {
-    // The file holds raw secret key material: refuse to read it when group or
-    // other users have any permission bits (0600/0400 only), matching the
-    // keystore's permission policy. Not enforceable on Windows.
+    // The file holds raw secret key material: enforce the shared secret-file
+    // permission policy (0600/0400/0440/0640). Not enforceable on Windows.
     if (process.platform !== 'win32') {
       const mode = statSync(path).mode & 0o777;
-      if ((mode & 0o077) !== 0) {
+      if (!isSecretFileModeAllowed(mode)) {
         throw new CLIError(
-          `Refusing to read ${label} at ${path}: permissions 0${mode.toString(8)} are too open; expected 0600. `
-          + `Fix with: chmod 600 ${path}`,
+          `Refusing to read ${label} at ${path}: permissions 0${mode.toString(8)} are too open; `
+          + `expected one of 0600, 0400, 0440, 0640. Fix with: chmod 600 ${path}`,
           'INVALID_ARGUMENT_ERROR',
           { label, path, mode: `0${mode.toString(8)}` },
         );

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -3,7 +3,7 @@ import { KeyManagerSigner } from '@did-btcr2/key-manager';
 import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { Command } from 'commander';
 import { assertKeystoreAllowedForNetwork, deriveNetwork, resolveBroadcastOptions, resolveSigningKeyRef, type ApiFactory } from '../config.js';
-import { confirmBroadcast, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
+import { broadcastConfirmer, DEFAULT_FEE_RATE_SATS_PER_VBYTE } from '../confirm.js';
 import { CLIError } from '../error.js';
 import { printWatchHint } from '../hints.js';
 import { resolveKeyRef } from '../keystore/resolve-key-ref.js';
@@ -109,11 +109,13 @@ export function registerUpdateCommand(
         feeRate       : options.feeRate,
         changeAddress : options.changeAddress,
       });
-      // On-chain spends require explicit operator confirmation: show the plan
-      // (including the estimated absolute fee) and prompt, unless --yes was
-      // given. Skipped on regtest.
+      // On-chain spends require explicit operator confirmation: the SDK builds
+      // the beacon transaction first, then this callback displays the exact fee
+      // of the built transaction and prompts, unless --yes was given. Skipped
+      // on regtest. Declining (or a missing confirmation channel) aborts before
+      // anything is signed or broadcast.
       const feeEstimator = broadcastOptions?.feeEstimator;
-      confirmBroadcast({
+      const confirmBroadcast = broadcastConfirmer({
         action              : 'update',
         did,
         network,
@@ -136,6 +138,7 @@ export function registerUpdateCommand(
         beaconId             : parsed.beaconId,
         signer,
         publishToCas         : options.publishToCas,
+        confirmBroadcast,
         ...(broadcastOptions ? { broadcastOptions } : {}),
       });
       console.log(formatResult({ action: 'update', data }, globals()));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,16 +2,17 @@ import { createApi, DEFAULT_BITCOIN_NETWORK_CONFIG, DEFAULT_CAS_GATEWAY, Identif
 import type { KeyManager } from '@did-btcr2/key-manager';
 import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { BroadcastOptions } from '@did-btcr2/method';
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { CLIError } from './error.js';
 import { MAX_FEE_RATE_SATS_PER_VBYTE } from './confirm.js';
-import { ensureDir, writeFileAtomic } from './keystore/atomic.js';
+import { ensureDir, isSecretFileModeAllowed, writeFileAtomic } from './keystore/atomic.js';
 import { FileBackedKeyManager } from './keystore/file-backed-key-manager.js';
 import { keystoreProtection, keystoreVerifierId } from './keystore/file-key-store.js';
 import { defaultKeystorePath } from './keystore/paths.js';
 import { acquirePassphrase } from './keystore/passphrase.js';
 import { readLiveSessionPassphrase } from './keystore/session.js';
+import { scrubUrlUserinfo, REDACTED } from './output.js';
 import { defaultConfigPath, defaultSessionPath } from './paths.js';
 import { blankToUndef, SUPPORTED_NETWORKS, type KeystoreProtectionLabel, type NetworkOption, type OutputFormat } from './types.js';
 
@@ -643,6 +644,16 @@ export function resolveConnectionConfig(
   const wantsRpc = rpcUnit !== undefined || rpcWallet !== undefined || rpcHeaders !== undefined;
   const hasRpcHost = rpcUnit?.url !== undefined || networkHasDefaultRpc;
   if (wantsRpc && hasRpcHost) {
+    // The credential unit is atomic: when a flag or profile layer supplies the
+    // RPC url (or user), a password from BTCR2_BTC_RPC_PASS is NOT merged across
+    // layers. Say so; a silently dropped password would otherwise surface later
+    // as an opaque RPC auth failure.
+    if (blankToUndef(env.btcRpcPass) !== undefined && rpcUnit !== undefined && rpcUnit.src !== 'env') {
+      console.error(
+        `Warning: ${ENV_VARS.BTC_RPC_PASS} is set, but the RPC credentials were resolved from the `
+        + `${rpcUnit.src} layer; the environment password is ignored.`,
+      );
+    }
     const password = resolveSecretRef(rpcUnit?.pass) ?? readRpcPassFile();
     btc.rpc = {
       ...(rpcUnit?.url  !== undefined ? { host: rpcUnit.url } : {}),
@@ -749,8 +760,23 @@ function trimTrailingNewline(value: string): string {
 /** Reads a secret file, throwing a {@link CLIError} (not a raw Node error) that names the path and source. */
 function readSecretFile(path: string, source: string): string {
   try {
+    // The file holds a cleartext secret: enforce the shared secret-file
+    // permission policy (0600/0400/0440/0640) before reading it. Not
+    // enforceable on Windows.
+    if (process.platform !== 'win32') {
+      const mode = statSync(path).mode & 0o777;
+      if (!isSecretFileModeAllowed(mode)) {
+        throw new CLIError(
+          `Refusing to read the RPC password ${source} at ${path}: permissions 0${mode.toString(8)} are too open; `
+          + `expected one of 0600, 0400, 0440, 0640. Fix with: chmod 600 ${path}`,
+          'CONFIG_READ_ERROR',
+          { path, mode: `0${mode.toString(8)}` },
+        );
+      }
+    }
     return trimTrailingNewline(readFileSync(path, 'utf-8'));
   } catch (error: unknown) {
+    if (error instanceof CLIError) throw error;
     throw new CLIError(
       `Could not read the RPC password ${source} at ${path}: ${(error as Error).message}`,
       'CONFIG_READ_ERROR',
@@ -957,6 +983,15 @@ export interface DoctorReport {
 /** Default per-probe timeout (ms) for `config doctor`. */
 const DOCTOR_PROBE_TIMEOUT_MS = 5000;
 
+/**
+ * Masks `user:pass@` userinfo anywhere in a string. Probe error messages can
+ * echo the full request URL (including embedded credentials), so details are
+ * scrubbed before they reach the doctor report.
+ */
+function scrubUserinfoInText(text: string): string {
+  return text.replace(/([a-z][a-z0-9+.-]*:\/\/[^/@\s:]+):[^/@\s]*@/gi, `$1:${REDACTED}@`);
+}
+
 /** Fetches a URL with a bounded timeout, reporting reachability rather than throwing. */
 async function probeEndpoint(
   endpoint : DoctorCheck['endpoint'],
@@ -974,7 +1009,7 @@ async function probeEndpoint(
       ? { endpoint, target, ok: true }
       : { endpoint, target, ok: false, detail: `HTTP ${res.status}` };
   } catch (error) {
-    return { endpoint, target, ok: false, detail: (error as Error).message };
+    return { endpoint, target, ok: false, detail: scrubUserinfoInText((error as Error).message) };
   }
 }
 
@@ -998,17 +1033,22 @@ export async function runDoctor(network: NetworkOption, overrides?: ConnectionOv
   const api = defaultApiFactory(network, overrides);
   const checks: DoctorCheck[] = [];
 
+  // Targets are printed verbatim in the report, so scrub any userinfo embedded
+  // in the endpoint URLs (the probes themselves still use the full URL).
   const restHost = api.btc.connection.rest.config.host.replace(/\/+$/, '');
-  checks.push(await probeEndpoint('btc-rest', restHost, `${restHost}/blocks/tip/height`, { headers: api.btc.connection.rest.config.headers }));
+  checks.push(await probeEndpoint(
+    'btc-rest', scrubUrlUserinfo(restHost)!, `${restHost}/blocks/tip/height`,
+    { headers: api.btc.connection.rest.config.headers },
+  ));
 
   const rpc = api.btc.connection.rpc;
   if (rpc) {
-    const target = rpc.config.host ?? '(default rpc)';
+    const target = scrubUrlUserinfo(rpc.config.host) ?? '(default rpc)';
     try {
       await withProbeTimeout(rpc.getBlockchainInfo(), DOCTOR_PROBE_TIMEOUT_MS);
       checks.push({ endpoint: 'btc-rpc', target, ok: true });
     } catch (error) {
-      checks.push({ endpoint: 'btc-rpc', target, ok: false, detail: (error as Error).message });
+      checks.push({ endpoint: 'btc-rpc', target, ok: false, detail: scrubUserinfoInText((error as Error).message) });
     }
   }
 
@@ -1018,10 +1058,10 @@ export async function runDoctor(network: NetworkOption, overrides?: ConnectionOv
   const conn = resolveConnectionConfig(network, overrides);
   if (conn.cas?.rpcUrl) {
     const base = conn.cas.rpcUrl.replace(/\/+$/, '');
-    checks.push(await probeEndpoint('cas', conn.cas.rpcUrl, `${base}/api/v0/version`, { method: 'POST' }));
+    checks.push(await probeEndpoint('cas', scrubUrlUserinfo(conn.cas.rpcUrl)!, `${base}/api/v0/version`, { method: 'POST' }));
   } else {
     const gateway = (conn.cas?.gateway ?? DEFAULT_CAS_GATEWAY).replace(/\/+$/, '');
-    checks.push(await probeEndpoint('cas', gateway, gateway));
+    checks.push(await probeEndpoint('cas', scrubUrlUserinfo(gateway)!, gateway));
   }
 
   const mismatch = profileNetworkMismatch(network, overrides);

--- a/packages/cli/src/confirm.ts
+++ b/packages/cli/src/confirm.ts
@@ -12,15 +12,7 @@ export const MAX_FEE_RATE_SATS_PER_VBYTE = 1000;
 /** The SDK default fee rate applied when the operator sets none. */
 export const DEFAULT_FEE_RATE_SATS_PER_VBYTE = 5;
 
-/**
- * Approximate vsize of a single-party beacon signal transaction (P2PKH input
- * is the worst case; P2WPKH/P2TR are smaller). Used only for the pre-broadcast
- * fee estimate shown at the confirmation prompt; the exact fee is fixed later
- * inside the beacon's two-pass transaction build.
- */
-export const ESTIMATED_BEACON_TX_VBYTES = 250;
-
-/** A planned on-chain broadcast presented to the operator for confirmation. */
+/** A built on-chain broadcast presented to the operator for confirmation. */
 export type BroadcastPlan = {
   /** The command doing the broadcast. */
   action          : 'update' | 'deactivate';
@@ -30,6 +22,10 @@ export type BroadcastPlan = {
   network         : NetworkOption;
   /** The beacon service id spending the UTXO. */
   beaconId        : string;
+  /** The exact fee (sats) the built beacon transaction pays. */
+  feeSats         : bigint;
+  /** The vsize the fee was computed from; the signed transaction is this or smaller. */
+  vsize           : number;
   /** The effective fee rate in sats/vByte. */
   feeRateSatsPerVByte : number;
 };
@@ -49,9 +45,10 @@ export type ConfirmBroadcastOptions = {
 /**
  * Requires explicit operator confirmation before an on-chain beacon broadcast.
  * Skipped on regtest (a local, disposable network) and when
- * `--yes` was passed. Otherwise displays the plan, including the estimated
- * absolute fee, and requires a "yes" answer. Non-interactive invocations
- * without `--yes` fail closed with `CONFIRMATION_REQUIRED_ERROR`.
+ * `--yes` was passed. Otherwise displays the plan, including the exact
+ * absolute fee of the built transaction, and requires a "yes" answer.
+ * Non-interactive invocations without `--yes` fail closed with
+ * `CONFIRMATION_REQUIRED_ERROR`.
  *
  * @throws {CLIError} `CONFIRMATION_REQUIRED_ERROR` when no confirmation
  * channel is available, or `BROADCAST_ABORTED_ERROR` when the operator
@@ -61,14 +58,15 @@ export function confirmBroadcast(plan: BroadcastPlan, options: ConfirmBroadcastO
   if (plan.network === 'regtest') return;
   if (options.yes) return;
 
-  const estimatedSats = Math.ceil(plan.feeRateSatsPerVByte * ESTIMATED_BEACON_TX_VBYTES);
+  const feeSats = plan.feeSats;
   const lines = [
     `About to broadcast an on-chain ${plan.action}:`,
     `  DID:      ${plan.did}`,
     `  Network:  ${plan.network}`,
     `  Beacon:   ${plan.beaconId}`,
-    `  Fee:      ~${estimatedSats} sats (${(estimatedSats / 1e8).toFixed(8)} BTC) `
-      + `at ${plan.feeRateSatsPerVByte} sat/vB (estimated for a ~${ESTIMATED_BEACON_TX_VBYTES} vB transaction)`,
+    `  Fee:      ${feeSats} sats (${(Number(feeSats) / 1e8).toFixed(8)} BTC) `
+      + `at ${plan.feeRateSatsPerVByte} sat/vB for a ${plan.vsize} vB transaction `
+      + '(exact fee of the built transaction)',
   ];
   if (plan.action === 'deactivate') {
     lines.push('  WARNING:  deactivation is permanent and cannot be undone.');
@@ -95,25 +93,98 @@ export function confirmBroadcast(plan: BroadcastPlan, options: ConfirmBroadcastO
 }
 
 /**
+ * Adapts {@link confirmBroadcast} to the confirmation callback the SDK update
+ * flow invokes once the beacon transaction is built: the returned function
+ * merges the built transaction's exact fee and size into the plan and confirms
+ * it. This is the callback `update`/`deactivate` hand to `api.btcr2.update`.
+ */
+export function broadcastConfirmer(
+  base    : Omit<BroadcastPlan, 'feeSats' | 'vsize'>,
+  options : ConfirmBroadcastOptions = {},
+): (tx: { feeSats: bigint; vsize: number }) => void {
+  return (tx) => confirmBroadcast({ ...base, feeSats: tx.feeSats, vsize: tx.vsize }, options);
+}
+
+/**
+ * A 4-byte shared buffer used only as an {@link Atomics.wait} target. It lets
+ * {@link ttyPrompt} block briefly on an empty non-blocking TTY instead of
+ * busy-spinning. It is never written to, so the wait always times out.
+ */
+const IDLE_WAIT = new Int32Array(new SharedArrayBuffer(4));
+
+/**
+ * Milliseconds to block on each empty read. Imperceptible to a typist yet long
+ * enough that an open prompt sits idle rather than pegging a CPU core.
+ */
+const IDLE_POLL_MS = 20;
+
+/**
+ * Hard cap on the total time {@link ttyPrompt} spends waiting for input that
+ * never arrives. Referencing `process.stdin` puts fd 0 in non-blocking mode,
+ * so an idle TTY reports EAGAIN instead of blocking; without a cap, a pty with
+ * no input attached (e.g. `docker run -t` without `-i`) would spin forever.
+ * On expiry the prompt returns the answer accumulated so far (usually empty),
+ * which the confirmation gate treats as a decline.
+ */
+const MAX_IDLE_MS = 300_000;
+
+/** I/O seams for {@link ttyPrompt}, injectable for tests. */
+export type TtyPromptIo = {
+  /** File descriptor to read; defaults to stdin's. */
+  fd?: number;
+  /** Byte reader; defaults to `fs.readSync`. */
+  read?: typeof readSync;
+  /** Label writer; defaults to stderr. */
+  write?: (text: string) => void;
+  /** Idle waiter; defaults to a brief {@link Atomics.wait}. */
+  wait?: (ms: number) => void;
+  /** Idle poll interval in ms; defaults to {@link IDLE_POLL_MS}. */
+  pollMs?: number;
+  /** Total idle-wait cap in ms; defaults to {@link MAX_IDLE_MS}. */
+  maxIdleMs?: number;
+};
+
+/**
  * Reads one line from the terminal synchronously (canonical mode, echo on).
  * The label goes to stderr so `--output json` on stdout stays machine-clean.
+ *
+ * Because fd 0 is non-blocking once `process.stdin` is referenced, a read on an
+ * idle TTY throws EAGAIN: that case waits briefly and retries (bounded by
+ * `maxIdleMs`) instead of mistaking "no key pressed yet" for an empty answer.
+ * EOF (read of 0) ends the line; any other read error propagates rather than
+ * being converted into an empty answer.
  */
-function ttyPrompt(label: string): string {
-  process.stderr.write(label);
+export function ttyPrompt(label: string, io: TtyPromptIo = {}): string {
+  const write = io.write ?? ((text: string) => process.stderr.write(text));
+  const fd = io.fd ?? process.stdin.fd;
+  const doRead = io.read ?? readSync;
+  const wait = io.wait ?? ((ms: number) => Atomics.wait(IDLE_WAIT, 0, 0, ms));
+  const pollMs = io.pollMs ?? IDLE_POLL_MS;
+  const maxIdleMs = io.maxIdleMs ?? MAX_IDLE_MS;
+  write(label);
   const byte = Buffer.alloc(1);
   const bytes: number[] = [];
+  let idleMs = 0;
   for (;;) {
     let read = 0;
     try {
-      read = readSync(process.stdin.fd, byte, 0, 1, null);
-    } catch {
-      break;
+      read = doRead(fd, byte, 0, 1, null);
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      if (code === 'EAGAIN') {
+        idleMs += pollMs;
+        if (idleMs > maxIdleMs) break;
+        wait(pollMs);
+        continue;
+      }
+      if (code === 'EOF') break;
+      throw error;
     }
     if (read === 0) break;
     const ch = byte[0];
     if (ch === 0x0a || ch === 0x0d) break;
     bytes.push(ch);
   }
-  process.stderr.write('\n');
+  write('\n');
   return Buffer.from(bytes).toString('utf-8');
 }

--- a/packages/cli/src/keystore/atomic.ts
+++ b/packages/cli/src/keystore/atomic.ts
@@ -48,24 +48,40 @@ export function writeFileAtomic(path: string, data: string, mode: number): void 
 }
 
 /**
- * Fails closed if a keystore file is readable or writable by group or other.
- * On Windows, where POSIX mode bits are not enforced, this is a no-op that
- * warns once on standard error.
+ * The single permission policy for every file this CLI reads a secret from:
+ * the keystore, the session file, a `--passphrase-file`, a `key import
+ * --secret-file`, an RPC-password file (`BTCR2_BTC_RPC_PASS_FILE` or a
+ * `file:` secret reference).
+ *
+ * Accepted modes (POSIX): `0600`, `0400`, `0440`, and `0640`. That is, the
+ * owner may read (and, for files this CLI maintains, write); the group may at
+ * most read; others get nothing; and no execute bits anywhere. Anything
+ * group/world-writable, world-readable, or executable is rejected.
  */
-export function assertSecurePerms(path: string): void {
+export function isSecretFileModeAllowed(mode: number): boolean {
+  return (mode & 0o137) === 0;
+}
+
+/**
+ * Enforces the secret-file permission policy ({@link isSecretFileModeAllowed})
+ * on `path`, throwing a {@link KeyStoreError} that names the path and the
+ * observed mode. On Windows, where POSIX mode bits are not enforced, this is a
+ * no-op that warns once on standard error.
+ */
+export function assertSecretFilePerms(path: string, label = 'Secret file'): void {
   if (isWindows) {
     if (!permsWarned) {
       process.stderr.write(
-        'warning: file permissions are not enforced on Windows; protect the keystore directory manually.\n',
+        'warning: file permissions are not enforced on Windows; protect secret files manually.\n',
       );
       permsWarned = true;
     }
     return;
   }
   const mode = statSync(path).mode & 0o777;
-  if ((mode & 0o077) !== 0) {
+  if (!isSecretFileModeAllowed(mode)) {
     throw new KeyStoreError(
-      `Keystore at ${path} has insecure permissions 0${mode.toString(8)}; expected 0600.`,
+      `${label} at ${path} has insecure permissions 0${mode.toString(8)}; expected one of 0600, 0400, 0440, 0640.`,
       'KEYSTORE_PERMISSION_ERROR',
       { path, mode: `0${mode.toString(8)}` },
     );

--- a/packages/cli/src/keystore/file-key-store.ts
+++ b/packages/cli/src/keystore/file-key-store.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { base64urlnopad } from '@scure/base';
 import type { KeystoreProtectionLabel } from '../types.js';
-import { assertSecurePerms, ensureDir, writeFileAtomic } from './atomic.js';
+import { assertSecretFilePerms, ensureDir, writeFileAtomic } from './atomic.js';
 import { DEFAULT_ARGON_PARAMS, decryptSecret, encryptSecret } from './envelope.js';
 import type { ArgonParams, SecretEnvelope } from './envelope.js';
 import { KeyStoreError } from './error.js';
@@ -152,7 +152,7 @@ export class FileKeyStore implements KeyValueStore<KeyIdentifier, KeyEntry> {
 
   #loadFromDisk(): void {
     if (!existsSync(this.#path)) return;
-    assertSecurePerms(this.#path);
+    assertSecretFilePerms(this.#path, 'Keystore');
     let parsed: KeystoreFile;
     try {
       parsed = JSON.parse(readFileSync(this.#path, 'utf-8')) as KeystoreFile;

--- a/packages/cli/src/keystore/passphrase.ts
+++ b/packages/cli/src/keystore/passphrase.ts
@@ -1,4 +1,5 @@
 import { readFileSync, readSync } from 'node:fs';
+import { assertSecretFilePerms } from './atomic.js';
 import { KeyStoreError } from './error.js';
 
 /** Environment variable that supplies the keystore passphrase for unattended use. */
@@ -47,6 +48,9 @@ export function acquirePassphrase(options: PassphraseOptions = {}): string {
     if (fromEnv) return assertNonEmpty(fromEnv.replace(/\r?\n$/, ''));
 
     if (options.passphraseFile) {
+      // The file holds a secret in cleartext: enforce the shared secret-file
+      // permission policy (0600/0400/0440/0640) before reading it.
+      assertSecretFilePerms(options.passphraseFile, 'Passphrase file');
       return assertNonEmpty(readFileSync(options.passphraseFile, 'utf-8').replace(/\r?\n$/, ''));
     }
 

--- a/packages/cli/src/keystore/session.ts
+++ b/packages/cli/src/keystore/session.ts
@@ -2,7 +2,7 @@ import { closeSync, constants, existsSync, fstatSync, openSync, readdirSync, rea
 import { basename, dirname, join, resolve } from 'node:path';
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { base64urlnopad } from '@scure/base';
-import { ensureDir, writeFileAtomic } from './atomic.js';
+import { ensureDir, isSecretFileModeAllowed, writeFileAtomic } from './atomic.js';
 
 /**
  * The session unlock agent (ADR 081). `keystore unlock` caches the verified
@@ -246,7 +246,8 @@ function evaluateSession(
 /**
  * Reads and parses the session file with a plaintext secret in mind. On POSIX,
  * opens with `O_NOFOLLOW` (refusing a symlink) and refuses a non-regular file, a
- * file not owned by this user, or one accessible by group or other, best-effort
+ * file not owned by this user, or one more open than the shared secret-file
+ * permission policy (0600/0400/0440/0640), best-effort
  * deleting a rejected file and reading only from the opened descriptor (no TOCTOU
  * re-open). On Windows those POSIX guards are skipped (they would throw), so the
  * file is read normally under the same directory ACL the keystore trusts, keeping
@@ -273,10 +274,10 @@ function secureReadSession(sessionPath: string): SessionFile | undefined {
     try {
       const st = fstatSync(fd);
       const myUid = typeof process.getuid === 'function' ? process.getuid() : undefined;
-      if (!st.isFile() || (myUid !== undefined && st.uid !== myUid) || (st.mode & 0o077) !== 0) {
-        // Not a regular file we own with 0600 perms: it was not written by this
-        // process. Best-effort remove it (it may hold a plaintext passphrase) and
-        // fall back to a prompt.
+      if (!st.isFile() || (myUid !== undefined && st.uid !== myUid) || !isSecretFileModeAllowed(st.mode & 0o777)) {
+        // Not a regular file we own with secret-file permissions: it was not
+        // written by this process. Best-effort remove it (it may hold a
+        // plaintext passphrase) and fall back to a prompt.
         try {
           rmSync(sessionPath, { force: true });
         } catch {

--- a/packages/cli/tests/broadcast-safety.spec.ts
+++ b/packages/cli/tests/broadcast-safety.spec.ts
@@ -6,10 +6,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
 import {
+  broadcastConfirmer,
   confirmBroadcast,
   DEFAULT_FEE_RATE_SATS_PER_VBYTE,
-  ESTIMATED_BEACON_TX_VBYTES,
   MAX_FEE_RATE_SATS_PER_VBYTE,
+  ttyPrompt,
+  type TtyPromptIo,
 } from '../src/confirm.js';
 import type { ApiFactory } from '../src/config.js';
 import { CLIError } from '../src/error.js';
@@ -54,6 +56,8 @@ describe('broadcast confirmation', () => {
     did                 : 'did:btcr2:xxxx',
     network             : 'bitcoin' as const,
     beaconId            : '#beacon-0',
+    feeSats             : 1860n,
+    vsize               : 155,
     feeRateSatsPerVByte : 12,
   };
 
@@ -98,7 +102,7 @@ describe('broadcast confirmation', () => {
     });
   });
 
-  it('displays the plan with an estimated absolute fee', () => {
+  it('displays the plan with the exact fee of the built transaction', () => {
     let label = '';
     confirmBroadcast({ ...base, action: 'update' }, {
       prompt : (l) => { label = l; return 'yes'; },
@@ -106,9 +110,27 @@ describe('broadcast confirmation', () => {
     expect(label).to.include(base.did);
     expect(label).to.include('bitcoin');
     expect(label).to.include('#beacon-0');
-    const estimatedSats = Math.ceil(base.feeRateSatsPerVByte * ESTIMATED_BEACON_TX_VBYTES);
-    expect(label).to.include(`~${estimatedSats} sats`);
+    expect(label).to.include('1860 sats');
+    expect(label).to.include('155 vB');
     expect(label).to.include('12 sat/vB');
+    expect(label).to.not.include('~');
+  });
+
+  it('shows the fee the built transaction pays, via the update-flow callback adapter', () => {
+    // The SDK hands the built transaction's exact fee and size to the
+    // confirmation callback; what the operator sees must be those values.
+    let label = '';
+    const confirm = broadcastConfirmer({
+      action              : 'update',
+      did                 : 'did:btcr2:xxxx',
+      network             : 'bitcoin',
+      beaconId            : '#beacon-0',
+      feeRateSatsPerVByte : 12,
+    }, { prompt: (l) => { label = l; return 'yes'; } });
+    confirm({ feeSats: 4321n, vsize: 149 });
+    expect(label).to.include('4321 sats');
+    expect(label).to.include('149 vB');
+    expect(label).to.not.include('1860');
   });
 
   it('warns that deactivation is permanent', () => {
@@ -139,12 +161,23 @@ describe('fee-rate ceiling and command-level confirmation', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // A real keystore-backed KeyManager plus a stubbed update that captures its
+  // params, so the signing wiring is exercised without real Bitcoin I/O. The
+  // stub stands in for the built beacon transaction: it invokes the
+  // confirmation callback with a fixed exact fee and size, and only records
+  // the call as completed after confirmation passes.
   function stubFactory(): ApiFactory {
     return () => {
       const realApi = createKeystoreTestApiFactory(keystore, 'pw')();
       return {
         kms   : realApi.kms,
-        btcr2 : { update: async (params: unknown) => { captured.params = params; return { signed: 'mock' }; } },
+        btcr2 : {
+          update : async (params: any) => {
+            await params.confirmBroadcast?.({ beaconId: '#beacon-0', feeSats: 1860n, vsize: 155 });
+            captured.params = params;
+            return { signed: 'mock' };
+          },
+        },
       } as unknown as DidBtcr2Api;
     };
   }
@@ -239,8 +272,82 @@ describe('fee-rate ceiling and command-level confirmation', () => {
       did                 : 'did:btcr2:xxxx',
       network             : 'signet',
       beaconId            : '#beacon-0',
+      feeSats             : 775n,
+      vsize               : 155,
       feeRateSatsPerVByte : DEFAULT_FEE_RATE_SATS_PER_VBYTE,
     }, { prompt: (l) => { label = l; return 'yes'; } });
     expect(label).to.include(`${DEFAULT_FEE_RATE_SATS_PER_VBYTE} sat/vB`);
+  });
+});
+
+describe('ttyPrompt terminal reads', () => {
+  type ReadFn = NonNullable<TtyPromptIo['read']>;
+
+  /** A readSync stand-in from a script of per-call behaviors. */
+  function fakeRead(script: Array<'EAGAIN' | 'EOF' | 'EIO' | number>): { read: ReadFn } {
+    const queue = [...script];
+    const read = ((_fd: number, buf: Buffer, off: number) => {
+      const next = queue.length ? queue.shift()! : 0x0a;
+      if (next === 'EAGAIN' || next === 'EOF' || next === 'EIO') {
+        const error = new Error(next) as Error & { code: string };
+        error.code = next;
+        throw error;
+      }
+      buf[off] = next;
+      return 1;
+    }) as unknown as ReadFn;
+    return { read };
+  }
+
+  const yesBytes = [...'yes\n'].map(c => c.charCodeAt(0));
+
+  it('retries EAGAIN until input arrives instead of aborting on an idle TTY', () => {
+    const { read } = fakeRead(['EAGAIN', 'EAGAIN', ...yesBytes]);
+    const answer = ttyPrompt('label', { read, write: () => {}, wait: () => {} });
+    expect(answer).to.equal('yes');
+  });
+
+  it('stops waiting at the idle cap and returns the accumulated (empty) answer', () => {
+    const { read } = fakeRead(['EAGAIN']);
+    let waited = 0;
+    const answer = ttyPrompt('label', {
+      read,
+      write     : () => {},
+      wait      : () => { waited += 5; },
+      pollMs    : 5,
+      maxIdleMs : 20,
+    });
+    expect(answer).to.equal('');
+    expect(waited).to.be.at.most(25);
+  });
+
+  it('an empty answer from the idle cap declines the broadcast', () => {
+    const { read } = fakeRead(['EAGAIN']);
+    const prompt = (label: string): string => ttyPrompt(label, {
+      read,
+      write     : () => {},
+      wait      : () => {},
+      pollMs    : 5,
+      maxIdleMs : 10,
+    });
+    expect(() => confirmBroadcast({
+      action              : 'update',
+      did                 : 'did:btcr2:xxxx',
+      network             : 'signet',
+      beaconId            : '#beacon-0',
+      feeSats             : 775n,
+      vsize               : 155,
+      feeRateSatsPerVByte : 5,
+    }, { prompt })).to.throw(CLIError, /not confirmed/);
+  });
+
+  it('treats EOF as end of input, not an error', () => {
+    const { read } = fakeRead([...yesBytes.slice(0, 3), 'EOF']);
+    expect(ttyPrompt('label', { read, write: () => {}, wait: () => {} })).to.equal('yes');
+  });
+
+  it('propagates real read errors instead of converting them to an empty answer', () => {
+    const { read } = fakeRead(['EIO']);
+    expect(() => ttyPrompt('label', { read, write: () => {}, wait: () => {} })).to.throw(/EIO/);
   });
 });

--- a/packages/cli/tests/config-commands.spec.ts
+++ b/packages/cli/tests/config-commands.spec.ts
@@ -218,6 +218,23 @@ describe('config and profile commands', () => {
     expect(parsed.checks.every((c: { ok: boolean }) => c.ok === false)).to.equal(true);
   });
 
+  it('config doctor never prints credentials embedded in endpoint URLs', async function () {
+    this.timeout(15000);
+    out = [];
+    await run(
+      '--btc-rest', 'http://doctor:restsecret@127.0.0.1:1',
+      '--btc-rpc-url', 'http://doctor:rpcsecret@127.0.0.1:1',
+      '--cas-gateway', 'http://doctor:cassecret@127.0.0.1:1',
+      'config', 'doctor', '-n', 'regtest',
+    );
+    const printed = out.join('\n');
+    expect(printed).to.not.contain('restsecret');
+    expect(printed).to.not.contain('rpcsecret');
+    expect(printed).to.not.contain('cassecret');
+    const parsed = JSON.parse(printed);
+    expect(parsed.checks.every((c: { target: string }) => !c.target.includes('@127.0.0.1') || c.target.includes('********'))).to.equal(true);
+  });
+
   it('config get redacts the rpc password by default', async () => {
     await run('config', 'init');
     await run('config', 'set', 'profiles.regtest.btc.rpcPass', 'super-secret');

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import { StaticFeeEstimator } from '@did-btcr2/method';
@@ -860,6 +860,7 @@ describe('resolveSecretRef and RPC password sources', () => {
   it('reads a file: reference and trims a trailing newline', () => {
     const file = join(tempDir, 'pass.txt');
     writeFileSync(file, 'from-file\n');
+    chmodSync(file, 0o600);
     expect(resolveSecretRef(`file:${file}`)).to.equal('from-file');
   });
 
@@ -881,6 +882,7 @@ describe('resolveSecretRef and RPC password sources', () => {
   it('reads the RPC password from BTCR2_BTC_RPC_PASS_FILE when the layer supplies none', () => {
     const file = join(tempDir, 'passfile.txt');
     writeFileSync(file, 'file-secret\n');
+    chmodSync(file, 0o600);
     process.env.BTCR2_BTC_RPC_PASS_FILE = file;
     const cfg = join(tempDir, 'nopass.json');
     writeFileSync(cfg, JSON.stringify({
@@ -888,6 +890,100 @@ describe('resolveSecretRef and RPC password sources', () => {
     }));
     const api = defaultApiFactory('regtest', { config: cfg });
     expect(api.btc.connection.rpc?.config.password).to.equal('file-secret');
+  });
+
+  it('accepts a group-read-only (0640) file: reference', function () {
+    if (process.platform === 'win32') this.skip();
+    const file = join(tempDir, 'group-pass.txt');
+    writeFileSync(file, 'group-secret\n');
+    chmodSync(file, 0o640);
+    expect(resolveSecretRef(`file:${file}`)).to.equal('group-secret');
+  });
+
+  it('rejects a world-readable (0644) file: reference', function () {
+    if (process.platform === 'win32') this.skip();
+    const file = join(tempDir, 'loose-pass.txt');
+    writeFileSync(file, 'loose-secret\n');
+    chmodSync(file, 0o644);
+    expect(() => resolveSecretRef(`file:${file}`)).to.throw(CLIError, /permissions/);
+  });
+
+  it('rejects a world-readable (0644) BTCR2_BTC_RPC_PASS_FILE', function () {
+    if (process.platform === 'win32') this.skip();
+    const file = join(tempDir, 'loose-passfile.txt');
+    writeFileSync(file, 'loose-secret\n');
+    chmodSync(file, 0o644);
+    process.env.BTCR2_BTC_RPC_PASS_FILE = file;
+    const cfg = join(tempDir, 'loosepass.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { rpcUrl: 'http://node:18443', rpcUser: 'u' } } },
+    }));
+    expect(() => defaultApiFactory('regtest', { config: cfg })).to.throw(CLIError, /permissions/);
+  });
+});
+
+describe('RPC password layer shadowing warning', () => {
+  const tempDir = join(tmpdir(), 'btcr2-shadow-test');
+  const saved: Record<string, string | undefined> = {};
+
+  before(() => mkdirSync(tempDir, { recursive: true }));
+
+  after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    for (const k of Object.values(ENV_VARS)) { saved[k] = process.env[k]; delete process.env[k]; }
+  });
+
+  afterEach(() => {
+    for (const k of Object.values(ENV_VARS)) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k];
+    }
+  });
+
+  /** Captures console.error output produced while `fn` runs. */
+  function captureWarnings(fn: () => void): string[] {
+    const warnings: string[] = [];
+    const original = console.error;
+    console.error = (m?: unknown) => { if (m !== undefined) warnings.push(String(m)); };
+    try {
+      fn();
+    } finally {
+      console.error = original;
+    }
+    return warnings;
+  }
+
+  it('warns when a flag RPC url shadows BTCR2_BTC_RPC_PASS', () => {
+    process.env[ENV_VARS.BTC_RPC_PASS] = 'env-secret';
+    const warnings = captureWarnings(() => {
+      const api = defaultApiFactory('regtest', { config: join(tempDir, 'absent.json'), btcRpcUrl: 'http://node-b:18443' });
+      expect(api.btc.connection.rpc?.config.host).to.equal('http://node-b:18443');
+      expect(api.btc.connection.rpc?.config.password).to.be.undefined;
+    });
+    expect(warnings.some(w => w.includes(ENV_VARS.BTC_RPC_PASS))).to.equal(true);
+  });
+
+  it('warns when a profile RPC url shadows BTCR2_BTC_RPC_PASS', () => {
+    process.env[ENV_VARS.BTC_RPC_PASS] = 'env-secret';
+    const cfg = join(tempDir, 'shadow.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { rpcUrl: 'http://node-a:18443', rpcUser: 'alice' } } },
+    }));
+    const warnings = captureWarnings(() => {
+      const api = defaultApiFactory('regtest', { config: cfg });
+      expect(api.btc.connection.rpc?.config.password).to.be.undefined;
+    });
+    expect(warnings.some(w => w.includes(ENV_VARS.BTC_RPC_PASS))).to.equal(true);
+  });
+
+  it('does not warn when the env layer supplies the whole credential unit', () => {
+    process.env[ENV_VARS.BTC_RPC_PASS] = 'env-secret';
+    process.env[ENV_VARS.BTC_RPC_URL] = 'http://env-node:18443';
+    const warnings = captureWarnings(() => {
+      const api = defaultApiFactory('regtest', { config: join(tempDir, 'absent.json') });
+      expect(api.btc.connection.rpc?.config.password).to.equal('env-secret');
+    });
+    expect(warnings.some(w => w.includes(ENV_VARS.BTC_RPC_PASS))).to.equal(false);
   });
 });
 

--- a/packages/cli/tests/file-key-store.spec.ts
+++ b/packages/cli/tests/file-key-store.spec.ts
@@ -5,6 +5,7 @@ import type { KeyEntry } from '@did-btcr2/key-manager';
 import { FileKeyStore } from '../src/keystore/file-key-store.js';
 import type { ArgonParams } from '../src/keystore/envelope.js';
 import { KeyStoreError } from '../src/keystore/error.js';
+import { isSecretFileModeAllowed } from '../src/keystore/atomic.js';
 import { expect } from './helpers.js';
 
 // Low-cost argon2id parameters keep the suite well under the mocha timeout.
@@ -135,8 +136,29 @@ describe('FileKeyStore', () => {
     expect(() => openStore(path)).to.throw(KeyStoreError).with.property('type', 'KEYSTORE_PERMISSION_ERROR');
   });
 
+  it('accepts a group-read-only (0640) keystore file', function () {
+    if (process.platform === 'win32') return this.skip();
+    writeFileSync(path, '{"v":1,"keys":{},"protection":"none"}', { mode: 0o600 });
+    chmodSync(path, 0o640);
+    expect(() => openStore(path)).to.not.throw();
+  });
+
   it('rejects a corrupt keystore file', () => {
     writeFileSync(path, 'not json', { mode: 0o600 });
     expect(() => openStore(path)).to.throw(KeyStoreError).with.property('type', 'KEYSTORE_CORRUPT_ERROR');
+  });
+});
+
+describe('secret-file permission policy', () => {
+  it('accepts owner read/write and read-only variants down to group-read', () => {
+    for (const mode of [0o600, 0o400, 0o440, 0o640]) {
+      expect(isSecretFileModeAllowed(mode), `0${mode.toString(8)}`).to.equal(true);
+    }
+  });
+
+  it('rejects group/world-writable, world-readable, and executable modes', () => {
+    for (const mode of [0o620, 0o660, 0o644, 0o666, 0o700, 0o755]) {
+      expect(isSecretFileModeAllowed(mode), `0${mode.toString(8)}`).to.equal(false);
+    }
   });
 });

--- a/packages/cli/tests/key-commands.spec.ts
+++ b/packages/cli/tests/key-commands.spec.ts
@@ -100,6 +100,18 @@ describe('key commands', () => {
     expect(result.keyId).to.match(/^urn:kms:secp256k1:/);
   });
 
+  it('import --secret-file accepts read-only and group-read-only secret files', async function () {
+    if (process.platform === 'win32') return; // perms not enforceable there
+    for (const [i, mode] of [0o400, 0o440, 0o640].entries()) {
+      const secretFile = join(dir, `secret-${i}.hex`);
+      writeFileSync(secretFile, bytesToHex(SchnorrKeyPair.generate().secretKey.bytes));
+      chmodSync(secretFile, mode);
+      out = [];
+      await runKey('import', '--secret-file', secretFile, '--name', `imported-${mode.toString(8)}`);
+      expect(JSON.parse(out[0]).keyId).to.match(/^urn:kms:secp256k1:/);
+    }
+  });
+
   it('import --secret-file refuses a group/world-readable secret file', async () => {
     if (process.platform === 'win32') return; // perms not enforceable there
     const secretFile = join(dir, 'loose.hex');
@@ -112,6 +124,17 @@ describe('key commands', () => {
       expect((err as Error).message).to.match(/permissions/);
     });
     expect(threw, 'expected a permission refusal').to.be.true;
+  });
+
+  it('import --secret-file refuses writable-by-others and executable secret files', async function () {
+    if (process.platform === 'win32') return; // perms not enforceable there
+    for (const mode of [0o620, 0o660, 0o666, 0o700]) {
+      const secretFile = join(dir, `loose-${mode.toString(8)}.hex`);
+      writeFileSync(secretFile, bytesToHex(SchnorrKeyPair.generate().secretKey.bytes));
+      chmodSync(secretFile, mode);
+      await expect(runKey('import', '--secret-file', secretFile))
+        .to.be.rejectedWith(CLIError, /permissions/);
+    }
   });
 
   it('import --public adds a watch-only key', async () => {

--- a/packages/cli/tests/passphrase.spec.ts
+++ b/packages/cli/tests/passphrase.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { acquirePassphrase, dropLastUtf8Char, ENV_KEYSTORE_PASSPHRASE } from '../src/keystore/passphrase.js';
@@ -23,6 +23,7 @@ describe('acquirePassphrase', () => {
     const dir = mkdtempSync(join(tmpdir(), 'btcr2-pass-'));
     const file = join(dir, 'pass.txt');
     writeFileSync(file, 'file-pass\n');
+    chmodSync(file, 0o600);
     try {
       expect(acquirePassphrase({ passphraseFile: file })).to.equal('file-pass');
     } finally {
@@ -53,11 +54,45 @@ describe('acquirePassphrase', () => {
     const dir = mkdtempSync(join(tmpdir(), 'btcr2-pass-'));
     const file = join(dir, 'empty.txt');
     writeFileSync(file, '\n');
+    chmodSync(file, 0o600);
     try {
       expect(() => acquirePassphrase({ passphraseFile: file }))
         .to.throw(KeyStoreError).with.property('type', 'PASSPHRASE_REQUIRED_ERROR');
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe('passphrase file permissions', () => {
+    before(function () {
+      if (process.platform === 'win32') this.skip(); // mode bits unenforced
+    });
+
+    let dir: string;
+
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'btcr2-pass-')); });
+
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    const readWithMode = (mode: number): string => {
+      delete process.env[ENV_KEYSTORE_PASSPHRASE];
+      const file = join(dir, 'pass.txt');
+      writeFileSync(file, 'file-pass\n');
+      chmodSync(file, mode);
+      return acquirePassphrase({ passphraseFile: file });
+    };
+
+    for (const mode of [0o600, 0o400, 0o440, 0o640]) {
+      it(`accepts a ${mode.toString(8)} passphrase file`, () => {
+        expect(readWithMode(mode)).to.equal('file-pass');
+      });
+    }
+
+    for (const mode of [0o620, 0o660, 0o644, 0o666, 0o700]) {
+      it(`rejects a ${mode.toString(8)} passphrase file`, () => {
+        expect(() => readWithMode(mode))
+          .to.throw(KeyStoreError).with.property('type', 'KEYSTORE_PERMISSION_ERROR');
+      });
     }
   });
 
@@ -91,6 +126,7 @@ describe('acquirePassphrase', () => {
       const dir = mkdtempSync(join(tmpdir(), 'btcr2-pass-'));
       const file = join(dir, 'pass.txt');
       writeFileSync(file, 'file-wins\n');
+      chmodSync(file, 0o600);
       const beforePrompt = (): string => { throw new Error('beforePrompt must not be consulted when a passphrase file is set'); };
       try {
         expect(acquirePassphrase({ passphraseFile: file, beforePrompt })).to.equal('file-wins');

--- a/packages/cli/tests/quickstart.spec.ts
+++ b/packages/cli/tests/quickstart.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
@@ -28,6 +28,7 @@ describe('quickstart (ADR 083)', () => {
     home = join(dir, 'home');
     passFile = join(dir, 'pass.txt');
     writeFileSync(passFile, 'pw\n');
+    chmodSync(passFile, 0o600);
     out = [];
     err = [];
     console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };

--- a/packages/cli/tests/session.spec.ts
+++ b/packages/cli/tests/session.spec.ts
@@ -258,6 +258,15 @@ describe('session unlock agent (ADR 081)', () => {
       expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal(undefined);
       expect(existsSync(sessionPath)).to.equal(false); // a loose-perm plaintext file is removed
     });
+
+    it('serves a group-read-only (0640) session file', function () {
+      if (process.platform === 'win32') return this.skip();
+      establishKeystore();
+      const vid = keystoreVerifierId(keystorePath);
+      writeSession(sessionPath, { keystorePath, verifierId: vid!, passphrase: 'pw', ttlMs: 60_000 });
+      chmodSync(sessionPath, 0o640);
+      expect(readLiveSessionPassphrase(sessionPath, keystorePath, vid)).to.equal('pw');
+    });
   });
 
   describe('keystore helpers', () => {

--- a/packages/cli/tests/unlock-commands.spec.ts
+++ b/packages/cli/tests/unlock-commands.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DidBtcr2Cli } from '../src/cli.js';
@@ -30,6 +30,7 @@ describe('keystore unlock / lock / status (ADR 081)', () => {
     home = join(dir, 'home');
     passFile = join(dir, 'pass.txt');
     writeFileSync(passFile, 'pw\n');
+    chmodSync(passFile, 0o600);
     out = [];
     err = [];
     console.log = (m?: unknown) => { if (m !== undefined) out.push(String(m)); };
@@ -94,6 +95,7 @@ describe('keystore unlock / lock / status (ADR 081)', () => {
       establishEncrypted();
       const wrongFile = join(dir, 'wrong.txt');
       writeFileSync(wrongFile, 'not-the-pass');
+      chmodSync(wrongFile, 0o600);
       await run('--passphrase-file', wrongFile, 'keystore', 'unlock');
       expect(err.join(' ')).to.match(/Incorrect passphrase/i);
       expect(existsSync(sessionPath())).to.equal(false);

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -173,7 +173,7 @@ function changeOutputKind(changeAddress: string, network: BTCNetwork): Singleton
 }
 
 /**
- * Options accepted by {@link SinglePartyBeacon.buildSignAndBroadcast} and related helpers.
+ * Options accepted by {@link SinglePartyBeacon.prepareSignalTx} and related helpers.
  */
 export interface BroadcastOptions {
   /** Fee estimator for computing the transaction fee. Defaults to {@link DEFAULT_FEE_ESTIMATOR}. */
@@ -233,10 +233,36 @@ export interface BeaconTxPlan {
   /** The fee (sats) already deducted from the change output. */
   feeSats: bigint;
   /**
+   * The vsize (vbytes) the fee was computed from. An upper bound for the
+   * finalized transaction's true vsize (the constants behind
+   * {@link beaconTxVsize} size the worst-case signature), so the fee rate
+   * actually paid is at least the configured rate.
+   */
+  vsize: number;
+  /**
    * Singleton beacon script kind, when applicable. Drives the signing dispatch
    * in {@link SinglePartyBeacon.signSinglePartyTx}. Aggregation plans set this to `'p2tr'`.
    */
   scriptKind: SingletonScriptKind;
+}
+
+/**
+ * A fully built single-party beacon signal transaction awaiting the caller's
+ * go-ahead. The transaction exists, so its fee is exact rather than an
+ * estimate, but nothing has been signed or broadcast: declining (by never
+ * calling {@link PreparedBroadcast.broadcast}) leaves the beacon UTXO unspent.
+ */
+export interface PreparedBroadcast {
+  /** The exact fee (sats) the built transaction pays (input value minus outputs). */
+  feeSats: bigint;
+  /** The vsize (vbytes) the fee was computed from; the signed transaction is this or smaller. */
+  vsize: number;
+  /**
+   * Publishes any off-chain artifacts (a CAS Announcement, when a `casPublish`
+   * callback was supplied), signs the spending input, and broadcasts the
+   * transaction. Resolves to the broadcast artifacts.
+   */
+  broadcast(): Promise<BroadcastResult>;
 }
 
 /**
@@ -357,7 +383,7 @@ async function fetchSpendableUtxo(
  * Returns the unsigned Transaction + prev-output metadata that an aggregation service's
  * signing session consumes (via {@link SigningTxData}).
  *
- * This is the reusable counterpart to {@link SinglePartyBeacon.buildSignAndBroadcast}'s internal
+ * This is the reusable counterpart to {@link SinglePartyBeacon.prepareSignalTx}'s internal
  * construction step: the aggregation path must produce an unsigned tx because the
  * signature comes from a MuSig2 round, not a local secret key.
  *
@@ -401,7 +427,8 @@ export async function buildAggregationBeaconTx(opts: {
   // round), so size it analytically. The input is the cohort's P2TR key path; only
   // the change output's kind varies, so the vsize follows the change address (ADR 045).
   const changeKind = changeOutputKind(changeAddress, opts.network);
-  const feeSats = await feeEstimator.estimateFee(beaconTxVsize('p2tr', changeKind));
+  const vsize = beaconTxVsize('p2tr', changeKind);
+  const feeSats = await feeEstimator.estimateFee(vsize);
   if(BigInt(utxo.value) <= feeSats) {
     throw new BeaconError(
       `UTXO value (${utxo.value}) insufficient to cover fee (${feeSats}).`,
@@ -437,6 +464,7 @@ export async function buildAggregationBeaconTx(opts: {
     changeAddress,
     utxo,
     feeSats,
+    vsize,
     scriptKind     : 'p2tr',
   };
 }
@@ -583,29 +611,39 @@ export abstract class SinglePartyBeacon {
   ): Promise<BroadcastResult>;
 
   /**
-   * Build + sign + broadcast a singleton beacon signal transaction. The beacon
-   * address's script kind (P2PKH / P2WPKH / P2TR) is detected automatically
-   * and the input is constructed and signed accordingly.
+   * Builds the beacon signal transaction for a signed update without signing or
+   * broadcasting it, so the caller can inspect (and confirm) the exact fee and
+   * size before any spend happens. The returned {@link PreparedBroadcast}
+   * carries the exact fee the built transaction pays; its `broadcast()` signs
+   * the input and sends the transaction.
    *
-   * Composed from the three extracted phases ({@link buildSinglePartyTx},
-   * {@link signSinglePartyTx}, {@link broadcastRawTx}) so each piece can be exercised
-   * in isolation. Aggregation beacons use {@link buildAggregationBeaconTx} instead:
-   * the multi-party path can't share the signing phase, but the tx-construction
-   * plumbing (UTXO fetch + OP_RETURN output + change output) is shared.
-   *
-   * @param signalBytes 32-byte payload to embed in OP_RETURN.
-   * @param signer Signer used to sign the spending input.
-   * @param bitcoin Bitcoin network connection.
-   * @param options Broadcast options (fee estimator, etc.).
-   * @returns The txid of the broadcast transaction.
-   * @throws {BeaconError} if the address is unfunded, no UTXO is available, or fee exceeds value.
+   * @param {SignedBTCR2Update} signedUpdate The signed BTCR2 update to broadcast.
+   * @param {Signer} signer Signer that will produce the signature for the spending input.
+   * @param {BitcoinConnection} bitcoin The Bitcoin network connection.
+   * @param {BroadcastOptions} [options] Optional broadcast configuration (e.g. fee estimator).
+   * @returns {Promise<PreparedBroadcast>} The built transaction's exact fee, size,
+   *   and broadcast continuation.
+   * @throws {BeaconError} if the bitcoin address is invalid, unfunded, or UTXO cannot cover the fee.
    */
-  protected async buildSignAndBroadcast(
+  abstract prepareBroadcast(
+    signedUpdate: SignedBTCR2Update,
+    signer: Signer,
+    bitcoin: BitcoinConnection,
+    options?: BroadcastOptions
+  ): Promise<PreparedBroadcast>;
+
+  /**
+   * Build the unsigned singleton beacon tx for `signalBytes` and return it with
+   * a continuation that signs and broadcasts it. Splitting build from
+   * sign-and-send lets a caller (e.g. an operator confirmation prompt) inspect
+   * the exact fee of the built transaction before anything is signed or spent.
+   */
+  protected async prepareSignalTx(
     signalBytes: Uint8Array,
     signer: Signer,
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
-  ): Promise<string> {
+  ): Promise<{ plan: BeaconTxPlan; broadcastTx: () => Promise<string> }> {
     const feeEstimator = options?.feeEstimator ?? DEFAULT_FEE_ESTIMATOR;
     const beaconAddress = this.service.serviceEndpoint.replace('bitcoin:', '');
     const { utxo, prevTxBytes } = await fetchSpendableUtxo(beaconAddress, bitcoin);
@@ -613,8 +651,13 @@ export abstract class SinglePartyBeacon {
       signalBytes, beaconAddress, utxo, prevTxBytes, signer, bitcoin, feeEstimator,
       changeAddress : options?.changeAddress,
     });
-    const signedHex = await this.signSinglePartyTx(plan, signer);
-    return this.broadcastRawTx(bitcoin, signedHex);
+    return {
+      plan,
+      broadcastTx : async () => {
+        const signedHex = await this.signSinglePartyTx(plan, signer);
+        return this.broadcastRawTx(bitcoin, signedHex);
+      },
+    };
   }
 
   /**
@@ -653,7 +696,8 @@ export abstract class SinglePartyBeacon {
     }
 
     const changeKind = changeOutputKind(changeAddress, network);
-    const feeSats = await opts.feeEstimator.estimateFee(beaconTxVsize(kind, changeKind));
+    const vsize = beaconTxVsize(kind, changeKind);
+    const feeSats = await opts.feeEstimator.estimateFee(vsize);
     const amount = BigInt(opts.utxo.value);
     if(amount <= feeSats) {
       throw new BeaconError(
@@ -715,6 +759,7 @@ export abstract class SinglePartyBeacon {
       changeAddress,
       utxo           : opts.utxo,
       feeSats,
+      vsize,
       scriptKind     : kind,
     };
   }

--- a/packages/method/src/core/beacon/cas-beacon.ts
+++ b/packages/method/src/core/beacon/cas-beacon.ts
@@ -4,7 +4,7 @@ import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions, BroadcastResult } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult, PreparedBroadcast } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import { CASBeaconError } from './error.js';
 import type { BeaconService, BeaconSignal, BlockMetadata, CasPublishFn } from './interfaces.js';
@@ -149,7 +149,7 @@ export class CASBeacon extends SinglePartyBeacon {
    * Creates a CAS Announcement mapping the DID to the update hash, optionally publishes the
    * announcement off-chain via the supplied `casPublish` callback, then broadcasts the hash of
    * the announcement via OP_RETURN. UTXO selection, PSBT construction, fee estimation, signing,
-   * and broadcast are delegated to {@link SinglePartyBeacon.buildSignAndBroadcast}.
+   * and broadcast are delegated to {@link SinglePartyBeacon.prepareSignalTx}.
    *
    * The CAS publish happens **before** the transaction broadcast: a publish failure aborts the
    * operation while the beacon UTXO is still unspent, so no on-chain signal ever points at an
@@ -171,6 +171,25 @@ export class CASBeacon extends SinglePartyBeacon {
     bitcoin: BitcoinConnection,
     options?: CASBroadcastOptions
   ): Promise<BroadcastResult> {
+    const prepared = await this.prepareBroadcast(signedUpdate, signer, bitcoin, options);
+    return prepared.broadcast();
+  }
+
+  /**
+   * Builds the CAS Beacon signal transaction without signing or broadcasting it.
+   * Creates the CAS Announcement mapping the DID to its update hash and embeds
+   * the announcement hash in the OP_RETURN output. The optional `casPublish`
+   * callback runs inside the returned continuation, after any caller-side
+   * confirmation and before the spend is signed and sent, so declining the
+   * broadcast publishes nothing and a publish failure still aborts while the
+   * beacon UTXO is unspent.
+   */
+  async prepareBroadcast(
+    signedUpdate: SignedBTCR2Update,
+    signer: Signer,
+    bitcoin: BitcoinConnection,
+    options?: CASBroadcastOptions
+  ): Promise<PreparedBroadcast> {
     // Extract the DID from the beacon service id (strip the #fragment)
     const did = this.service.id.split('#')[0];
 
@@ -183,15 +202,18 @@ export class CASBeacon extends SinglePartyBeacon {
     // Canonicalize and hash the CAS Announcement for the OP_RETURN output
     const announcementHash = hash(canonicalize(casAnnouncement));
 
-    // Publish the announcement to the content-addressed store before spending the
-    // beacon UTXO, so a publish failure aborts pre-spend.
-    if(options?.casPublish) {
-      await options.casPublish(casAnnouncement);
-    }
-
-    // Delegate UTXO selection, PSBT construction, fee estimation, signing, and broadcast
-    const txid = await this.buildSignAndBroadcast(announcementHash, signer, bitcoin, options);
-
-    return { signedUpdate, txid, announcement: casAnnouncement };
+    const { plan, broadcastTx } = await this.prepareSignalTx(announcementHash, signer, bitcoin, options);
+    return {
+      feeSats   : plan.feeSats,
+      vsize     : plan.vsize,
+      broadcast : async () => {
+        // Publish the announcement to the content-addressed store before spending
+        // the beacon UTXO, so a publish failure aborts pre-spend.
+        if(options?.casPublish) {
+          await options.casPublish(casAnnouncement);
+        }
+        return { signedUpdate, txid: await broadcastTx(), announcement: casAnnouncement };
+      },
+    };
   }
 }

--- a/packages/method/src/core/beacon/singleton-beacon.ts
+++ b/packages/method/src/core/beacon/singleton-beacon.ts
@@ -4,7 +4,7 @@ import type { SignedBTCR2Update } from '../btcr2-update.js';
 import type { Signer } from '@did-btcr2/keypair';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions, BroadcastResult } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult, PreparedBroadcast } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from './interfaces.js';
 
@@ -64,7 +64,7 @@ export class SingletonBeacon extends SinglePartyBeacon {
    *
    * The signal bytes embedded in OP_RETURN are the SHA-256 canonical hash of the signed update.
    * UTXO selection, PSBT construction, fee estimation, signing, and broadcast are delegated to
-   * {@link SinglePartyBeacon.buildSignAndBroadcast}.
+   * {@link SinglePartyBeacon.prepareSignalTx}.
    *
    * @param {SignedBTCR2Update} signedUpdate The signed BTCR2 update to broadcast.
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
@@ -79,8 +79,29 @@ export class SingletonBeacon extends SinglePartyBeacon {
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
   ): Promise<BroadcastResult> {
+    const prepared = await this.prepareBroadcast(signedUpdate, signer, bitcoin, options);
+    return prepared.broadcast();
+  }
+
+  /**
+   * Builds the SingletonBeacon signal transaction without signing or
+   * broadcasting it. The signal bytes embedded in OP_RETURN are the SHA-256
+   * canonical hash of the signed update; the returned {@link PreparedBroadcast}
+   * exposes the exact fee of the built transaction for pre-broadcast
+   * confirmation.
+   */
+  async prepareBroadcast(
+    signedUpdate: SignedBTCR2Update,
+    signer: Signer,
+    bitcoin: BitcoinConnection,
+    options?: BroadcastOptions
+  ): Promise<PreparedBroadcast> {
     const signalBytes = hash(canonicalize(signedUpdate));
-    const txid = await this.buildSignAndBroadcast(signalBytes, signer, bitcoin, options);
-    return { signedUpdate, txid };
+    const { plan, broadcastTx } = await this.prepareSignalTx(signalBytes, signer, bitcoin, options);
+    return {
+      feeSats   : plan.feeSats,
+      vsize     : plan.vsize,
+      broadcast : async () => ({ signedUpdate, txid: await broadcastTx() }),
+    };
   }
 }

--- a/packages/method/src/core/beacon/smt-beacon.ts
+++ b/packages/method/src/core/beacon/smt-beacon.ts
@@ -6,7 +6,7 @@ import { base64UrlToHash, blockHash, BTCR2MerkleTree, didToIndex, hashToHex, ver
 import { randomBytes } from '@noble/hashes/utils';
 import type { BeaconProcessResult, DataNeed } from '../resolver.js';
 import type { SidecarData } from '../types.js';
-import type { BroadcastOptions, BroadcastResult } from './beacon.js';
+import type { BroadcastOptions, BroadcastResult, PreparedBroadcast } from './beacon.js';
 import { SinglePartyBeacon } from './beacon.js';
 import { SMTBeaconError } from './error.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from './interfaces.js';
@@ -137,7 +137,7 @@ export class SMTBeacon extends SinglePartyBeacon {
    * Builds a single-entry Sparse Merkle Tree from the signed update, then broadcasts the tree's
    * root hash via OP_RETURN. For multi-party aggregation, use the {@link AggregationService}
    * subsystem directly instead of this method. UTXO selection, PSBT construction, fee estimation,
-   * signing, and broadcast are delegated to {@link SinglePartyBeacon.buildSignAndBroadcast}.
+   * signing, and broadcast are delegated to {@link SinglePartyBeacon.prepareSignalTx}.
    *
    * @param {SignedBTCR2Update} signedUpdate The signed BTCR2 update to broadcast.
    * @param {Signer} signer Signer that produces the ECDSA signature for the Bitcoin transaction.
@@ -154,6 +154,23 @@ export class SMTBeacon extends SinglePartyBeacon {
     bitcoin: BitcoinConnection,
     options?: BroadcastOptions
   ): Promise<BroadcastResult> {
+    const prepared = await this.prepareBroadcast(signedUpdate, signer, bitcoin, options);
+    return prepared.broadcast();
+  }
+
+  /**
+   * Builds the SMT Beacon signal transaction without signing or broadcasting it.
+   * Builds the single-entry Sparse Merkle Tree (and the inclusion proof carrying
+   * the leaf nonce) at prepare time so the tree root can ride in the OP_RETURN
+   * output; the returned {@link PreparedBroadcast} exposes the exact fee of the
+   * built transaction for pre-broadcast confirmation.
+   */
+  async prepareBroadcast(
+    signedUpdate: SignedBTCR2Update,
+    signer: Signer,
+    bitcoin: BitcoinConnection,
+    options?: BroadcastOptions
+  ): Promise<PreparedBroadcast> {
     // Extract the DID from the beacon service id (strip the #fragment)
     const did = this.service.id.split('#')[0];
 
@@ -170,8 +187,11 @@ export class SMTBeacon extends SinglePartyBeacon {
     const proof = tree.proof(did);
 
     // Root hash is the signal bytes for the OP_RETURN output
-    const txid = await this.buildSignAndBroadcast(tree.rootHash, signer, bitcoin, options);
-
-    return { signedUpdate, txid, proof };
+    const { plan, broadcastTx } = await this.prepareSignalTx(tree.rootHash, signer, bitcoin, options);
+    return {
+      feeSats   : plan.feeSats,
+      vsize     : plan.vsize,
+      broadcast : async () => ({ signedUpdate, txid: await broadcastTx(), proof }),
+    };
   }
 }

--- a/packages/method/tests/beacon-broadcast.spec.ts
+++ b/packages/method/tests/beacon-broadcast.spec.ts
@@ -117,6 +117,40 @@ describe('SinglePartyBeacon.broadcastSignal result shape', () => {
     });
   });
 
+  describe('prepareBroadcast', () => {
+    it('builds without broadcasting and exposes the exact fee the built transaction pays', async () => {
+      const { signer, service } = testBeaconSetup('SingletonBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+      const update = fakeUpdate('singleton-prepare');
+
+      const prepared = await new SingletonBeacon(service).prepareBroadcast(update, signer, bitcoin);
+
+      expect(sent, 'prepare must not broadcast').to.have.length(0);
+      const result = await prepared.broadcast();
+      expect(result.txid).to.equal(TXID);
+      expect(sent).to.have.length(1);
+
+      // The advertised fee is exactly what the broadcast transaction pays:
+      // the input value minus the sum of its outputs.
+      const tx = Transaction.fromRaw(hexToBytes(sent[0]!), { allowUnknownOutputs: true, allowUnknownInputs: true });
+      let outTotal = 0n;
+      for (let i = 0; i < tx.outputsLength; i++) outTotal += tx.getOutput(i).amount!;
+      expect(prepared.feeSats).to.equal(100_000n - outTotal);
+      expect(prepared.vsize).to.be.a('number').and.to.be.greaterThan(0);
+    });
+
+    it('a prepared broadcast that is never sent spends nothing', async () => {
+      const { signer, service } = testBeaconSetup('SingletonBeacon');
+      const sent: string[] = [];
+      const bitcoin = mockBitcoin(service.serviceEndpoint.replace('bitcoin:', ''), sent, []);
+
+      await new SingletonBeacon(service).prepareBroadcast(fakeUpdate('singleton-decline'), signer, bitcoin);
+
+      expect(sent).to.have.length(0);
+    });
+  });
+
   describe('CASBeacon', () => {
     it('returns the announcement mapping the DID to the update hash, plus the txid', async () => {
       const { signer, service } = testBeaconSetup('CASBeacon');


### PR DESCRIPTION
* fix(method): split beacon broadcast into prepare-then-broadcast so the exact fee is known before confirmation (audit M8; review MS-17)
* fix(api): thread a confirmBroadcast callback through updateDid between build and sign (review MS-17)
* fix(cli): EAGAIN-safe ttyPrompt; exact-fee confirm; doctor URL redaction; rpc-pass shadow warning; uniform secret-file modes (audit M8; review MS-04, MS-15, MS-17, MS-37, MS-38)
* test(cli): EAGAIN retry, cap, EOF and error cases; exact-fee display; doctor redaction; shadow warning; permission matrix (review MS-04, MS-15, MS-17, MS-37, MS-38)
* test(method): prepare-broadcast sends nothing and feeSats matches the sent transaction (review MS-17)
* docs(cli): unset env refs, reserved prefixes with file workaround, secret-file modes, exact-fee flow (review MS-38, MS-39, MS-40)