### PR TITLE
bind aggregation signing to the funded outpoint and validated signal

### DIFF
--- a/docs/adr/044-beacon-change-output-address.md
+++ b/docs/adr/044-beacon-change-output-address.md
@@ -6,6 +6,8 @@ title: "ADR 044: Beacon Change Output - Caller-Supplied Address to End Beacon-Ad
 
 **Status:** Accepted (implementation pending)
 
+**Amendment (2026-08):** Decision 1 is narrowed for the aggregation path: `buildAggregationBeaconTx` no longer accepts a `changeAddress`, and change always returns to the cohort's beacon address. Aggregation participants verify the transaction they sign and reject any output paying a foreign script, any spend without a self-change output, and any self-change below the dust floor, so a caller-named change destination could never be signed; the option is removed rather than shipped as a lever the cohort's own members veto (Decisions 2 and 5 are superseded accordingly). The single-party builders are unchanged and keep the `changeAddress` lever. The change-output dust floor is unified at 546 sats across all script kinds so the builders and the participant guard agree on one value, and the aggregation builder refuses a UTXO whose change after fees would fall below it instead of emitting an unsignable transaction.
+
 **Date:** 2026-06-24
 
 **Branch / PR:** `feat/aggregation-privacy-fees`

--- a/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
+++ b/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
@@ -14,10 +14,10 @@ import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
  * Then in two more terminals (one per participant):
  *   RELAY=ws://localhost:7777 SERVICE_DID=<did from above> bun lib/operations/aggregation/aggregation-participant.ts
  */
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils';
-import { p2tr, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Address, OutScript, Script, Transaction } from '@scure/btc-signer';
 import {
   AggregationServiceRunner,
   NostrTransport,
@@ -25,6 +25,7 @@ import {
 
 const RELAY = process.env.RELAY ?? 'ws://localhost:7777';
 const MIN_PARTICIPANTS = Number(process.env.MIN_PARTICIPANTS ?? '2');
+const NETWORK = getNetwork('mutinynet');
 
 const serviceKeys = SchnorrKeyPair.fromSecret('cbd42da155c70d5a8806a1f68bfb802097e152f28230990d8e3c979e78e52d1d');
 const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
@@ -44,20 +45,26 @@ const service = new AggregationServiceRunner({
   // Auto-accept all opt-ins (default behavior, explicit here for clarity)
   onOptInReceived : async () => ({ accepted: true }),
 
-  // Build a dummy P2TR transaction (in production: query Bitcoin for UTXO + build tx)
-  onProvideTxData : async ({ cohortId }) => {
+  // Build a dummy beacon announcement tx (in production: query Bitcoin for the
+  // cohort's funded UTXO and build from it). Participants verify the shape, so
+  // the tx must spend the script-tree beacon output (the funded address's
+  // scriptPubKey, NOT a tree-less p2tr of the aggregate key), return
+  // self-change to the beacon script above the dust floor, and carry the
+  // cohort's signal in a single zero-value OP_RETURN.
+  onProvideTxData : async ({ cohortId, signalBytes }) => {
     const cohort = service.session.getCohort(cohortId)!;
-    const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-    const payment = p2tr(aggPk);
+    const script = OutScript.encode(Address(NETWORK).decode(cohort.beaconAddress));
     const prevOutValue = 100000n;
-    const tx = new Transaction({ version: 2 });
+    const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
     tx.addInput({
-      txid        : '00'.repeat(32),
-      index       : 0,
-      witnessUtxo : { amount: prevOutValue, script: payment.script },
+      txid           : '00'.repeat(32),
+      index          : 0,
+      witnessUtxo    : { amount: prevOutValue, script },
+      tapInternalKey : cohort.internalKey,
     });
-    tx.addOutput({ script: payment.script, amount: prevOutValue - 500n });
-    return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+    tx.addOutput({ script, amount: prevOutValue - 500n });
+    tx.addOutput({ script: Script.encode(['RETURN', signalBytes]), amount: 0n });
+    return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
   },
 });
 

--- a/packages/aggregation/lib/operations/aggregation/e2e-http-transport.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-http-transport.ts
@@ -19,10 +19,10 @@ import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater, resolveBtcr2S
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { createServer } from 'node:http';
 
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils';
-import { p2tr, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Address, OutScript, Script, Transaction } from '@scure/btc-signer';
 
 import type { HttpRequestLike, SseStream, Transport } from '../../../src/index.js';
 import {
@@ -36,6 +36,7 @@ import {
 
 const PORT    = Number(process.env.PORT ?? 8080);
 const BASE_URL = `http://localhost:${PORT}/`;
+const NETWORK = getNetwork('mutinynet');
 
 // ────────────────────────────────────────────────
 // Keys + DIDs. Service and Alice are KEY (k1) DIDs: the pubkey derives from the
@@ -206,19 +207,24 @@ const service = new AggregationServiceRunner({
   keys      : serviceKeys,
   config    : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: bytesToHex(serviceKeys.publicKey.compressed.slice(1)), recoverySequence: 144 },
 
-  onProvideTxData : async ({ cohortId }) => {
+  onProvideTxData : async ({ cohortId, signalBytes }) => {
     const cohort = service.session.getCohort(cohortId)!;
-    const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-    const payment = p2tr(aggPk);
+    // Spend the cohort's script-tree beacon output (the funded address's
+    // scriptPubKey, NOT a tree-less p2tr of the aggregate key), return
+    // self-change to the beacon script, and anchor the signal in a single
+    // zero-value OP_RETURN: participants verify all of this before signing.
+    const script = OutScript.encode(Address(NETWORK).decode(cohort.beaconAddress));
     const prevOutValue = 100000n;
-    const tx = new Transaction({ version: 2 });
+    const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
     tx.addInput({
-      txid        : '00'.repeat(32),
-      index       : 0,
-      witnessUtxo : { amount: prevOutValue, script: payment.script },
+      txid           : '00'.repeat(32),
+      index          : 0,
+      witnessUtxo    : { amount: prevOutValue, script },
+      tapInternalKey : cohort.internalKey,
     });
-    tx.addOutput({ script: payment.script, amount: prevOutValue - 500n });
-    return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+    tx.addOutput({ script, amount: prevOutValue - 500n });
+    tx.addOutput({ script: Script.encode(['RETURN', signalBytes]), amount: 0n });
+    return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
   },
 });
 

--- a/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
@@ -11,10 +11,10 @@ import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater, resolveBtcr2S
  * Usage:
  *   RELAY=ws://localhost:7777 bun lib/operations/aggregation/e2e-per-actor-transport.ts
  */
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { bytesToHex } from '@noble/hashes/utils';
-import { p2tr, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Address, OutScript, Script, Transaction } from '@scure/btc-signer';
 import type {
   Transport} from '../../../src/index.js';
 import {
@@ -24,6 +24,7 @@ import {
 } from '../../../src/index.js';
 
 const RELAY = process.env.RELAY ?? 'ws://localhost:7777';
+const NETWORK = getNetwork('mutinynet');
 
 const serviceKeys = SchnorrKeyPair.generate();
 const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
@@ -109,19 +110,24 @@ const service = new AggregationServiceRunner({
   keys      : serviceKeys,
   config    : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: bytesToHex(serviceKeys.publicKey.compressed.slice(1)), recoverySequence: 144 },
 
-  onProvideTxData : async ({ cohortId }) => {
+  onProvideTxData : async ({ cohortId, signalBytes }) => {
     const cohort = service.session.getCohort(cohortId)!;
-    const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-    const payment = p2tr(aggPk);
+    // Spend the cohort's script-tree beacon output (the funded address's
+    // scriptPubKey, NOT a tree-less p2tr of the aggregate key), return
+    // self-change to the beacon script, and anchor the signal in a single
+    // zero-value OP_RETURN: participants verify all of this before signing.
+    const script = OutScript.encode(Address(NETWORK).decode(cohort.beaconAddress));
     const prevOutValue = 100000n;
-    const tx = new Transaction({ version: 2 });
+    const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
     tx.addInput({
-      txid        : '00'.repeat(32),
-      index       : 0,
-      witnessUtxo : { amount: prevOutValue, script: payment.script },
+      txid           : '00'.repeat(32),
+      index          : 0,
+      witnessUtxo    : { amount: prevOutValue, script },
+      tapInternalKey : cohort.internalKey,
     });
-    tx.addOutput({ script: payment.script, amount: prevOutValue - 500n });
-    return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+    tx.addOutput({ script, amount: prevOutValue - 500n });
+    tx.addOutput({ script: Script.encode(['RETURN', signalBytes]), amount: 0n });
+    return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
   },
 });
 

--- a/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
@@ -25,11 +25,11 @@ import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/me
  * Exit code: 0 on success, non-zero on any assertion failure.
  */
 import assert from 'node:assert/strict';
+import { getNetwork } from '@did-btcr2/bitcoin';
 import { LocalSigner, SchnorrKeyPair } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/hashes/utils';
-import { p2tr, SigHash, Transaction } from '@scure/btc-signer';
-import * as musig2 from '@scure/btc-signer/musig2';
+import { Address, OutScript, Script, SigHash, Transaction } from '@scure/btc-signer';
 import type { Transport } from '../../../src/index.js';
 import {
   AggregationParticipantRunner,
@@ -40,6 +40,7 @@ import {
 
 const RELAY = process.env.RELAY ?? 'ws://localhost:7777';
 const TIMEOUT_MS = Number(process.env.TIMEOUT_MS ?? 60_000);
+const NETWORK = getNetwork('mutinynet');
 
 // ── Identities ──
 const serviceKeys = SchnorrKeyPair.generate();
@@ -103,24 +104,34 @@ const service = new AggregationServiceRunner({
   config      : { minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon', recoveryKey: bytesToHex(serviceKeys.publicKey.compressed.slice(1)), recoverySequence: 144 },
   cohortTtlMs : TIMEOUT_MS,
 
-  onProvideTxData : async ({ cohortId }) => {
+  onProvideTxData : async ({ cohortId, signalBytes }) => {
     const cohort = service.session.getCohort(cohortId)!;
-    const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
-    const payment = p2tr(aggPk);
+    // Spend the cohort's script-tree beacon output (the funded address's
+    // scriptPubKey, NOT a tree-less p2tr of the aggregate key), return
+    // self-change to the beacon script, and anchor the signal in a single
+    // zero-value OP_RETURN: participants verify all of this before signing.
+    const script = OutScript.encode(Address(NETWORK).decode(cohort.beaconAddress));
     const prevOutValue = 100_000n;
-    const tx = new Transaction({ version: 2 });
+    const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
     tx.addInput({
-      txid        : '00'.repeat(32),
-      index       : 0,
-      witnessUtxo : { amount: prevOutValue, script: payment.script },
+      txid           : '00'.repeat(32),
+      index          : 0,
+      witnessUtxo    : { amount: prevOutValue, script },
+      tapInternalKey : cohort.internalKey,
     });
-    tx.addOutput({ script: payment.script, amount: prevOutValue - 500n });
+    tx.addOutput({ script, amount: prevOutValue - 500n });
+    tx.addOutput({ script: Script.encode(['RETURN', signalBytes]), amount: 0n });
 
-    capturedTweakedPk = payment.tweakedPubkey;
-    capturedSighash = tx.preimageWitnessV1(0, [payment.script], SigHash.DEFAULT, [prevOutValue]);
+    // The output script of a P2TR address is OP_1 <32-byte tweaked pubkey>:
+    // the tweaked key is read back from the funded script itself so the final
+    // BIP-340 check verifies against the exact key the UTXO commits to.
+    const decoded = OutScript.decode(script);
+    assert.ok(decoded.type === 'tr', 'beacon output is not P2TR');
+    capturedTweakedPk = decoded.pubkey;
+    capturedSighash = tx.preimageWitnessV1(0, [script], SigHash.DEFAULT, [prevOutValue]);
     capturedBeaconAddress = cohort.beaconAddress;
 
-    return { tx, prevOutScripts: [payment.script], prevOutValues: [prevOutValue] };
+    return { tx, prevOutScripts: [script], prevOutValues: [prevOutValue] };
   },
 });
 

--- a/packages/aggregation/src/core/beacon-strategy.ts
+++ b/packages/aggregation/src/core/beacon-strategy.ts
@@ -1,4 +1,4 @@
-import { canonicalize } from '@did-btcr2/common';
+import { canonicalize, hash } from '@did-btcr2/common';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof } from '@did-btcr2/smt';
 import { base64UrlToHash, blockHash, didToIndex, hashToBase64Url, verifySerializedProof } from '@did-btcr2/smt';
@@ -56,6 +56,17 @@ export interface AggregateBeaconStrategy {
     expectedHash?: string;
     body: BaseBody;
   }): BeaconValidationResult;
+
+  /**
+   * Participant: recompute the signal bytes the validated aggregated content
+   * commits to (CAS: hash of the canonical announcement; SMT: the tree root
+   * the proof's `id` names). The participant compares this against the
+   * coordinator-supplied `signalBytesHex` so an equivocating coordinator
+   * cannot bind the member's consent (and later its signature) to a signal
+   * that does not match the content it validated. Returns undefined when the
+   * validation result carries no signal-bearing sidecar.
+   */
+  expectedSignal(result: BeaconValidationResult): Uint8Array | undefined;
 }
 
 const CAS_STRATEGY: AggregateBeaconStrategy = {
@@ -80,6 +91,11 @@ const CAS_STRATEGY: AggregateBeaconStrategy = {
       matches : casAnnouncement[participantDid] === expectedHash,
       casAnnouncement,
     };
+  },
+
+  expectedSignal(result) {
+    if(!result.casAnnouncement) return undefined;
+    return hash(canonicalize(result.casAnnouncement));
   },
 };
 
@@ -122,6 +138,16 @@ const SMT_STRATEGY: AggregateBeaconStrategy = {
       matches : verifySerializedProof(smtProof, index, candidateHash),
       smtProof,
     };
+  },
+
+  expectedSignal(result) {
+    const rootId = result.smtProof?.id;
+    if(typeof rootId !== 'string') return undefined;
+    try {
+      return base64UrlToHash(rootId);
+    } catch {
+      return undefined;
+    }
   },
 };
 

--- a/packages/aggregation/src/core/messages/base.ts
+++ b/packages/aggregation/src/core/messages/base.ts
@@ -32,6 +32,10 @@ export type BaseBody = Partial<CohortConditions> & {
   /** Hex-encoded scriptPubKey of the UTXO being spent. Required for BIP-341 sighash. */
   prevOutScriptHex?: string;
   prevOutValue?: string;
+  /** Display-order txid of the beacon UTXO the signing tx spends (input 0). */
+  fundingTxid?: string;
+  /** Output index of the beacon UTXO the signing tx spends (input 0). */
+  fundingVout?: number;
   communicationPk?: Uint8Array;
   data?: string;
   /**

--- a/packages/aggregation/src/core/messages/bodies.ts
+++ b/packages/aggregation/src/core/messages/bodies.ts
@@ -102,6 +102,10 @@ export interface AuthorizationRequestBody {
   pendingTx: string;
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid of the beacon UTXO the pending tx spends (input 0). */
+  fundingTxid: string;
+  /** Output index of the beacon UTXO the pending tx spends (input 0). */
+  fundingVout: number;
 }
 
 export interface NonceContributionBody {
@@ -135,6 +139,10 @@ export interface FallbackAuthorizationRequestBody {
   pendingTx: string;
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid of the beacon UTXO the pending tx spends (input 0). */
+  fundingTxid: string;
+  /** Output index of the beacon UTXO the pending tx spends (input 0). */
+  fundingVout: number;
   fallbackLeafScriptHex: string;
 }
 
@@ -279,6 +287,8 @@ export function isSubmitUpdateMessage(m: BaseMessage): m is SubmitUpdateMessage 
     const pv = (proof as Record<string, unknown>).proofValue;
     if(vm !== undefined && typeof vm !== 'string') return false;
     if(pv !== undefined && typeof pv !== 'string') return false;
+    const cap = (proof as Record<string, unknown>).capability;
+    if(cap !== undefined && typeof cap !== 'string') return false;
   }
   return true;
 }
@@ -307,7 +317,9 @@ export function isAuthorizationRequestMessage(m: BaseMessage): m is Authorizatio
     && hasStr(m.body, 'sessionId')
     && hasStr(m.body, 'pendingTx')
     && hasStr(m.body, 'prevOutScriptHex')
-    && hasStr(m.body, 'prevOutValue');
+    && hasStr(m.body, 'prevOutValue')
+    && hasStr(m.body, 'fundingTxid')
+    && hasIntMin(m.body, 'fundingVout', 0);
 }
 
 export function isNonceContributionMessage(m: BaseMessage): m is NonceContributionMessage {
@@ -338,6 +350,8 @@ export function isFallbackAuthorizationRequestMessage(m: BaseMessage): m is Fall
     && hasStr(m.body, 'pendingTx')
     && hasStr(m.body, 'prevOutScriptHex')
     && hasStr(m.body, 'prevOutValue')
+    && hasStr(m.body, 'fundingTxid')
+    && hasIntMin(m.body, 'fundingVout', 0)
     && hasStr(m.body, 'fallbackLeafScriptHex');
 }
 

--- a/packages/aggregation/src/core/messages/factories.ts
+++ b/packages/aggregation/src/core/messages/factories.ts
@@ -192,6 +192,10 @@ type AuthorizationRequestMessage = {
   pendingTx: string;
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid of the beacon UTXO the pending tx spends (input 0). */
+  fundingTxid: string;
+  /** Output index of the beacon UTXO the pending tx spends (input 0). */
+  fundingVout: number;
 };
 type NonceContributionMessage = {
   from: string;
@@ -274,6 +278,10 @@ type FallbackAuthorizationRequestMessage = {
   pendingTx: string;
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid of the beacon UTXO the pending tx spends (input 0). */
+  fundingTxid: string;
+  /** Output index of the beacon UTXO the pending tx spends (input 0). */
+  fundingVout: number;
   fallbackLeafScriptHex: string;
 };
 type FallbackSignatureMessage = {

--- a/packages/aggregation/src/core/signing-session.ts
+++ b/packages/aggregation/src/core/signing-session.ts
@@ -263,8 +263,18 @@ export class BeaconSigningSession {
   /**
    * Generates a fresh MuSig2 nonce contribution for the participant.
    * Stores the secret nonce internally for use in `generatePartialSignature()`.
+   *
+   * Callable once per session: a repeated call would silently overwrite the
+   * retained secret nonce, and a MuSig2 secret nonce must never linger past its
+   * round. A session that needs a new nonce is a new session.
    */
   public generateNonceContribution(participantPublicKey: Uint8Array, participantSecretKey: Uint8Array): Uint8Array {
+    if(this.#secretNonce) {
+      throw new SigningSessionError(
+        'Nonce contribution already generated for this session; create a new session for a new round.',
+        'NONCE_ALREADY_GENERATED'
+      );
+    }
     const aggPublicKey = musig2.keyAggExport(musig2.keyAggregate(this.cohort.cohortKeys));
     const nonces = musig2.nonceGen(participantPublicKey, participantSecretKey, aggPublicKey);
     this.#secretNonce = nonces.secret;

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -38,27 +38,32 @@ import type { AggregationSigner } from '../core/signer.js';
 import { BeaconSigningSession } from '../core/signing-session.js';
 
 /**
- * True if `tx` has an OP_RETURN output whose payload equals the 32-byte signal
- * `signalHex`. A member binds its fallback signature to the exact signal it
- * validated, so a coordinator that drives the fallback output selection cannot
- * anchor a different announcement (a stale signal, or one whose CAS/SMT root
- * omits the member's update) under the member's signature.
+ * Inspect the OP_RETURN outputs of `tx` against the 32-byte signal `signalHex`.
+ * A genuine beacon announcement carries exactly one OP_RETURN whose payload is
+ * the signal; a coordinator that pads the tx with extra OP_RETURNs (only one of
+ * which matches) or omits the match must fail approval, because a member binds
+ * its signature to the exact signal it validated.
  */
-function txEmbedsSignal(tx: Transaction, signalHex: string): boolean {
+function txSignalAnchor(tx: Transaction, signalHex: string): { opReturnCount: number; anchored: boolean } {
   let expected: Uint8Array;
-  try { expected = hexToBytes(signalHex); } catch { return false; }
-  if(expected.length === 0) return false;
+  try { expected = hexToBytes(signalHex); } catch { expected = new Uint8Array(); }
+  let opReturnCount = 0;
+  let anchored = false;
   for(let i = 0; i < tx.outputsLength; i++) {
     const script = tx.getOutput(i)?.script;
     if(!script) continue;
     let decoded: Array<string | Uint8Array>;
     try { decoded = Script.decode(script) as Array<string | Uint8Array>; } catch { continue; }
-    if(decoded.length === 2 && decoded[0] === 'RETURN' && decoded[1] instanceof Uint8Array) {
+    if(decoded[0] !== 'RETURN') continue;
+    opReturnCount += 1;
+    if(decoded.length === 2 && decoded[1] instanceof Uint8Array) {
       const payload = decoded[1];
-      if(payload.length === expected.length && payload.every((b, j) => b === expected[j])) return true;
+      if(expected.length > 0 && payload.length === expected.length && payload.every((b, j) => b === expected[j])) {
+        anchored = true;
+      }
     }
   }
-  return false;
+  return { opReturnCount, anchored };
 }
 
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
@@ -132,6 +137,9 @@ export interface PendingSigningRequest {
   /** Hex-encoded scriptPubKey of the UTXO being spent. Required for BIP-341 sighash. */
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid:vout of the beacon UTXO the pending tx must spend (input 0). */
+  fundingTxid: string;
+  fundingVout: number;
 }
 
 /**
@@ -145,6 +153,9 @@ export interface PendingFallbackRequest {
   pendingTxHex: string;
   prevOutScriptHex: string;
   prevOutValue: string;
+  /** Display-order txid:vout of the beacon UTXO the pending tx must spend (input 0). */
+  fundingTxid: string;
+  fundingVout: number;
   /** Fallback leaf script, hex (advisory; the member recomputes it from its own cohort). */
   fallbackLeafScriptHex: string;
 }
@@ -538,6 +549,15 @@ export class AggregationParticipant {
       body            : message.body!,
     });
 
+    // Never trust the coordinator-supplied signal: recompute it from the
+    // content just validated and drop an equivocated distribution. Otherwise a
+    // coordinator could bind this member's ack (and later its signature) to a
+    // signal whose CAS/SMT content differs from what the member saw.
+    const recomputed = strategy.expectedSignal(result);
+    let distributed: Uint8Array | undefined;
+    try { distributed = hexToBytes(signalBytesHex); } catch { distributed = undefined; }
+    if(!recomputed || !distributed || !bytesEqual(recomputed, distributed)) return;
+
     state.validation = {
       cohortId,
       beaconType,
@@ -619,7 +639,10 @@ export class AggregationParticipant {
     const pendingTxHex = message.body?.pendingTx;
     const prevOutScriptHex = message.body?.prevOutScriptHex;
     const prevOutValue = message.body?.prevOutValue;
+    const fundingTxid = message.body?.fundingTxid;
+    const fundingVout = message.body?.fundingVout;
     if(!sessionId || !pendingTxHex || !prevOutScriptHex || !prevOutValue) return;
+    if(!fundingTxid || !Number.isInteger(fundingVout) || fundingVout! < 0) return;
 
     state.signingRequest = {
       cohortId,
@@ -627,6 +650,8 @@ export class AggregationParticipant {
       pendingTxHex,
       prevOutScriptHex,
       prevOutValue,
+      fundingTxid,
+      fundingVout : fundingVout!,
     };
     state.phase = ParticipantCohortPhase.AwaitingSigning;
   }
@@ -647,10 +672,37 @@ export class AggregationParticipant {
         'MISSING_STATE', { cohortId }
       );
     }
-    if(!txEmbedsSignal(tx, signalHex)) {
+    const { opReturnCount, anchored } = txSignalAnchor(tx, signalHex);
+    if(opReturnCount !== 1) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} carries ${opReturnCount} OP_RETURN outputs; a beacon announcement must carry exactly one.`,
+        'SIGNAL_MISMATCH', { cohortId, opReturnCount }
+      );
+    }
+    if(!anchored) {
       throw new AggregationParticipantError(
         `Transaction for cohort ${cohortId} does not anchor the validated signal.`,
         'SIGNAL_MISMATCH', { cohortId }
+      );
+    }
+  }
+
+  /**
+   * Refuse to sign unless input 0 of the service-supplied tx spends exactly the
+   * funded outpoint declared on the authorization request. The sighash binds
+   * the prevout script and amount, but not which beacon-address UTXO funds the
+   * spend; without this check the coordinator could silently choose which of
+   * the cohort's UTXOs is consumed.
+   */
+  #assertFundedOutpoint(cohortId: string, tx: Transaction, fundingTxid: string, fundingVout: number): void {
+    const input = tx.getInput(0);
+    const inputTxid = input?.txid === undefined
+      ? undefined
+      : (typeof input.txid === 'string' ? input.txid : bytesToHex(input.txid)).toLowerCase();
+    if(inputTxid !== fundingTxid.toLowerCase() || input?.index !== fundingVout) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} does not spend the declared funded outpoint ${fundingTxid}:${fundingVout}.`,
+        'FUNDING_OUTPOINT_MISMATCH', { cohortId }
       );
     }
   }
@@ -785,6 +837,10 @@ export class AggregationParticipant {
     // Refuse to sign unless the tx anchors the signal this member validated.
     this.#assertTxAnchorsValidatedSignal(cohortId, state, tx);
 
+    // Refuse to sign unless input 0 spends the funded outpoint the service
+    // declared on the authorization request.
+    this.#assertFundedOutpoint(cohortId, tx, state.signingRequest.fundingTxid, state.signingRequest.fundingVout);
+
     // Derive UTXO metadata for Taproot sighash (BIP-341). Use the script
     // supplied by the service in AUTHORIZATION_REQUEST rather than reading
     // the change output: input and change may use different scripts in future
@@ -913,16 +969,31 @@ export class AggregationParticipant {
     const pendingTxHex = message.body?.pendingTx;
     const prevOutScriptHex = message.body?.prevOutScriptHex;
     const prevOutValue = message.body?.prevOutValue;
+    const fundingTxid = message.body?.fundingTxid;
+    const fundingVout = message.body?.fundingVout;
     const fallbackLeafScriptHex = message.body?.fallbackLeafScriptHex;
     if(!sessionId || !pendingTxHex || !prevOutScriptHex || !prevOutValue || !fallbackLeafScriptHex) return;
+    if(!fundingTxid || !Number.isInteger(fundingVout) || fundingVout! < 0) return;
 
     // The fallback must belong to this member's in-flight signing session (the
-    // service reuses the optimistic session id). When no local session exists yet
-    // (a reordered fallback arriving before the AUTHORIZATION_REQUEST) there is
-    // nothing to compare, so the request is accepted.
-    if(state.signingSession && sessionId !== state.signingSession.id) return;
+    // service reuses the optimistic session id). Before the session exists the
+    // binding falls back to the authorization request's session id, so a
+    // reordered fallback arriving while AwaitingSigning is still checked. Only
+    // when neither exists (a fallback arriving straight after validation) is
+    // there nothing to compare, and the request is accepted.
+    const boundSessionId = state.signingSession?.id ?? state.signingRequest?.sessionId;
+    if(boundSessionId !== undefined && sessionId !== boundSessionId) return;
 
-    state.fallbackRequest = { cohortId, sessionId, pendingTxHex, prevOutScriptHex, prevOutValue, fallbackLeafScriptHex };
+    state.fallbackRequest = {
+      cohortId,
+      sessionId,
+      pendingTxHex,
+      prevOutScriptHex,
+      prevOutValue,
+      fundingTxid,
+      fundingVout : fundingVout!,
+      fallbackLeafScriptHex,
+    };
     // The optimistic path is abandoned; wipe any retained secret nonce for it.
     state.signingSession?.clearSecrets();
     state.phase = ParticipantCohortPhase.AwaitingFallbackSig;
@@ -958,6 +1029,10 @@ export class AggregationParticipant {
     // Refuse to sign unless the fallback tx anchors the signal this member
     // validated (the coordinator drives output selection on the fallback path).
     this.#assertTxAnchorsValidatedSignal(cohortId, state, tx);
+
+    // Refuse to sign unless input 0 spends the funded outpoint the service
+    // declared on the fallback authorization request.
+    this.#assertFundedOutpoint(cohortId, tx, req.fundingTxid, req.fundingVout);
 
     // The fallback signs the SAME beacon tx with SIGHASH_DEFAULT, so the full
     // output/fee sanity check applies identically.

--- a/packages/aggregation/src/service/service.ts
+++ b/packages/aggregation/src/service/service.ts
@@ -39,6 +39,23 @@ import { ServiceCohortPhase } from '../core/phases.js';
 import { BeaconSigningSession } from '../core/signing-session.js';
 
 /**
+ * Extract the funded outpoint (display-order txid + vout) a signing tx spends
+ * at input 0. Carried on the (fallback) authorization request so participants
+ * can verify the tx they sign spends exactly this beacon UTXO.
+ */
+function fundingOutpointOf(tx: Transaction, cohortId: string): { fundingTxid: string; fundingVout: number } {
+  const input = tx.getInput(0);
+  if(!input?.txid || input.index === undefined) {
+    throw new AggregationServiceError(
+      `Cannot start signing for cohort ${cohortId}: the pending tx has no outpoint at input 0.`,
+      'MISSING_FUNDING_OUTPOINT', { cohortId }
+    );
+  }
+  const txid = typeof input.txid === 'string' ? input.txid : bytesToHex(input.txid);
+  return { fundingTxid: txid.toLowerCase(), fundingVout: input.index };
+}
+
+/**
  * Cohort configuration set by the service operator: the advertised cohort
  * {@link CohortConditions} plus the Bitcoin network. `beaconType` and
  * `minParticipants` are required; the other conditions are optional (absent =
@@ -103,6 +120,7 @@ export type RejectionReason =
   | 'INVALID_PARTIAL_SIG'
   | 'DUPLICATE_PARTIAL_SIG'
   | 'BAD_PARTIAL_SIG'
+  | 'SIGNAL_MISMATCH'
   | 'SESSION_ERROR';
 
 /** Record of a silently-dropped inbound message. Drained by the runner to emit events. */
@@ -157,6 +175,9 @@ interface ServiceCohortState {
 
 /** Default maximum canonicalized byte-length of a submitted BTCR2 update. */
 export const DEFAULT_MAX_UPDATE_SIZE_BYTES = 256 * 1024;
+
+/** Prefix of the ZCAP root capability a did:btcr2 update proof invokes (`urn:zcap:root:<url-encoded did>`). */
+const ROOT_CAPABILITY_PREFIX = 'urn:zcap:root:';
 
 /**
  * Default cap on pending (not-yet-accepted) opt-ins retained per cohort. Opt-ins
@@ -694,8 +715,8 @@ export class AggregationService {
    * Verify the BIP-340 Schnorr Data Integrity proof on a submitted update using the
    * participant's accepted cohort key. Returns `false` (and the update is silently
    * dropped) if the proof is missing or malformed, the verificationMethod does
-   * not name the sender's DID, the update document carries an `id` naming a DID
-   * other than the sender's, the sender has no accepted key on record,
+   * not name the sender's DID, the proof's root capability names a DID other
+   * than the sender's, the sender has no accepted key on record,
    * or the signature fails verification.
    * @param {ServiceCohortState} state - the current state of the cohort to which the update was submitted
    * @param {string} sender - the DID of the participant who submitted the update
@@ -719,13 +740,19 @@ export class AggregationService {
     const vmDid = proof.verificationMethod.split('#')[0];
     if(vmDid !== sender) return false;
 
-    // If the update document carries an `id`, it must be the sender's own DID:
-    // a validly-signed update whose document id names a DIFFERENT DID would be
-    // aggregated under the sender's key while actually updating someone else's
-    // DID document. Updates without an `id` (e.g. patch-only
-    // payloads) are unaffected.
-    const docId = (signedUpdate as { id?: unknown }).id;
-    if(typeof docId === 'string' && docId !== sender) return false;
+    // The proof's root capability names the DID being updated
+    // (`urn:zcap:root:<url-encoded did>`); it must be the sender's own DID.
+    // Without this check a member could submit a validly-proved update naming
+    // a DIFFERENT DID and have it aggregated under its own slot.
+    const capability = proof.capability;
+    if(typeof capability !== 'string' || !capability.startsWith(ROOT_CAPABILITY_PREFIX)) return false;
+    let capabilityDid: string;
+    try {
+      capabilityDid = decodeURIComponent(capability.slice(ROOT_CAPABILITY_PREFIX.length));
+    } catch {
+      return false;
+    }
+    if(capabilityDid !== sender) return false;
 
     // The sender's key is the one accepted into the cohort:
     // pending-but-unaccepted opt-ins no longer authenticate submissions.
@@ -824,7 +851,11 @@ export class AggregationService {
     // cohort into signing.
     const signalBytesHex = message.body?.signalBytesHex;
     const expectedHex = state.cohort.signalBytes ? bytesToHex(state.cohort.signalBytes) : undefined;
-    if(!signalBytesHex || signalBytesHex !== expectedHex) return;
+    if(!signalBytesHex || signalBytesHex !== expectedHex) {
+      this.#reject(state, message.from, 'SIGNAL_MISMATCH',
+        'Validation ack does not commit to the distributed signal');
+      return;
+    }
 
     // addValidation throws UNKNOWN_PARTICIPANT for a non-member ack. Convert to a
     // recorded rejection: an opted-in-but-not-accepted (or former) sender who
@@ -887,6 +918,11 @@ export class AggregationService {
       );
     }
 
+    // Declare the funded outpoint the tx spends so each participant can bind
+    // its signature to the exact beacon UTXO, not just the beacon script and
+    // amount committed by the sighash.
+    const { fundingTxid, fundingVout } = fundingOutpointOf(txData.tx, cohortId);
+
     const messages: BaseMessage[] = [];
     for(const participantDid of state.cohort.participants) {
       messages.push(createAuthorizationRequestMessage({
@@ -897,6 +933,8 @@ export class AggregationService {
         pendingTx        : txData.tx.hex,
         prevOutScriptHex : bytesToHex(prevOutScript),
         prevOutValue     : txData.prevOutValues[0]?.toString() ?? '0',
+        fundingTxid,
+        fundingVout,
       }));
     }
     return messages;
@@ -1152,6 +1190,8 @@ export class AggregationService {
     state.fallbackRequired = false;
     state.phase = ServiceCohortPhase.FallbackRequested;
 
+    const { fundingTxid, fundingVout } = fundingOutpointOf(session.pendingTx, cohortId);
+
     const messages: BaseMessage[] = [];
     for(const participantDid of state.cohort.participants) {
       messages.push(createFallbackAuthorizationRequestMessage({
@@ -1162,6 +1202,8 @@ export class AggregationService {
         pendingTx             : session.pendingTx.hex,
         prevOutScriptHex      : bytesToHex(prevOutScript),
         prevOutValue          : prevOutValue.toString(),
+        fundingTxid,
+        fundingVout,
         fallbackLeafScriptHex : bytesToHex(fallbackLeaf),
       }));
     }

--- a/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-auth-hardening.spec.ts
@@ -340,6 +340,8 @@ describe('Aggregation transport + message auth hardening', () => {
         pendingTx             : 'aa',
         prevOutScriptHex      : 'bb',
         prevOutValue          : '1000',
+        fundingTxid           : '00'.repeat(32),
+        fundingVout           : 0,
         fallbackLeafScriptHex : 'cc',
       }));
       expect(ctx.aliceP.pendingFallbackRequests.has(cohortId)).to.be.false;
@@ -362,6 +364,8 @@ describe('Aggregation transport + message auth hardening', () => {
         pendingTx        : 'aa',
         prevOutScriptHex : 'bb',
         prevOutValue     : '1000',
+        fundingTxid      : '00'.repeat(32),
+        fundingVout      : 0,
       }));
       expect(ctx.aliceP.pendingSigningRequests.has(cohortId)).to.be.false;
       expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
@@ -431,10 +435,51 @@ describe('Aggregation transport + message auth hardening', () => {
         pendingTx             : 'aa',
         prevOutScriptHex      : 'bb',
         prevOutValue          : '1000',
+        fundingTxid           : '00'.repeat(32),
+        fundingVout           : 0,
         fallbackLeafScriptHex : 'cc',
       }));
       expect(ctx.aliceP.pendingFallbackRequests.has(cohortId)).to.be.false;
       expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      // Control: the service's genuine fallback reuses the session id and is accepted
+      route(ctx.service.startFallbackSigning(cohortId), { [ctx.alice.did]: ctx.aliceP });
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+    });
+
+    it('ignores a fallback request naming a foreign session id before nonce approval', () => {
+      const ctx = setup();
+      const cohortId = driveToOptedIn(ctx);
+      driveToValidation(ctx, cohortId);
+      route(ctx.aliceP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+      route(ctx.bobP.approveValidation(cohortId), { [ctx.svc.did]: ctx.service });
+
+      const cohort = ctx.service.getCohort(cohortId)!;
+      const script = beaconOutputScript(cohort);
+      const tx = buildSignalTx(script, 100000n, cohort.signalBytes!);
+      route(ctx.service.startSigning(cohortId, {
+        tx,
+        prevOutScripts : [script],
+        prevOutValues  : [100000n],
+      }), { [ctx.alice.did]: ctx.aliceP, [ctx.bob.did]: ctx.bobP });
+
+      // Alice is AwaitingSigning: no signing session exists yet, only the
+      // authorization request's session id to bind against.
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingSigning);
+      ctx.aliceP.receive(createFallbackAuthorizationRequestMessage({
+        from                  : ctx.svc.did,
+        to                    : ctx.alice.did,
+        cohortId,
+        sessionId             : 'foreign-session',
+        pendingTx             : 'aa',
+        prevOutScriptHex      : 'bb',
+        prevOutValue          : '1000',
+        fundingTxid           : '00'.repeat(32),
+        fundingVout           : 0,
+        fallbackLeafScriptHex : 'cc',
+      }));
+      expect(ctx.aliceP.pendingFallbackRequests.has(cohortId)).to.be.false;
+      expect(ctx.aliceP.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingSigning);
 
       // Control: the service's genuine fallback reuses the session id and is accepted
       route(ctx.service.startFallbackSigning(cohortId), { [ctx.alice.did]: ctx.aliceP });
@@ -530,5 +575,60 @@ describe('Aggregation transport + message auth hardening', () => {
       route(bobP.approveValidation(cohortId), parties);
       expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
     });
+  });
+
+  describe('participant recomputes the distributed signal', () => {
+    function setupAndDrive(beaconType: string) {
+      const svc = makeIdentity();
+      const alice = makeIdentity();
+      const bob = makeIdentity();
+      const service = new AggregationService({ did: svc.did, publicKey: svc.keys.publicKey });
+      const aliceP = new AggregationParticipant({ did: alice.did, signer: new KeyPairAggregationSigner(alice.keys) });
+      const bobP = new AggregationParticipant({ did: bob.did, signer: new KeyPairAggregationSigner(bob.keys) });
+      const parties = { [svc.did]: service, [alice.did]: aliceP, [bob.did]: bobP };
+
+      const cohortId = service.createCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType,
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      route(service.advertise(cohortId), parties);
+      route(aliceP.joinCohort(cohortId), parties);
+      route(bobP.joinCohort(cohortId), parties);
+      route(service.acceptParticipant(cohortId, alice.did), parties);
+      route(service.acceptParticipant(cohortId, bob.did), parties);
+      route(service.finalizeKeygen(cohortId), parties);
+      route(aliceP.submitUpdate(cohortId, createSignedUpdate(alice.did, alice.keys)), parties);
+      route(bobP.submitUpdate(cohortId, createSignedUpdate(bob.did, bob.keys)), parties);
+      return { svc, alice, bob, service, aliceP, bobP, parties, cohortId };
+    }
+
+    for(const beaconType of ['CASBeacon', 'SMTBeacon']) {
+      it(`${beaconType}: drops a distribution whose signalBytesHex does not match its content`, () => {
+        const ctx = setupAndDrive(beaconType);
+        const distMsgs = ctx.service.buildAndDistribute(ctx.cohortId);
+        const forAlice = distMsgs.find(m => m.to === ctx.alice.did)!;
+        const forBob = distMsgs.find(m => m.to === ctx.bob.did)!;
+
+        // An equivocating coordinator hands Alice content that does not hash to
+        // the declared signal. The participant recomputes the signal from the
+        // content and must drop the message instead of acking or signing it.
+        const tampered = new BaseMessage({
+          type    : forAlice.type,
+          from    : forAlice.from,
+          to      : forAlice.to,
+          body    : { ...forAlice.body!, cohortId: ctx.cohortId, signalBytesHex: 'ab'.repeat(32) },
+        });
+        ctx.aliceP.receive(tampered);
+        expect(ctx.aliceP.pendingValidations.has(ctx.cohortId)).to.be.false;
+        expect(ctx.aliceP.getCohortPhase(ctx.cohortId)).to.equal(ParticipantCohortPhase.UpdateSubmitted);
+
+        // Control: the genuine distribution surfaces for validation.
+        ctx.bobP.receive(forBob);
+        expect(ctx.bobP.pendingValidations.has(ctx.cohortId)).to.be.true;
+      });
+    }
   });
 });

--- a/packages/aggregation/tests/aggregation-dos-hardening.spec.ts
+++ b/packages/aggregation/tests/aggregation-dos-hardening.spec.ts
@@ -55,7 +55,7 @@ function makeIdentity(network = 'mutinynet'): { keys: SchnorrKeyPair; did: strin
 function createSignedUpdate(
   did: string,
   keys: SchnorrKeyPair,
-  opts?: { docId?: string },
+  opts?: { capabilityDid?: string },
 ): SignedBTCR2Update {
   const context = [
     'https://w3id.org/security/v2',
@@ -71,7 +71,6 @@ function createSignedUpdate(
     sourceHash      : `zQmSourceHash${did.slice(-6)}`,
     targetHash      : `zQmTargetHash${did.slice(-6)}`,
     targetVersionId : 2,
-    ...(opts?.docId ? { id: opts.docId } : {}),
   } as UnsignedBTCR2Update;
   const config: Btcr2DataIntegrityConfig = {
     '@context'         : context,
@@ -79,7 +78,7 @@ function createSignedUpdate(
     type               : 'DataIntegrityProof',
     verificationMethod : `${did}#initialKey`,
     proofPurpose       : 'capabilityInvocation',
-    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capability         : `urn:zcap:root:${encodeURIComponent(opts?.capabilityDid ?? did)}`,
     capabilityAction   : 'Write',
   };
   const multikey = SchnorrMultikey.fromSecretKey(`${did}#initialKey`, did, keys.secretKey.bytes);
@@ -1390,13 +1389,13 @@ describe('Aggregation DoS + liveness hardening', () => {
     });
   });
 
-  describe('update document id must match the sender DID', () => {
-    it('drops a validly-signed update whose document id names a different DID', () => {
+  describe('update proof capability must name the sender DID', () => {
+    it('drops a validly-signed update whose root capability names a different DID', () => {
       const victim = makeIdentity();
       const fx = driveToCohortSet();
-      // Alice signs correctly (her key, her verificationMethod), but the update
-      // document carries the victim's DID as its id.
-      const update = createSignedUpdate(fx.alice.did, fx.alice.keys, { docId: victim.did });
+      // Alice signs correctly (her key, her verificationMethod), but the proof
+      // invokes the root capability of the victim's DID, not her own.
+      const update = createSignedUpdate(fx.alice.did, fx.alice.keys, { capabilityDid: victim.did });
       fx.service.receive(createSubmitUpdateMessage({
         from         : fx.alice.did,
         to           : fx.serviceId.did,
@@ -1408,9 +1407,9 @@ describe('Aggregation DoS + liveness hardening', () => {
       expect(fx.service.collectedUpdates(fx.cohortId).has(fx.alice.did)).to.be.false;
     });
 
-    it('accepts an update whose document id matches the sender DID', () => {
+    it('accepts an update whose root capability names the sender DID', () => {
       const fx = driveToCohortSet();
-      const update = createSignedUpdate(fx.alice.did, fx.alice.keys, { docId: fx.alice.did });
+      const update = createSignedUpdate(fx.alice.did, fx.alice.keys, { capabilityDid: fx.alice.did });
       fx.service.receive(createSubmitUpdateMessage({
         from         : fx.alice.did,
         to           : fx.serviceId.did,

--- a/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
+++ b/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
@@ -1,9 +1,8 @@
 import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
 import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
-import { getNetwork } from '@did-btcr2/bitcoin';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { schnorr } from '@noble/curves/secp256k1.js';
-import { Script, SigHash, Transaction, p2tr } from '@scure/btc-signer';
+import { Script, SigHash, Transaction } from '@scure/btc-signer';
 import { expect } from 'chai';
 import {
   AggregationParticipant,
@@ -28,8 +27,6 @@ import {
   ServiceCohortPhase,
   SUBMIT_UPDATE,
   VALIDATION_ACK,
-  buildFallbackLeaf,
-  buildRecoveryLeaves,
   createFallbackAuthorizationRequestMessage,
   createFallbackSignatureMessage,
 } from '../src/index.js';
@@ -37,10 +34,10 @@ import { DidBtcr2 } from '@did-btcr2/method';
 import { bytesToHex } from '@noble/hashes/utils';
 import { MessageBus, MockTransport } from './helpers/mock-transport.js';
 import { beaconOutputScript } from './helpers/beacon-script.js';
+import { fallbackLeafScript } from './helpers/fallback-leaf.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
-const NET = getNetwork('mutinynet');
 
 function createSignedUpdate(did: string, keys: SchnorrKeyPair, version = 2): SignedBTCR2Update {
   const context = [
@@ -119,14 +116,7 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
 
   /** The real script-tree beacon output script the cohort's address commits to. */
   function beaconScript(cohortId: string): Uint8Array {
-    const cohort = service.getCohort(cohortId)!;
-    const leaves = buildRecoveryLeaves('operator-funded', {
-      recoveryKey       : cohort.recoveryKey!,
-      recoverySequence  : cohort.recoverySequence!,
-      cohortKeys        : cohort.cohortKeys,
-      fallbackThreshold : cohort.effectiveFallbackThreshold,
-    });
-    return p2tr(cohort.internalKey, leaves, NET, true).script;
+    return beaconOutputScript(service.getCohort(cohortId)!);
   }
 
   async function formAndValidate(beaconType: string): Promise<{ cohortId: string; script: Uint8Array; value: bigint }> {
@@ -183,7 +173,7 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
 
     // The finalized fallback tx carries a verifiable k-of-n script-path witness.
     const witness = result.signedTx.getInput(0).finalScriptWitness!;
-    const leaf = buildFallbackLeaf({ cohortKeys: service.getCohort(cohortId)!.cohortKeys, fallbackThreshold: service.getCohort(cohortId)!.effectiveFallbackThreshold });
+    const leaf = fallbackLeafScript(service.getCohort(cohortId)!.cohortKeys, service.getCohort(cohortId)!.effectiveFallbackThreshold);
     expect(witness[witness.length - 2]).to.deep.equal(leaf);
     const sighash = result.signedTx.preimageWitnessV1(0, [ script ], SigHash.DEFAULT, [ value ], undefined, leaf, 0xc0);
     const sigEntries = witness.slice(0, witness.length - 2).filter(e => e.length === 64);
@@ -250,7 +240,7 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
     // A coordinator hands the member a tx whose OP_RETURN carries a DIFFERENT
     // signal than the one the member validated. The member must refuse to sign.
     const tampered = beaconTx(script, cohort.internalKey, value, new Uint8Array(32).fill(0xbe));
-    const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+    const leaf = fallbackLeafScript(cohort.cohortKeys, cohort.effectiveFallbackThreshold);
     parts[0].receive(createFallbackAuthorizationRequestMessage({
       from                  : serviceDid,
       to                    : dids[0],
@@ -259,6 +249,8 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
       pendingTx             : tampered.hex,
       prevOutScriptHex      : bytesToHex(script),
       prevOutValue          : value.toString(),
+      fundingTxid           : '22'.repeat(32),
+      fundingVout           : 0,
       fallbackLeafScriptHex : bytesToHex(leaf),
     }) as never);
     expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
@@ -273,7 +265,7 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
     expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
     const result = service.getResult(cohortId)!;
     const witness = result.signedTx.getInput(0).finalScriptWitness!;
-    const leaf = buildFallbackLeaf({ cohortKeys: service.getCohort(cohortId)!.cohortKeys, fallbackThreshold: service.getCohort(cohortId)!.effectiveFallbackThreshold });
+    const leaf = fallbackLeafScript(service.getCohort(cohortId)!.cohortKeys, service.getCohort(cohortId)!.effectiveFallbackThreshold);
     const sighash = result.signedTx.preimageWitnessV1(0, [ script ], SigHash.DEFAULT, [ value ], undefined, leaf, 0xc0);
     const sigEntries = witness.slice(0, witness.length - 2).filter(e => e.length === 64);
     const xonly = service.getCohort(cohortId)!.cohortKeys.map(k => k.slice(1));

--- a/packages/aggregation/tests/aggregation-participant-tx-checks.spec.ts
+++ b/packages/aggregation/tests/aggregation-participant-tx-checks.spec.ts
@@ -13,16 +13,21 @@ import type {
 import {
   AggregationParticipant,
   AggregationService,
+  AUTHORIZATION_REQUEST,
   KeyPairAggregationSigner,
   ParticipantCohortPhase,
   ServiceCohortPhase,
-  buildFallbackLeaf,
   createFallbackAuthorizationRequestMessage,
 } from '../src/index.js';
 import { beaconOutputScript } from './helpers/beacon-script.js';
+import { fallbackLeafScript } from './helpers/fallback-leaf.js';
 
 const TEST_RECOVERY_KEY = 'a'.repeat(64);
 const TEST_RECOVERY_SEQUENCE = 144;
+
+/** Placeholder funded outpoint every test tx spends at input 0. */
+const FUNDING_TXID = '00'.repeat(32);
+const FUNDING_VOUT = 0;
 
 function makeIdentity(network = 'mutinynet'): { keys: SchnorrKeyPair; did: string } {
   const keys = SchnorrKeyPair.generate();
@@ -77,8 +82,34 @@ interface TxSpec {
   withSignal?: boolean;
   /** Sats carried by the OP_RETURN output (must be 0 for a well-formed tx). */
   signalAmount?: bigint;
+  /** Payload for the OP_RETURN output; defaults to the cohort's validated signal. */
+  signalOverride?: Uint8Array;
+  /** Add a second zero-value OP_RETURN output carrying 32 zero bytes. */
+  extraOpReturn?: boolean;
   /** Change output paying a foreign script. */
   foreignChange?: bigint;
+}
+
+/** Build a tx from `spec` spending the placeholder outpoint at input 0. */
+function buildSpecTx(spec: TxSpec, script: Uint8Array, value: bigint, signalBytes: Uint8Array): Transaction {
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({
+    txid        : FUNDING_TXID,
+    index       : FUNDING_VOUT,
+    witnessUtxo : { amount: value, script: spec.prevOutScript ?? script },
+  });
+  if(spec.extraInput) {
+    tx.addInput({ txid: '11'.repeat(32), index: 1, witnessUtxo: { amount: 1000n, script: foreignScript() } });
+  }
+  if(spec.selfChange !== undefined) tx.addOutput({ script, amount: spec.selfChange });
+  if(spec.foreignChange !== undefined) tx.addOutput({ script: foreignScript(), amount: spec.foreignChange });
+  if(spec.withSignal !== false) {
+    tx.addOutput({ script: Script.encode([ 'RETURN', spec.signalOverride ?? signalBytes ]), amount: spec.signalAmount ?? 0n });
+  }
+  if(spec.extraOpReturn) {
+    tx.addOutput({ script: Script.encode([ 'RETURN', new Uint8Array(32) ]), amount: 0n });
+  }
+  return tx;
 }
 
 interface Drive {
@@ -94,9 +125,16 @@ interface Drive {
 /**
  * Drive a 1-member cohort to the member's AwaitingSigning phase with a signing
  * tx built from `spec`. All protocol messages are cryptographically real; only
- * the final tx shape varies.
+ * the final tx shape varies. `tamperAuthRequest.mutate` rewrites the
+ * authorization request body addressed to the member before delivery;
+ * `tamperAuthRequest.dropRequest` asserts the member never leaves
+ * ValidationSent (the tampered request was ignored).
  */
-function driveToAwaitingSigning(spec: TxSpec, participantOpts?: { maxFeeSats?: bigint | number }): Drive {
+function driveToAwaitingSigning(
+  spec: TxSpec,
+  participantOpts?: { maxFeeSats?: bigint | number },
+  tamperAuthRequest?: { mutate?: (body: Record<string, unknown>) => void; dropRequest?: boolean },
+): Drive {
   const serviceId = makeIdentity();
   const member = makeIdentity();
   const service = new AggregationService({ did: serviceId.did, publicKey: serviceId.keys.publicKey });
@@ -110,6 +148,7 @@ function driveToAwaitingSigning(spec: TxSpec, participantOpts?: { maxFeeSats?: b
       // Broadcasts (the cohort advert) reach the listening member; addressed
       // messages reach their named recipient.
       if(m.to === undefined) { participant.receive(m); continue; }
+      if(m.to === member.did && m.type === AUTHORIZATION_REQUEST) tamperAuthRequest?.mutate?.(m.body as Record<string, unknown>);
       (m.to === member.did ? participant : service).receive(m);
     }
   };
@@ -133,25 +172,44 @@ function driveToAwaitingSigning(spec: TxSpec, participantOpts?: { maxFeeSats?: b
   const cohort = service.getCohort(cohortId)!;
   const script = beaconOutputScript(cohort);
   const value = spec.prevOutValue ?? 100000n;
-  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
-  tx.addInput({
-    txid        : '00'.repeat(32),
-    index       : 0,
-    witnessUtxo : { amount: value, script: spec.prevOutScript ?? script },
-  });
-  if(spec.extraInput) {
-    tx.addInput({ txid: '11'.repeat(32), index: 1, witnessUtxo: { amount: 1000n, script: foreignScript() } });
-  }
-  if(spec.selfChange !== undefined) tx.addOutput({ script, amount: spec.selfChange });
-  if(spec.foreignChange !== undefined) tx.addOutput({ script: foreignScript(), amount: spec.foreignChange });
-  if(spec.withSignal !== false) {
-    tx.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes! ]), amount: spec.signalAmount ?? 0n });
-  }
+  const tx = buildSpecTx(spec, script, value, cohort.signalBytes!);
 
   const prevOutScript = spec.prevOutScript ?? script;
   route(service.startSigning(cohortId, { tx, prevOutScripts: [ prevOutScript ], prevOutValues: [ value ] }));
-  expect(participant.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingSigning);
+  expect(participant.getCohortPhase(cohortId)).to.equal(
+    tamperAuthRequest?.dropRequest ? ParticipantCohortPhase.ValidationSent : ParticipantCohortPhase.AwaitingSigning
+  );
   return { service, participant, cohortId, serviceDid: serviceId.did, memberDid: member.did, script, value };
+}
+
+/**
+ * From an AwaitingSigning drive, deliver a fallback authorization request
+ * carrying a tx built from `spec` and land the member in AwaitingFallbackSig.
+ * The declared funded outpoint matches the tx unless `declareOutpoint` says
+ * otherwise.
+ */
+function driveToAwaitingFallback(
+  d: Drive,
+  spec: TxSpec,
+  declareOutpoint?: { fundingTxid: string; fundingVout: number },
+): void {
+  const cohort = d.service.getCohort(d.cohortId)!;
+  const sessionId = d.service.getSigningSessionId(d.cohortId)!;
+  const value = spec.prevOutValue ?? d.value;
+  const tx = buildSpecTx(spec, d.script, value, cohort.signalBytes!);
+  d.participant.receive(createFallbackAuthorizationRequestMessage({
+    from                  : d.serviceDid,
+    to                    : d.memberDid,
+    cohortId              : d.cohortId,
+    sessionId,
+    pendingTx             : tx.hex,
+    prevOutScriptHex      : bytesToHex(spec.prevOutScript ?? d.script),
+    prevOutValue          : value.toString(),
+    fundingTxid           : declareOutpoint?.fundingTxid ?? FUNDING_TXID,
+    fundingVout           : declareOutpoint?.fundingVout ?? FUNDING_VOUT,
+    fallbackLeafScriptHex : bytesToHex(fallbackLeafScript(cohort.cohortKeys, cohort.effectiveFallbackThreshold)),
+  }));
+  expect(d.participant.getCohortPhase(d.cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
 }
 
 describe('Participant beacon-tx validation', () => {
@@ -203,33 +261,113 @@ describe('Participant beacon-tx validation', () => {
     expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FEE_TOO_HIGH|ceiling/);
   });
 
-  it('refuses a fallback spend whose change pays a foreign script', () => {
-    // The optimistic request is well-formed; the tampered tx arrives on the
-    // fallback authorization request.
-    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
-    const cohort = d.service.getCohort(d.cohortId)!;
-    const sessionId = d.service.getSigningSessionId(d.cohortId)!;
+  it('refuses a tx whose OP_RETURN anchors a different signal', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n, signalOverride: new Uint8Array(32).fill(0xbe) });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/SIGNAL_MISMATCH|does not anchor/);
+  });
 
-    const tampered = new Transaction({ version: 2, allowUnknownOutputs: true });
-    tampered.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: d.value, script: d.script } });
-    tampered.addOutput({ script: foreignScript(), amount: d.value - 500n });
-    tampered.addOutput({ script: Script.encode([ 'RETURN', cohort.signalBytes! ]), amount: 0n });
+  it('refuses a tx with two OP_RETURN outputs even when one anchors the signal', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n, extraOpReturn: true });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/SIGNAL_MISMATCH|exactly one/);
+  });
 
-    const leaf = buildFallbackLeaf({
-      cohortKeys        : cohort.cohortKeys,
-      fallbackThreshold : cohort.effectiveFallbackThreshold,
+  it('refuses a tx with no OP_RETURN output', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n, withSignal: false });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/SIGNAL_MISMATCH|exactly one/);
+  });
+
+  it('refuses a spend whose declared funding txid does not match input 0', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n }, undefined, {
+      mutate : (body) => { body.fundingTxid = 'ff'.repeat(32); },
     });
-    d.participant.receive(createFallbackAuthorizationRequestMessage({
-      from                  : d.serviceDid,
-      to                    : d.memberDid,
-      cohortId              : d.cohortId,
-      sessionId,
-      pendingTx             : tampered.hex,
-      prevOutScriptHex      : bytesToHex(d.script),
-      prevOutValue          : d.value.toString(),
-      fallbackLeafScriptHex : bytesToHex(leaf),
-    }));
-    expect(d.participant.getCohortPhase(d.cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
-    expect(() => d.participant.approveFallback(d.cohortId)).to.throw(/FOREIGN_OUTPUT|beacon address/);
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FUNDING_OUTPOINT_MISMATCH|funded outpoint/);
+  });
+
+  it('refuses a spend whose declared funding vout does not match input 0', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n }, undefined, {
+      mutate : (body) => { body.fundingVout = 7; },
+    });
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/FUNDING_OUTPOINT_MISMATCH|funded outpoint/);
+  });
+
+  it('ignores an authorization request that declares no funded outpoint', () => {
+    const d = driveToAwaitingSigning({ selfChange: 100000n - 500n }, undefined, {
+      mutate      : (body) => { delete body.fundingTxid; },
+      dropRequest : true,
+    });
+    expect(d.participant.pendingSigningRequests.has(d.cohortId)).to.be.false;
+    expect(() => d.participant.approveNonce(d.cohortId)).to.throw(/INVALID_PHASE|AwaitingSigning/);
+  });
+
+  describe('fallback path parity', () => {
+    const cases: Array<{ name: string; spec: TxSpec; error: RegExp }> = [
+      {
+        name   : 'a prevOutScript that is not the cohort beacon script',
+        spec   : { prevOutScript: foreignScript(), selfChange: 100000n - 500n },
+        error  : /PREVOUT_SCRIPT_MISMATCH|beacon UTXO/,
+      },
+      {
+        name   : 'a spend with more than one input',
+        spec   : { selfChange: 100000n - 500n, extraInput: true },
+        error  : /UNEXPECTED_INPUT_COUNT|exactly one/,
+      },
+      {
+        name   : 'change paid to a foreign script',
+        spec   : { foreignChange: 100000n - 500n },
+        error  : /FOREIGN_OUTPUT|beacon address/,
+      },
+      {
+        name   : 'a spend with no self-change output (whole UTXO burned)',
+        spec   : {},
+        error  : /MISSING_SELF_CHANGE|carried forward/,
+      },
+      {
+        name   : 'a dust self-change output',
+        spec   : { selfChange: 100n },
+        error  : /DUST_SELF_CHANGE|dust/,
+      },
+      {
+        name   : 'a value-carrying OP_RETURN output',
+        spec   : { selfChange: 100000n - 1500n, signalAmount: 1000n },
+        error  : /SIGNAL_OUTPUT_CARRIES_VALUE|zero-value/,
+      },
+      {
+        name   : 'a fee above the default ceiling',
+        spec   : { prevOutValue: 300000n, selfChange: 150000n },
+        error  : /FEE_TOO_HIGH|ceiling/,
+      },
+      {
+        name   : 'a tx whose OP_RETURN anchors a different signal',
+        spec   : { selfChange: 100000n - 500n, signalOverride: new Uint8Array(32).fill(0xbe) },
+        error  : /SIGNAL_MISMATCH|does not anchor/,
+      },
+      {
+        name   : 'a tx with two OP_RETURN outputs even when one anchors the signal',
+        spec   : { selfChange: 100000n - 500n, extraOpReturn: true },
+        error  : /SIGNAL_MISMATCH|exactly one/,
+      },
+    ];
+
+    for(const { name, spec, error } of cases) {
+      it(`refuses a fallback spend with ${name}`, () => {
+        const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
+        driveToAwaitingFallback(d, spec);
+        expect(() => d.participant.approveFallback(d.cohortId)).to.throw(error);
+      });
+    }
+
+    it('refuses a fallback spend whose declared funding outpoint does not match input 0', () => {
+      const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
+      driveToAwaitingFallback(d, { selfChange: 100000n - 500n }, { fundingTxid: 'ff'.repeat(32), fundingVout: 0 });
+      expect(() => d.participant.approveFallback(d.cohortId)).to.throw(/FUNDING_OUTPOINT_MISMATCH|funded outpoint/);
+    });
+
+    it('accepts a well-formed fallback spend (control)', () => {
+      const d = driveToAwaitingSigning({ selfChange: 100000n - 500n });
+      driveToAwaitingFallback(d, { selfChange: 100000n - 500n });
+      const msgs = d.participant.approveFallback(d.cohortId);
+      expect(msgs).to.have.lengthOf(1);
+      expect(d.participant.getCohortPhase(d.cohortId)).to.equal(ParticipantCohortPhase.Complete);
+    });
   });
 });

--- a/packages/aggregation/tests/aggregation-signing.spec.ts
+++ b/packages/aggregation/tests/aggregation-signing.spec.ts
@@ -70,6 +70,39 @@ describe('Aggregation signing regressions', () => {
       expect(() => p1.generatePartialSignature(kp1.secretKey.bytes))
         .to.throw(/MISSING_SECRET_NONCE|Secret nonce not available/);
     });
+
+    it('rejects a repeated generateNonceContribution instead of overwriting the secret nonce', () => {
+      const kp1 = SchnorrKeyPair.generate();
+      const kp2 = SchnorrKeyPair.generate();
+      const cohort = new AggregationCohort({
+        minParticipants  : 2,
+        network          : 'bitcoin',
+        recoveryKey      : hexToBytes(TEST_RECOVERY_KEY),
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      cohort.participants.push('did:btcr2:alice', 'did:btcr2:bob');
+      cohort.participantKeys.set('did:btcr2:alice', kp1.publicKey.compressed);
+      cohort.participantKeys.set('did:btcr2:bob', kp2.publicKey.compressed);
+      cohort.cohortKeys = [kp1.publicKey.compressed, kp2.publicKey.compressed];
+      cohort.computeBeaconAddress();
+
+      const aggPk = musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys));
+      const payment = p2tr(aggPk);
+      const tx = buildDummyTx(payment.script, 100000n);
+
+      const p1 = new BeaconSigningSession({
+        cohort,
+        pendingTx      : tx,
+        prevOutScripts : [payment.script],
+        prevOutValues  : [100000n],
+      });
+      p1.generateNonceContribution(kp1.publicKey.compressed, kp1.secretKey.bytes);
+
+      // A second call would silently overwrite the retained secret nonce; the
+      // session refuses instead of risking a leaked or desynchronized nonce.
+      expect(() => p1.generateNonceContribution(kp1.publicKey.compressed, kp1.secretKey.bytes))
+        .to.throw(/NONCE_ALREADY_GENERATED|already generated/);
+    });
   });
 
   describe('T3.2: partial-sig pre-verification', () => {

--- a/packages/aggregation/tests/helpers/fallback-leaf.ts
+++ b/packages/aggregation/tests/helpers/fallback-leaf.ts
@@ -1,0 +1,14 @@
+import { p2tr_ms } from '@scure/btc-signer';
+import { sortKeys } from '@scure/btc-signer/musig2';
+
+/**
+ * Test-local copy of the k-of-n fallback leaf construction: a BIP-342
+ * CHECKSIGADD multisig over the cohort's BIP-327-sorted x-only keys. Deliberately
+ * duplicated from the production builder (src/core/recovery-policy.ts) so a
+ * production drift moves the two apart and the tests that cross-check them fail
+ * loudly instead of silently tracking it.
+ */
+export function fallbackLeafScript(cohortKeys: Uint8Array[], fallbackThreshold: number): Uint8Array {
+  const xOnlyKeys = sortKeys(cohortKeys.map(k => new Uint8Array(k))).map(k => k.slice(1));
+  return p2tr_ms(fallbackThreshold, xOnlyKeys).script;
+}

--- a/packages/method/src/core/beacon/beacon.ts
+++ b/packages/method/src/core/beacon/beacon.ts
@@ -64,16 +64,20 @@ export const CHANGE_OUTPUT_VBYTES: Readonly<Record<SingletonScriptKind, number>>
 };
 
 /**
- * Dust threshold (sats) below which a change output is not worth creating, by script
- * kind (the standard Bitcoin Core dust relay thresholds at the default 3 sat/vB dust
- * rate). When the change after fees falls below this, the builders omit the change
+ * Dust threshold (sats) below which a change output is not worth creating. Unified
+ * at 546 (the standard Bitcoin Core P2PKH dust relay threshold at the default 3
+ * sat/vB dust rate, the largest of the per-kind thresholds) so every beacon
+ * builder and the aggregation participant guard agree on one floor. When the
+ * change after fees falls below this, the single-party builders omit the change
  * output and let the remainder fall into the fee rather than emit an unspendable,
- * relay-rejected dust output (ADR 044).
+ * relay-rejected dust output (ADR 044); the aggregation builder refuses outright,
+ * since a cohort's participants reject a beacon spend without a self-change
+ * output at or above this floor.
  */
 export const DUST_LIMIT_SATS: Readonly<Record<SingletonScriptKind, number>> = {
   p2pkh  : 546,
-  p2wpkh : 294,
-  p2tr   : 330,
+  p2wpkh : 546,
+  p2tr   : 546,
 };
 
 /**
@@ -298,11 +302,10 @@ export function opReturnScript(signalBytes: Uint8Array): Uint8Array {
  * be rejected as insufficient; conversely, at a very low fee rate an output near the
  * floor could cover the fee. The floor's job is only to skip trivially small inputs.
  *
- * The value is the standard Bitcoin Core P2PKH dust threshold, the largest of the
- * three singleton beacon script kinds (P2PKH 546, P2TR 330, P2WPKH 294 per
- * {@link DUST_LIMIT_SATS}): a UTXO above it is non-dust under any beacon address kind.
- * Distinct from {@link DUST_LIMIT_SATS}, which sizes the outgoing change output by
- * kind; this bounds the incoming UTXO chosen to fund the transaction.
+ * The value equals {@link DUST_LIMIT_SATS} (the unified 546-sat floor): a UTXO
+ * above it is non-dust under any beacon address kind.
+ * Distinct roles: {@link DUST_LIMIT_SATS} sizes the outgoing change output;
+ * this bounds the incoming UTXO chosen to fund the transaction.
  */
 export const SPENDABLE_DUST_LIMIT_SATS = 546;
 
@@ -403,17 +406,16 @@ export async function buildAggregationBeaconTx(opts: {
   network: BTCNetwork;
   /** Optional fee estimator (defaults to 5 sat/vB). */
   feeEstimator?: FeeEstimator;
-  /**
-   * Address to send change to. Defaults to the beacon (cohort) address. Supply the
-   * funder's address (an operator-funded cohort's funding wallet) to stop reusing the
-   * cohort address for change (ADR 044). Change ownership is the funder's call, which
-   * the cohort-condition model leaves to the caller (ADR 039).
-   */
-  changeAddress?: string;
 }): Promise<BeaconTxPlan> {
   const feeEstimator = opts.feeEstimator ?? DEFAULT_FEE_ESTIMATOR;
   const { utxo, prevTxBytes } = await fetchSpendableUtxo(opts.beaconAddress, opts.bitcoin);
-  const changeAddress = resolveChangeAddress(opts.beaconAddress, opts.network, opts.changeAddress);
+
+  // Change always returns to the beacon address: the cohort's participants
+  // verify the tx they sign and reject any output that pays a foreign script
+  // (and any spend that carries the UTXO forward to no one), so a caller-named
+  // change destination can never be signed. Unlike the single-party builders,
+  // this builder takes no changeAddress option.
+  const changeAddress = opts.beaconAddress;
 
   // The funded beacon output is a Taproot script-tree output: key path is the
   // MuSig2 aggregate, script path is the k-of-n fallback + CSV recovery leaves
@@ -424,16 +426,29 @@ export async function buildAggregationBeaconTx(opts: {
   const witnessScript = OutScript.encode(Address(opts.network).decode(opts.beaconAddress));
 
   // The fee cannot be probe-measured (no secret key until the downstream MuSig2
-  // round), so size it analytically. The input is the cohort's P2TR key path; only
-  // the change output's kind varies, so the vsize follows the change address (ADR 045).
-  const changeKind = changeOutputKind(changeAddress, opts.network);
-  const vsize = beaconTxVsize('p2tr', changeKind);
+  // round), so size it analytically. The input is the cohort's P2TR key path and
+  // the change output is always the same P2TR beacon address, so the vsize is
+  // the fixed P2TR beacon constant (ADR 045), computed without a secret.
+  const vsize = beaconTxVsize('p2tr', 'p2tr');
   const feeSats = await feeEstimator.estimateFee(vsize);
   if(BigInt(utxo.value) <= feeSats) {
     throw new BeaconError(
       `UTXO value (${utxo.value}) insufficient to cover fee (${feeSats}).`,
       'INSUFFICIENT_FUNDS',
       { address: opts.beaconAddress, valueSats: utxo.value, feeSats }
+    );
+  }
+
+  // Change is mandatory on an aggregation spend: participants refuse to sign a
+  // tx with no self-change output at or above the dust floor, so a UTXO whose
+  // change would be dust can never be signed. Refuse here instead of emitting a
+  // tx the cohort's own members will reject.
+  const changeValue = BigInt(utxo.value) - feeSats;
+  if(changeValue < BigInt(DUST_LIMIT_SATS.p2tr)) {
+    throw new BeaconError(
+      `Change after fees (${changeValue} sats) falls below the ${DUST_LIMIT_SATS.p2tr}-sat dust floor; fund the beacon address with a larger UTXO.`,
+      'INSUFFICIENT_FUNDS',
+      { address: opts.beaconAddress, valueSats: utxo.value, feeSats, changeSats: changeValue }
     );
   }
 
@@ -448,12 +463,9 @@ export async function buildAggregationBeaconTx(opts: {
     witnessUtxo    : { amount: BigInt(utxo.value), script: witnessScript },
     tapInternalKey : opts.internalPubkey,
   });
-  // Change first (omitted when it would be dust, sweeping the remainder into the
-  // fee), then the OP_RETURN signal, which the spec requires to be the last output.
-  const changeValue = BigInt(utxo.value) - feeSats;
-  if(changeValue >= BigInt(DUST_LIMIT_SATS[changeKind])) {
-    tx.addOutputAddress(changeAddress, changeValue, opts.network);
-  }
+  // Change first, then the OP_RETURN signal, which the spec requires to be the
+  // last output.
+  tx.addOutputAddress(changeAddress, changeValue, opts.network);
   tx.addOutput({ script: opReturnScript(opts.signalBytes), amount: 0n });
 
   return {

--- a/packages/method/tests/beacon-change-output.spec.ts
+++ b/packages/method/tests/beacon-change-output.spec.ts
@@ -90,53 +90,26 @@ describe('beacon change output (ADR 044)', () => {
       expect(plan.tx.outputsLength).to.equal(2);
       expect(plan.tx.getOutputAddress(0, network)).to.equal(beaconAddress);
       expect(bytesToHex(plan.tx.getOutput(1).script!)).to.equal(opReturn);
-      // Default change kind is the P2TR beacon address: fee sized for P2TR change.
+      // Change always pays the P2TR beacon address: fee sized for P2TR change.
       expect(plan.feeSats).to.equal(BigInt(FEE_RATE * beaconTxVsize('p2tr', 'p2tr')));
     });
 
-    it('routes change to a supplied address and sizes the fee for that change kind', async () => {
-      const changeAddress = p2wpkh(freshKey(), network).address!;
-      const bitcoin = mockBitcoin(beaconAddress, 100_000);
-      const plan = await buildAggregationBeaconTx({
-        beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
-        changeAddress,
-      });
-
-      expect(plan.changeAddress).to.equal(changeAddress);
-      expect(plan.tx.getOutputAddress(0, network)).to.equal(changeAddress);
-      // OP_RETURN stays last even with a rotated change output.
-      expect(bytesToHex(plan.tx.getOutput(1).script!)).to.equal(opReturn);
-      // A P2WPKH change output is cheaper than the default P2TR change: the fee follows.
-      expect(plan.feeSats).to.equal(BigInt(FEE_RATE * beaconTxVsize('p2tr', 'p2wpkh')));
-      expect(Number(plan.feeSats)).to.be.lessThan(FEE_RATE * beaconTxVsize('p2tr', 'p2tr'));
-    });
-
-    it('omits a dust change output, leaving the signal as the sole output', async () => {
-      // Fund just above the fee, so the change after fees is below the dust limit.
+    it('refuses a UTXO whose change after fees would be dust', async () => {
+      // Fund just above the fee, so the change after fees is below the dust floor.
+      // Cohort participants refuse to sign a spend with no self-change output at
+      // or above the floor, so the builder must refuse rather than emit one.
       const feeSats = FEE_RATE * beaconTxVsize('p2tr', 'p2tr');
-      const bitcoin = mockBitcoin(beaconAddress, feeSats + 50); // 50-sat change < 330 dust
-      const plan = await buildAggregationBeaconTx({
-        beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
-      });
-
-      // Change is swept into the fee: the only output is the OP_RETURN signal.
-      expect(plan.tx.outputsLength).to.equal(1);
-      expect(bytesToHex(plan.tx.getOutput(0).script!)).to.equal(opReturn);
-    });
-
-    it('rejects an invalid change address before spending the UTXO', async () => {
-      const bitcoin = mockBitcoin(beaconAddress, 100_000);
+      const bitcoin = mockBitcoin(beaconAddress, feeSats + 50); // 50-sat change < 546 dust
       let threw = false;
       try {
         await buildAggregationBeaconTx({
-          beaconAddress, internalPubkey : internalKey, signalBytes    : new Uint8Array(32), bitcoin, network,
-          changeAddress  : 'not-a-bitcoin-address',
+          beaconAddress, internalPubkey : internalKey, signalBytes : new Uint8Array(32), bitcoin, network,
         });
       } catch(err) {
         threw = true;
-        expect((err as Error).message).to.match(/Invalid change address/);
+        expect((err as Error).message).to.match(/dust floor/);
       }
-      expect(threw, 'expected an invalid change address to throw').to.equal(true);
+      expect(threw, 'expected a dust-change UTXO to throw').to.equal(true);
     });
   });
 });


### PR DESCRIPTION
* fix(aggregation-service): declare funded outpoint, sender-bind via proof.capability, reject mismatched acks (audit M5, L19; review MS-09, MS-11, MS-12)
* fix(aggregation-participant): verify outpoint and OP_RETURN shape, recompute signal, bind fallback session early (audit M5, L21; review MS-09, MS-12, MS-26)
* fix(aggregation): reject repeated nonce generation rather than overwriting the live secret (audit L16; review MS-25)
* fix(method): unify the aggregation dust floor at 546, drop changeAddress, throw on dust change (audit M5; review MS-09)
* fix(aggregation-lib): rebuild the four e2e scripts to construct valid signal transactions under the tightened rules (review MS-09)
* test(aggregation): fallback negative-case parity, test-local fallback leaf builder, equivocation and outpoint cases (review MS-12, MS-47.8)
* docs(adr): amend ADR 044 for the narrowed aggregation change-output behavior (review MS-09)