### PR TITLE
terminate resolution at the requested version and fail closed at intake

### DIFF
--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -103,15 +103,17 @@ describe('DidBtcr2Cli', () => {
     it('reads resolution options from a file', async () => {
       const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
       const cli = new DidBtcr2Cli(createTestApiFactory());
+      const messages: string[] = [];
+      console.log = (msg?: any) => { if (msg !== undefined) messages.push(String(msg)); };
       const tempPath = join(tmpdir(), 'btcr2-resolve-test.json');
       await writeFile(tempPath, '{"versionId":"1"}', 'utf-8');
 
       try {
         const resolve = getSubcommand(cli, 'resolve');
-        // Resolving requires a Bitcoin connection, so this will reject
-        await expect(
-          resolve.parseAsync(['-i', validDid, '-p', tempPath], { from: 'user' })
-        ).to.be.rejected;
+        // versionId "1" is terminal at the genesis document: resolution completes
+        // without beacon discovery, so no Bitcoin connection is required.
+        await resolve.parseAsync(['-i', validDid, '-p', tempPath], { from: 'user' });
+        expect(messages.join('\n')).to.include(validDid);
       } finally {
         await rm(tempPath, { force: true });
       }

--- a/packages/common/src/json-patch.ts
+++ b/packages/common/src/json-patch.ts
@@ -9,10 +9,17 @@ export type PatchOpCode = 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test
 
 /** Maximum operations in a single JSON Patch. */
 export const MAX_PATCH_OPERATIONS = 1024;
-/** Maximum length of an operation's JSON Pointer path. */
+/** Maximum length of an operation's JSON Pointer path (and of a move/copy `from` pointer). */
 export const MAX_PATCH_PATH_LENGTH = 2048;
-/** Maximum JSON-serialized size of an operation's value, in bytes. */
+/** Maximum JSON-serialized size of an operation's value, in UTF-8 bytes. */
 export const MAX_PATCH_VALUE_BYTES = 256 * 1024;
+/**
+ * Maximum aggregate size of a patch, in UTF-8 bytes: the sum of each operation's
+ * serialized value plus its path and `from` pointer lengths. The per-operation
+ * caps alone (1024 operations x 256 KiB) would allow roughly 256 MiB of patch
+ * work; this budget bounds the whole patch to 1 MiB.
+ */
+export const MAX_PATCH_TOTAL_BYTES = 1024 * 1024;
 
 /**
  * A JSON Patch operation, as defined in {@link https://datatracker.ietf.org/doc/html/rfc6902 | RFC 6902}.
@@ -106,8 +113,9 @@ export class JSONPatch {
    * Validate JSON Patch operations.
    *
    * Beyond shape checks, patches carried by untrusted DID updates are bounded
-   * in count, path length, and value size so a hostile update cannot force
-   * unbounded patch work.
+   * in count, path (and `from`) length, per-value size, and total serialized
+   * size so a hostile update cannot force unbounded patch work. Sizes are
+   * measured in UTF-8 bytes, the on-the-wire unit.
    *
    * @param {PatchOperation[]} operations - The operations to validate.
    * @returns {MethodError | null} A MethodError if validation fails, otherwise null.
@@ -117,6 +125,8 @@ export class JSONPatch {
     if (operations.length > MAX_PATCH_OPERATIONS) {
       return new MethodError(`Too many operations: ${operations.length} > ${MAX_PATCH_OPERATIONS}`, 'JSON_PATCH_VALIDATION_ERROR');
     }
+    const encoder = new TextEncoder();
+    let totalBytes = 0;
     for (const op of operations) {
       if (!op || typeof op !== 'object') return new MethodError('Operation must be an object', 'JSON_PATCH_VALIDATION_ERROR');
       if (typeof op.op !== 'string') return new MethodError('Operation.op must be a string', 'JSON_PATCH_VALIDATION_ERROR');
@@ -124,19 +134,30 @@ export class JSONPatch {
       if (op.path.length > MAX_PATCH_PATH_LENGTH) {
         return new MethodError(`Operation.path too long: ${op.path.length} > ${MAX_PATCH_PATH_LENGTH}`, 'JSON_PATCH_VALIDATION_ERROR');
       }
-      if ((op.op === 'move' || op.op === 'copy') && typeof op.from !== 'string') {
-        return new MethodError(`Operation.from must be a string for op=${op.op}`, 'JSON_PATCH_VALIDATION_ERROR');
+      if (op.op === 'move' || op.op === 'copy') {
+        if (typeof op.from !== 'string') {
+          return new MethodError(`Operation.from must be a string for op=${op.op}`, 'JSON_PATCH_VALIDATION_ERROR');
+        }
+        if (op.from.length > MAX_PATCH_PATH_LENGTH) {
+          return new MethodError(`Operation.from too long: ${op.from.length} > ${MAX_PATCH_PATH_LENGTH}`, 'JSON_PATCH_VALIDATION_ERROR');
+        }
       }
+      totalBytes += encoder.encode(op.path).length
+        + (typeof op.from === 'string' ? encoder.encode(op.from).length : 0);
       if (op.value !== undefined) {
-        let valueSize: number;
+        let valueBytes: number;
         try {
-          valueSize = JSON.stringify(op.value).length;
+          valueBytes = encoder.encode(JSON.stringify(op.value)).length;
         } catch {
           return new MethodError('Operation.value is not JSON-serializable', 'JSON_PATCH_VALIDATION_ERROR');
         }
-        if (valueSize > MAX_PATCH_VALUE_BYTES) {
-          return new MethodError(`Operation.value too large: ${valueSize} > ${MAX_PATCH_VALUE_BYTES} bytes`, 'JSON_PATCH_VALIDATION_ERROR');
+        if (valueBytes > MAX_PATCH_VALUE_BYTES) {
+          return new MethodError(`Operation.value too large: ${valueBytes} > ${MAX_PATCH_VALUE_BYTES} bytes`, 'JSON_PATCH_VALIDATION_ERROR');
         }
+        totalBytes += valueBytes;
+      }
+      if (totalBytes > MAX_PATCH_TOTAL_BYTES) {
+        return new MethodError(`Patch too large: ${totalBytes} > ${MAX_PATCH_TOTAL_BYTES} bytes total`, 'JSON_PATCH_VALIDATION_ERROR');
       }
     }
     return null;

--- a/packages/common/tests/json-patch.spec.ts
+++ b/packages/common/tests/json-patch.spec.ts
@@ -44,6 +44,32 @@ describe('JSONPatch', () => {
     expect(JSONPatch.validateOperations(ops)?.message).to.match(/value too large/);
   });
 
+  it('measures value size in UTF-8 bytes, not UTF-16 code units', () => {
+    // 200k three-byte characters: ~200k UTF-16 code units (under the old cap)
+    // but ~600k UTF-8 bytes (over the 256 KiB cap).
+    const ops = [{ op: 'add', path: '/x', value: '\u20AC'.repeat(200 * 1024) } as any];
+    expect(JSONPatch.validateOperations(ops)?.message).to.match(/value too large/);
+  });
+
+  it('rejects a move/copy operation with an over-long from pointer', () => {
+    const from = `/${'a'.repeat(2048)}`;
+    expect(JSONPatch.validateOperations([{ op: 'move', path: '/x', from } as any])?.message)
+      .to.match(/from too long/);
+    expect(JSONPatch.validateOperations([{ op: 'copy', path: '/x', from } as any])?.message)
+      .to.match(/from too long/);
+  });
+
+  it('rejects a patch whose operations individually fit but exceed the total budget', () => {
+    // 5 x 250 KiB values: each under the 256 KiB per-op cap, ~1.25 MiB in total.
+    const ops = Array.from({ length: 5 }, () => ({ op: 'add', path: '/x', value: 'x'.repeat(250 * 1024) }) as any);
+    expect(JSONPatch.validateOperations(ops)?.message).to.match(/Patch too large/);
+  });
+
+  it('accepts a patch within the total budget', () => {
+    const ops = Array.from({ length: 3 }, () => ({ op: 'add', path: '/x', value: 'x'.repeat(250 * 1024) }) as any);
+    expect(JSONPatch.validateOperations(ops)).to.be.null;
+  });
+
   it('accepts a patch within the bounds', () => {
     const ops = [{ op: 'add', path: '/x', value: 'y' } as any];
     expect(JSONPatch.validateOperations(ops)).to.be.null;

--- a/packages/method/docs/beacon-system-overview.md
+++ b/packages/method/docs/beacon-system-overview.md
@@ -193,6 +193,20 @@ The SMT proof verification (spec section SMT Proof Verification) computes the ca
 
 ---
 
+## Compatibility and Migration Notes
+
+### Current-document hash covers the full genesis JSON
+
+During resolution, the current-document hash that every update's `sourceHash` chains from is computed over the **complete** genesis JSON. An earlier implementation hashed the class-serialized subset of the document, which silently dropped unknown fields, dropped `deactivated`, and substituted a defaulted `@context` when one was missing. Those fields are now hashed like any other.
+
+Consequence: an EXTERNAL update chain anchored before this change on a non-standard genesis document (one carrying fields the old subset dropped) fails resolution with `INVALID_DID_UPDATE`, because its anchored `sourceHash` no longer matches the recomputed current-document hash. Remedy: the controller signs a fresh update whose `sourceHash` covers the full current document and announces it on a beacon, re-basing the chain.
+
+### `capabilityAction: "Write"` is required at resolve time
+
+Update proofs must carry `capabilityAction` with the exact value `"Write"`; the resolver rejects any update whose proof omits the field or sets a different value (`INVALID_DID_UPDATE`). The field is optional in the Data Integrity specification, so updates produced by other tooling, or anchored before this enforcement, may lack it. Remedy: re-sign the update with `capabilityAction: "Write"` in the proof (this implementation's write path sets it automatically) and re-announce it.
+
+---
+
 ## Usage Example: Runner Layer (recommended)
 
 The runner layer handles message routing, callback orchestration, and event emission.

--- a/packages/method/src/core/identifier.ts
+++ b/packages/method/src/core/identifier.ts
@@ -80,7 +80,8 @@ export class Identifier {
 
     // network MUST be a known network name. This encoder does not mint custom/numeric networks: the
     // public surface (DidCreateOptions.network) is a string, and a numeric nibble >= 5 would overflow
-    // the 4-bit network field and corrupt the version nibble. Custom networks remain decode-only.
+    // the 4-bit network field and corrupt the version nibble. Custom networks are rejected at decode
+    // for the same reason.
     if (typeof network !== 'string') {
       throw new IdentifierError('Expected "network" to be a known network name', INVALID_DID, { network });
     }
@@ -192,18 +193,22 @@ export class Identifier {
     }
     const version = 1;
 
-    // 11. network_value is the low nibble of the first byte. 0-5 map to named networks; 12-14 are custom
-    //     networks (returned as the numeric values 1-3); 6-11 and 15 are reserved/out-of-range and rejected.
+    // 11. network_value is the low nibble of the first byte. 0-5 map to named networks and are
+    //     accepted. Custom networks (12-14) would decode to a numeric network that the encoder
+    //     refuses and the resolver cannot use, so they are rejected loudly here at decode; 6-11
+    //     and 15 are reserved/out-of-range and likewise rejected.
     const networkValue = dataBytes[0] & 0x0F;
     const networkName = BitcoinNetworkNames[networkValue] as string | undefined;
-    let network: string | number;
-    if (typeof networkName === 'string') {
-      network = networkName;
-    } else if (networkValue >= 12 && networkValue <= 14) {
-      network = networkValue - 11;
-    } else {
+    if (typeof networkName !== 'string') {
+      if (networkValue >= 12 && networkValue <= 14) {
+        throw new IdentifierError(
+          `Custom networks (network_value 12-14) are not supported: ${networkValue}`,
+          INVALID_DID, { identifier }
+        );
+      }
       throw new IdentifierError(`Invalid network: ${networkValue}`, INVALID_DID, { identifier });
     }
+    const network = networkName;
 
     // 12. genesisBytes is everything after the first byte.
     const genesisBytes = dataBytes.slice(1);
@@ -221,7 +226,7 @@ export class Identifier {
     }
 
     // 14. Return idType, hrp, version, network, and genesisBytes.
-    return { idType, hrp, version, network, genesisBytes } as DidComponents;
+    return { idType, hrp, version, network, genesisBytes };
   }
 
   /**

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -159,6 +159,31 @@ function isSMTProof(value: unknown): value is SMTProof {
 }
 
 /**
+ * Validate one provided beacon signal's shape and block metadata. Malformed
+ * entries (non-integer or negative height/time/confirmations, missing signal
+ * bytes) are rejected with a typed error at the provide() boundary rather than
+ * flowing downstream as unchecked values. This runs before confirmation-depth
+ * gating, which is a filter, not a rejection.
+ */
+function assertValidBeaconSignal(signal: unknown, kind: DataNeed['kind']): asserts signal is BeaconSignal {
+  if(!isRecord(signal) || typeof signal.signalBytes !== 'string' || !isRecord(signal.blockMetadata)) {
+    throw new ResolveError(
+      'Provided beacon signal must have signalBytes (string) and blockMetadata (object).',
+      INVALID_DID_UPDATE, { kind }
+    );
+  }
+  const { height, time, confirmations } = signal.blockMetadata;
+  if(!Number.isInteger(height) || (height as number) < 0
+    || !Number.isInteger(time) || (time as number) < 0
+    || !Number.isInteger(confirmations) || (confirmations as number) < 0) {
+    throw new ResolveError(
+      'Provided beacon signal blockMetadata must carry non-negative integer height, time, and confirmations.',
+      INVALID_DID_UPDATE, { kind, blockMetadata: signal.blockMetadata }
+    );
+  }
+}
+
+/**
  * Different possible Resolver states representing phases in the resolution process.
  */
 enum ResolverPhase {
@@ -461,12 +486,13 @@ export class Resolver {
       const blocktime = DateUtils.blocktimeToTimestamp(block.time);
 
       // Spec: a beacon signal is only valid once its transaction is included in a
-      // block with at least minConf confirmations (6 when not provided). Signals
-      // below the threshold are not beacon signals: skip them so they neither
-      // apply, nor confirm duplicates, nor clobber resolution metadata. A later
-      // tuple that chains to a skipped update then correctly surfaces as a
-      // late-publishing error.
-      if(block.confirmations < minConf) continue;
+      // block with at least minConf confirmations (6 when not provided). The check
+      // fails closed: anything that is not an integer meeting minConf (missing,
+      // NaN, fractional, or a non-numeric value) is treated as unconfirmed and
+      // skipped, so it neither applies, nor confirms duplicates, nor clobbers
+      // resolution metadata. A later tuple that chains to a skipped update then
+      // correctly surfaces as a late-publishing error.
+      if(!Number.isInteger(block.confirmations) || block.confirmations < minConf) continue;
 
       // Check update.targetVersionId against currentVersionId.
       // If update.targetVersionId <= currentVersionId, this update re-announces a version
@@ -761,6 +787,18 @@ export class Resolver {
   }
 
   /**
+   * True when an exact versionId was requested and the resolution has reached it.
+   * Reaching the requested version is terminal: the resolver must not scan the
+   * returned document for new beacons or emit data needs for versions after the
+   * target.
+   */
+  #reachedRequestedVersionId(): boolean {
+    if(this.#versionId === undefined) return false;
+    const requested = Number(this.#versionId);
+    return !isNaN(requested) && requested <= this.#currentVersionId;
+  }
+
+  /**
    * Advance the state machine. Returns either:
    * - `{ status: 'action-required', needs }` - caller must provide data via {@link provide}
    * - `{ status: 'resolved', result }` - resolution complete
@@ -796,6 +834,15 @@ export class Resolver {
         // Phase: BeaconDiscovery
         // Extract beacon services, emit NeedBeaconSignals for addresses not yet queried.
         case ResolverPhase.BeaconDiscovery: {
+          // A requested versionId that has already been reached is terminal: return
+          // the current document without querying beacons for later versions. This
+          // also covers versionId '1', which resolves the genesis document without
+          // any beacon discovery at all.
+          if(this.#reachedRequestedVersionId()) {
+            this.#phase = ResolverPhase.Complete;
+            continue;
+          }
+
           const beaconServices = BeaconUtils.getBeaconServices(this.#currentDocument!);
 
           // Filter to services whose addresses haven't been requested yet
@@ -867,6 +914,7 @@ export class Resolver {
             // counter and update-hash history rather than restarting them. Without
             // this carry, a linear history split across discovery rounds would be
             // rejected at round two as late publishing.
+            const previousResponse = this.#resolvedResponse;
             this.#resolvedResponse = Resolver.updates(
               this.#currentDocument!,
               this.#unsortedUpdates,
@@ -875,6 +923,16 @@ export class Resolver {
               { currentVersionId: this.#currentVersionId, updateHashHistory: this.#updateHashHistory },
               this.#minConf
             );
+            // A round that applies nothing (only duplicates, skipped signals, or
+            // updates past the versionTime cutoff) returns fresh default metadata.
+            // Carry forward the last applied updated/confirmations rather than
+            // erasing them.
+            if(previousResponse
+              && this.#resolvedResponse.metadata.updated === ''
+              && previousResponse.metadata.updated) {
+              this.#resolvedResponse.metadata.updated = previousResponse.metadata.updated;
+              this.#resolvedResponse.metadata.confirmations = previousResponse.metadata.confirmations;
+            }
             // updates() reports the version it reached via metadata.versionId; carry
             // it forward so the next round continues the monotonic sequence.
             this.#currentVersionId = Number(this.#resolvedResponse.metadata.versionId);
@@ -968,7 +1026,24 @@ export class Resolver {
           );
         }
         for(const [service, serviceSignals] of data) {
-          this.#beaconServicesSignals.set(service, serviceSignals);
+          if(!Array.isArray(serviceSignals)) {
+            throw new ResolveError(
+              'Provided data for NeedBeaconSignals must map each beacon service to an array of signals.',
+              INVALID_DID_UPDATE, { kind: need.kind }
+            );
+          }
+          // Gate at intake: a signal below the minimum confirmation depth is not
+          // yet a valid beacon signal, so it is dropped here, before it can
+          // generate CAS/SMT/signed-update retrieval needs. The gate in
+          // Resolver.updates() still applies for direct static callers.
+          const confirmed: Array<BeaconSignal> = [];
+          for(const signal of serviceSignals) {
+            assertValidBeaconSignal(signal, need.kind);
+            if(signal.blockMetadata.confirmations >= this.#minConf) {
+              confirmed.push(signal);
+            }
+          }
+          this.#beaconServicesSignals.set(service, confirmed);
         }
         break;
       }
@@ -1021,7 +1096,17 @@ export class Resolver {
           );
         }
         // proof.id is base64url per spec; smtRootHash is the hex on-chain signal.
-        const proofIdHex = encodeHash(decodeHash(data.id, 'base64urlnopad'), 'hex');
+        // A malformed proof id must surface as a typed error, not a raw decode
+        // throw escaping resolution.
+        let proofIdHex: string;
+        try {
+          proofIdHex = encodeHash(decodeHash(data.id, 'base64urlnopad'), 'hex');
+        } catch {
+          throw new ResolveError(
+            'Malformed SMT proof id',
+            INVALID_DID_UPDATE, { kind: need.kind, proofId: data.id }
+          );
+        }
         if(proofIdHex !== need.smtRootHash) {
           throw new ResolveError(
             `SMT proof root hash mismatch: expected ${need.smtRootHash}, got ${proofIdHex}`,

--- a/packages/method/src/utils/did-document.ts
+++ b/packages/method/src/utils/did-document.ts
@@ -194,11 +194,6 @@ export class DidDocument implements Btcr2DidDocument {
       throw new DidDocumentError('DID Document must have an id', INVALID_DID_DOCUMENT, document);
     }
 
-    // Set the ID and ID type
-    const idType = document.id.includes('k1')
-      ? IdentifierTypes.KEY
-      : IdentifierTypes.EXTERNAL;
-
     // Validate ID and parts for non-intermediate
     const isGenesis = document.id === ID_PLACEHOLDER_VALUE;
 
@@ -217,6 +212,20 @@ export class DidDocument implements Btcr2DidDocument {
         throw new DidDocumentError('Invalid service: ' + service, INVALID_DID_DOCUMENT, document);
       }
     }
+
+    // "deactivated", when present, must be a boolean. A non-boolean value would
+    // survive structural validation yet never trigger deactivation semantics
+    // (the resolver checks strict === true), so reject it here, fail-closed.
+    if (!DidDocument.isValidDeactivated(document.deactivated)) {
+      throw new DidDocumentError('Invalid "deactivated"', INVALID_DID_DOCUMENT, document);
+    }
+
+    // Derive the identifier type from the decoded identifier HRP, not substring
+    // matching: an EXTERNAL id whose data part contains "k1" is not a KEY
+    // identifier. The id was validated above, so decode cannot throw here.
+    const idType = isGenesis
+      ? IdentifierTypes.EXTERNAL
+      : Identifier.decode(id).idType;
 
     // Set core properties
     this.id = document.id;
@@ -346,7 +355,22 @@ export class DidDocument implements Btcr2DidDocument {
     if (!this.isValidVerificationRelationships(didDocument)) {
       throw new DidDocumentError('Invalid verification relationships', INVALID_DID_DOCUMENT, didDocument);
     }
+    if (!this.isValidDeactivated(didDocument?.deactivated)) {
+      throw new DidDocumentError('Invalid "deactivated"', INVALID_DID_DOCUMENT, didDocument);
+    }
     return true;
+  }
+
+  /**
+   * Validates that "deactivated", when present, is a boolean. A non-boolean
+   * value would pass structural checks yet never trigger deactivation (the
+   * resolver checks strict === true), so it is rejected, fail-closed.
+   * @private
+   * @param {unknown} deactivated The deactivated value to validate.
+   * @returns {boolean} True if absent or a boolean.
+   */
+  private static isValidDeactivated(deactivated: unknown): boolean {
+    return deactivated === undefined || typeof deactivated === 'boolean';
   }
 
   /**
@@ -473,7 +497,13 @@ export class DidDocument implements Btcr2DidDocument {
    * @returns {GenesisDocument} The GenesisDocument representation of the DidDocument.
    */
   public toIntermediate(): GenesisDocument {
-    if(this.id.includes('k1')) {
+    // Derive the identifier type from the decoded identifier HRP, not substring
+    // matching. The placeholder id belongs to genesis documents, which are
+    // already intermediate.
+    const idType = this.id === ID_PLACEHOLDER_VALUE
+      ? IdentifierTypes.EXTERNAL
+      : Identifier.decode(this.id).idType;
+    if(idType === IdentifierTypes.KEY) {
       throw new DidDocumentError('Cannot convert a key identifier to an intermediate document', INVALID_DID_DOCUMENT, this);
     }
     return new GenesisDocument(this);

--- a/packages/method/tests/decode-identifier.spec.ts
+++ b/packages/method/tests/decode-identifier.spec.ts
@@ -113,19 +113,36 @@ describe('Decode Identifier', () => {
       expect(() => Identifier.decode(forge('k', 0x0F, validKeyBytes))).to.throw(/network/i);
     });
 
-    it('accepts custom network_value 12 (returns numeric 1)', () => {
-      const decoded = Identifier.decode(forge('k', 0x0C, validKeyBytes));
-      expect(decoded.network).to.equal(1);
+    it('rejects custom network_value 12 (KEY)', () => {
+      expect(() => Identifier.decode(forge('k', 0x0C, validKeyBytes))).to.throw(/custom networks/i);
     });
 
-    it('accepts custom network_value 13 (returns numeric 2)', () => {
-      const decoded = Identifier.decode(forge('k', 0x0D, validKeyBytes));
-      expect(decoded.network).to.equal(2);
+    it('rejects custom network_value 13 (KEY)', () => {
+      expect(() => Identifier.decode(forge('k', 0x0D, validKeyBytes))).to.throw(/custom networks/i);
     });
 
-    it('accepts custom network_value 14 (returns numeric 3)', () => {
-      const decoded = Identifier.decode(forge('k', 0x0E, validKeyBytes));
-      expect(decoded.network).to.equal(3);
+    it('rejects custom network_value 14 (KEY)', () => {
+      expect(() => Identifier.decode(forge('k', 0x0E, validKeyBytes))).to.throw(/custom networks/i);
+    });
+
+    it('rejects custom network_value 12 (EXTERNAL)', () => {
+      expect(() => Identifier.decode(forge('x', 0x0C, validHashBytes))).to.throw(/custom networks/i);
+    });
+
+    it('rejects custom network_value 13 (EXTERNAL)', () => {
+      expect(() => Identifier.decode(forge('x', 0x0D, validHashBytes))).to.throw(/custom networks/i);
+    });
+
+    it('rejects custom network_value 14 (EXTERNAL)', () => {
+      expect(() => Identifier.decode(forge('x', 0x0E, validHashBytes))).to.throw(/custom networks/i);
+    });
+
+    it('isValid reports custom-network KEY identifiers invalid', () => {
+      expect(Identifier.isValid(forge('k', 0x0C, validKeyBytes))).to.equal(false);
+    });
+
+    it('isValid reports custom-network EXTERNAL identifiers invalid', () => {
+      expect(Identifier.isValid(forge('x', 0x0E, validHashBytes))).to.equal(false);
     });
   });
 

--- a/packages/method/tests/did-document.spec.ts
+++ b/packages/method/tests/did-document.spec.ts
@@ -148,3 +148,36 @@ describe('DidDocument.isValid verificationMethod array (STD-2: enforce at the do
     expect(() => DidDocument.isValid(doc)).to.throw('Invalid "verificationMethod"');
   });
 });
+
+describe('DidDocument deactivated validation (fail-closed boolean)', () => {
+  it('rejects a non-boolean deactivated at the isValid boundary', () => {
+    const doc = validDocument();
+    doc.deactivated = 'yes';
+    expect(() => DidDocument.isValid(doc)).to.throw('Invalid "deactivated"');
+  });
+
+  it('rejects a non-boolean deactivated through validate', () => {
+    const doc = validDocument();
+    doc.deactivated = 1;
+    expect(() => DidDocument.validate(doc)).to.throw('Invalid "deactivated"');
+  });
+
+  it('rejects a non-boolean deactivated at construction', () => {
+    const doc = validDocument();
+    doc.deactivated = 'true';
+    expect(() => new DidDocument(doc as any)).to.throw('Invalid "deactivated"');
+  });
+
+  it('accepts deactivated true and false', () => {
+    const docTrue = validDocument();
+    docTrue.deactivated = true;
+    expect(DidDocument.isValid(docTrue)).to.equal(true);
+    const docFalse = validDocument();
+    docFalse.deactivated = false;
+    expect(DidDocument.isValid(docFalse)).to.equal(true);
+  });
+
+  it('accepts a document with no deactivated field', () => {
+    expect(DidDocument.isValid(validDocument())).to.equal(true);
+  });
+});

--- a/packages/method/tests/resolver-plain-documents.spec.ts
+++ b/packages/method/tests/resolver-plain-documents.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
 import { canonicalHashBytes, IdentifierTypes, JSONPatch } from '@did-btcr2/common';
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { p2pkh, p2tr, p2wpkh } from '@scure/btc-signer';
 import { DidBtcr2 } from '../src/did-btcr2.js';
 import { Identifier } from '../src/core/identifier.js';
 import { Resolver } from '../src/core/resolver.js';
@@ -66,9 +69,51 @@ describe('resolver plain-document handling', () => {
     }
   });
 
-  it('patching the deterministic() output keeps every field (no toJSON-subset drop)', () => {
-    const doc = Resolver.deterministic(Identifier.decode(deterministicData[0]!.did));
-    const baselineDoc = JSON.parse(JSON.stringify(doc));
+  it('patching the deterministic() output keeps every field (fixed literal baseline)', () => {
+    const fixture = deterministicData[0]!;
+    const didComponents = Identifier.decode(fixture.did);
+    const doc = Resolver.deterministic(didComponents);
+
+    // Fixed literal baseline: the full field inventory a deterministic document
+    // must carry, written out in this test. Identifier-derived values (the
+    // multibase key and the three beacon addresses) are recomputed here from the
+    // decoded genesis bytes, not read from the resolver output, so a field the
+    // resolver drops turns into a deep-equal mismatch.
+    const genesisBytes = didComponents.genesisBytes;
+    const network = getNetwork('bitcoin');
+    const { multibase } = new CompressedSecp256k1PublicKey(genesisBytes);
+    const keyRef = `${fixture.did}#initialKey`;
+    const baselineDoc = {
+      id                 : fixture.did,
+      '@context'         : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+      verificationMethod : [{
+        id                 : keyRef,
+        type               : 'Multikey',
+        controller         : fixture.did,
+        publicKeyMultibase : multibase.encoded,
+      }],
+      authentication       : [keyRef],
+      assertionMethod      : [keyRef],
+      capabilityInvocation : [keyRef],
+      capabilityDelegation : [keyRef],
+      service              : [
+        {
+          id              : `${fixture.did}#initialP2PKH`,
+          type            : 'SingletonBeacon',
+          serviceEndpoint : `bitcoin:${p2pkh(genesisBytes, network).address}`,
+        },
+        {
+          id              : `${fixture.did}#initialP2WPKH`,
+          type            : 'SingletonBeacon',
+          serviceEndpoint : `bitcoin:${p2wpkh(genesisBytes, network).address}`,
+        },
+        {
+          id              : `${fixture.did}#initialP2TR`,
+          type            : 'SingletonBeacon',
+          serviceEndpoint : `bitcoin:${p2tr(genesisBytes.slice(1, 33), undefined, network).address}`,
+        },
+      ],
+    };
     const patch = [{ op: 'add' as const, path: '/alsoKnownAs', value: ['did:web:example.com'] }];
 
     const patched = JSONPatch.apply(doc, patch);

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -1701,11 +1701,15 @@ describe('Resolver security regressions', () => {
 
   it('versionId "1" returns the genesis document even when updates exist', () => {
     const sourceDocument = resolveDeterministic(fixture.did);
-    const updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did), benignPatch(fixture.did)]);
+    // Updates exist on-chain, but a versionId "1" request is terminal at genesis:
+    // resolution completes without any beacon discovery.
+    const _updates = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did), benignPatch(fixture.did)]);
 
-    const resolved = driveSingleBeacon(fixture.did, updates, { versionId: '1' });
-    expect(resolved.metadata.versionId).to.equal('1');
-    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length);
+    const resolver = DidBtcr2.resolve(fixture.did, { versionId: '1' });
+    const state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected immediate resolution at genesis');
+    expect(state.result.metadata.versionId).to.equal('1');
+    expect(state.result.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length);
   });
 
   it('versionId "2" returns exactly the v2 document', () => {
@@ -1804,10 +1808,13 @@ describe('Resolver security regressions (audit: discovery hardening)', () => {
     const [u2] = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did)]);
 
     // The same update announced twice: the apply at height 100 (10 confs), the
-    // duplicate at height 105 (5 confs, later time).
+    // duplicate at height 105 (7 confs, later time). The duplicate must clear the
+    // minConf threshold so it genuinely reaches the duplicate-confirmation branch;
+    // a duplicate below minConf would be discarded by the confirmation gate first
+    // and this test would pass without exercising the branch at all.
     const resolved = driveSignalSequence(fixture.did, [u2], [u2, u2], [
       { height: 100, time: 1700000000, confirmations: 10 },
-      { height: 105, time: 1700001000, confirmations: 5 },
+      { height: 105, time: 1700001000, confirmations: 7 },
     ]);
 
     expect(resolved.metadata.versionId).to.equal('2');
@@ -1851,5 +1858,291 @@ describe('Resolver security regressions (audit: discovery hardening)', () => {
     (sourceDocument as any).deactivated = true;
     const response = Resolver.updates(sourceDocument, []);
     expect(response.metadata.deactivated).to.be.true;
+  });
+
+  it('providing an SMT proof with a malformed id throws a typed ResolveError', () => {
+    const { genesisDocument } = externalData[2]; // regtest
+    const smtGenesisDoc = JSON.parse(JSON.stringify(genesisDocument));
+    smtGenesisDoc.service[0].type = 'SMTBeacon';
+    const smtGenesisBytes = hash(canonicalize(smtGenesisDoc));
+    const smtDid = DidBtcr2.create(smtGenesisBytes, { idType: 'EXTERNAL', version: 1, network: 'regtest' });
+
+    const resolver = DidBtcr2.resolve(smtDid, { sidecar: { genesisDocument: smtGenesisDoc } });
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+    const beaconNeed = state.needs[0] as NeedBeaconSignals;
+    const smtService = beaconNeed.beaconServices[0] as BeaconService;
+    const fakeRootHash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const fakeSignals = new Map<BeaconService, Array<BeaconSignal>>();
+    fakeSignals.set(smtService, [{
+      tx            : {} as any,
+      signalBytes   : fakeRootHash,
+      blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+    }]);
+    resolver.provide(beaconNeed, fakeSignals);
+
+    state = resolver.resolve();
+    if(state.status !== 'action-required' || state.needs[0].kind !== 'NeedSMTProof') {
+      throw new Error('expected NeedSMTProof');
+    }
+
+    let thrown: any;
+    try {
+      resolver.provide(state.needs[0] as NeedSMTProof, { id: '!!!not-base64url!!!', collapsed: '', hashes: [] } as any);
+    } catch(error) {
+      thrown = error;
+    }
+    expect(thrown, 'expected a typed error').to.exist;
+    expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+    expect(thrown.message).to.match(/Malformed SMT proof id/);
+  });
+});
+
+describe('Resolver terminal resolution at a requested version', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+
+  it('versionId "1" resolves the genesis document immediately, with no beacon discovery', () => {
+    const resolver = DidBtcr2.resolve(fixture.did, { versionId: '1' });
+    const state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected immediate resolution at genesis');
+    expect(state.result.metadata.versionId).to.equal('1');
+    expect(state.result.didDocument.id).to.equal(fixture.did);
+  });
+
+  it('versionId "2" terminates without discovering beacons the v2 update added', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    // u2 (v1->v2) adds a beacon that carries u3 (v2->v3) in a later round.
+    const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, 2);
+
+    const resolver = DidBtcr2.resolve(fixture.did, { sidecar: { updates }, versionId: '2' });
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+    const need = state.needs[0] as NeedBeaconSignals;
+    const signals = new Map<BeaconService, Array<BeaconSignal>>();
+    for(const service of need.beaconServices) {
+      const updateHashHex = signalByAddress.get(BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string));
+      signals.set(service, updateHashHex
+        ? [{ tx: {} as any, signalBytes: updateHashHex, blockMetadata: { height: 100, time: 1700000000, confirmations: 6 } }]
+        : []);
+    }
+    resolver.provide(need, signals);
+    state = resolver.resolve();
+    // The requested version was reached by applying u2: resolution must terminate
+    // here rather than scan the v2 document for new beacons and emit data needs
+    // for versions after the target.
+    if(state.status !== 'resolved') throw new Error('expected resolution to terminate at version 2');
+    expect(state.result.metadata.versionId).to.equal('2');
+    expect(state.result.didDocument.service).to.have.lengthOf(sourceDocument.service.length + 1);
+  });
+
+  it('versionTime holds across discovery rounds and preserves the last in-window metadata', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    // u2 (in-window, on the genesis beacon) adds a beacon; u3 (mined after the
+    // cutoff) is announced on that added beacon and discovered a round later.
+    const { updates, signalByAddress } = buildDiscoveryChain(fixture.did, sourceDocument, fixture.secretKey, 2);
+
+    const resolver = DidBtcr2.resolve(fixture.did, {
+      sidecar     : { updates },
+      versionTime : '2023-11-14T22:13:30Z'
+    });
+
+    // Round 1: the genesis beacon announces u2, in-window at depth 10.
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals (round 1)');
+    {
+      const need = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      for(const service of need.beaconServices) {
+        const updateHashHex = signalByAddress.get(BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string));
+        signals.set(service, updateHashHex
+          ? [{ tx: {} as any, signalBytes: updateHashHex, blockMetadata: { height: 100, time: 1700000000, confirmations: 10 } }]
+          : []);
+      }
+      resolver.provide(need, signals);
+    }
+
+    // Round 2: the beacon u2 added announces u3, mined after the cutoff.
+    state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals (round 2)');
+    {
+      const need = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      for(const service of need.beaconServices) {
+        const updateHashHex = signalByAddress.get(BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string));
+        signals.set(service, updateHashHex
+          ? [{ tx: {} as any, signalBytes: updateHashHex, blockMetadata: { height: 101, time: 1700001000, confirmations: 6 } }]
+          : []);
+      }
+      resolver.provide(need, signals);
+    }
+
+    state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected resolved');
+    // u3 is past the cutoff and never applies, and the truncated round must not
+    // reset the metadata recorded when u2 applied.
+    expect(state.result.metadata.versionId).to.equal('2');
+    expect(state.result.metadata.updated).to.equal('2023-11-14T22:13:20Z');
+    expect(state.result.metadata.confirmations).to.equal(10);
+  });
+
+  it('a discovery round containing only a duplicate preserves previously applied metadata', () => {
+    const source = resolveDeterministic(fixture.did);
+    // u2 (v1->v2) adds a beacon; that beacon re-announces u2 a round later, so the
+    // second round contains only a duplicate and applies nothing.
+    const { updates } = buildDiscoveryChain(fixture.did, source, fixture.secretKey, 1);
+    const [u2] = updates;
+    const u2hash = canonicalHash(u2, { encoding: 'hex' });
+
+    const resolver = DidBtcr2.resolve(fixture.did, { sidecar: { updates } });
+
+    // Round 1: u2 applies at depth 10.
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals (round 1)');
+    {
+      const need = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      for(const service of need.beaconServices) {
+        signals.set(service, [{ tx: {} as any, signalBytes: u2hash, blockMetadata: { height: 100, time: 1700000000, confirmations: 10 } }]);
+      }
+      resolver.provide(need, signals);
+    }
+
+    // Round 2: the beacon u2 added re-announces u2 (a duplicate) at depth 7.
+    state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals (round 2)');
+    {
+      const need = state.needs[0] as NeedBeaconSignals;
+      const signals = new Map<BeaconService, Array<BeaconSignal>>();
+      for(const service of need.beaconServices) {
+        signals.set(service, [{ tx: {} as any, signalBytes: u2hash, blockMetadata: { height: 105, time: 1700001000, confirmations: 7 } }]);
+      }
+      resolver.provide(need, signals);
+    }
+
+    state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected resolved');
+    expect(state.result.metadata.versionId).to.equal('2');
+    expect(state.result.metadata.updated).to.equal('2023-11-14T22:13:20Z');
+    expect(state.result.metadata.confirmations).to.equal(10);
+  });
+});
+
+describe('Resolver beacon-signal intake validation', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+
+  /** Fresh resolver parked at the NeedBeaconSignals stage. */
+  function resolverAtSignals() {
+    const resolver = DidBtcr2.resolve(fixture.did);
+    const state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+    return { resolver, need: state.needs[0] as NeedBeaconSignals };
+  }
+
+  it('rejects malformed beacon-signal block metadata with a typed error', () => {
+    const cases: Array<{ name: string; meta: Record<string, unknown> }> = [
+      { name: 'NaN height', meta: { height: NaN, time: 1700000000, confirmations: 6 } },
+      { name: 'fractional time', meta: { height: 100, time: 1700000000.5, confirmations: 6 } },
+      { name: 'string confirmations', meta: { height: 100, time: 1700000000, confirmations: '6' } },
+      { name: 'negative confirmations', meta: { height: 100, time: 1700000000, confirmations: -1 } },
+      { name: 'missing height', meta: { time: 1700000000, confirmations: 6 } },
+    ];
+    for(const { name, meta } of cases) {
+      const { resolver, need } = resolverAtSignals();
+      const service = need.beaconServices[0] as BeaconService;
+      const signals = new Map([[service, [{ tx: {}, signalBytes: 'ab'.repeat(32), blockMetadata: meta }]]]);
+      let thrown: any;
+      try {
+        resolver.provide(need, signals as any);
+      } catch(error) {
+        thrown = error;
+      }
+      expect(thrown, name).to.exist;
+      expect(thrown.type, name).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message, name).to.match(/blockMetadata/);
+    }
+  });
+
+  it('rejects a non-array signal list for a beacon service', () => {
+    const { resolver, need } = resolverAtSignals();
+    const service = need.beaconServices[0] as BeaconService;
+    const signals = new Map([[service, 'not-an-array']]);
+    expect(() => resolver.provide(need, signals as any)).to.throw(/array of signals/);
+  });
+
+  it('rejects a signal missing signalBytes', () => {
+    const { resolver, need } = resolverAtSignals();
+    const service = need.beaconServices[0] as BeaconService;
+    const signals = new Map([[service, [{ tx: {}, blockMetadata: { height: 100, time: 1700000000, confirmations: 6 } }]]]);
+    expect(() => resolver.provide(need, signals as any)).to.throw(/signalBytes/);
+  });
+
+  it('drops an under-confirmed signal at intake instead of emitting NeedSignedUpdate', () => {
+    const { resolver, need } = resolverAtSignals();
+    const service = need.beaconServices[0] as BeaconService;
+    // An unknown update hash at depth 3 (< minConf 6): gating at apply time would
+    // still emit the retrieval need first; gating at intake drops the signal and
+    // resolution completes at version 1.
+    resolver.provide(need, new Map([[service, [{
+      tx            : {} as any,
+      signalBytes   : 'ab'.repeat(32),
+      blockMetadata : { height: 100, time: 1700000000, confirmations: 3 }
+    }]]]));
+    const state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected resolved, got action-required');
+    expect(state.result.metadata.versionId).to.equal('1');
+  });
+
+  it('drops an under-confirmed CAS signal at intake instead of emitting NeedCASAnnouncement', () => {
+    const { genesisDocument } = externalData[2]; // regtest
+    const casGenesisDoc = JSON.parse(JSON.stringify(genesisDocument));
+    casGenesisDoc.service[0].type = 'CASBeacon';
+    const casGenesisBytes = hash(canonicalize(casGenesisDoc));
+    const casDid = DidBtcr2.create(casGenesisBytes, { idType: 'EXTERNAL', version: 1, network: 'regtest' });
+
+    const resolver = DidBtcr2.resolve(casDid, { sidecar: { genesisDocument: casGenesisDoc } });
+    let state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedBeaconSignals');
+    const need = state.needs[0] as NeedBeaconSignals;
+    const casService = need.beaconServices[0] as BeaconService;
+    resolver.provide(need, new Map([[casService, [{
+      tx            : {} as any,
+      signalBytes   : 'cd'.repeat(32),
+      blockMetadata : { height: 100, time: 1700000000, confirmations: 3 }
+    }]]]));
+    state = resolver.resolve();
+    if(state.status !== 'resolved') throw new Error('expected resolved, got action-required');
+    expect(state.result.metadata.versionId).to.equal('1');
+  });
+
+  it('still emits retrieval needs for a signal meeting minConf', () => {
+    const { resolver, need } = resolverAtSignals();
+    const service = need.beaconServices[0] as BeaconService;
+    resolver.provide(need, new Map([[service, [{
+      tx            : {} as any,
+      signalBytes   : 'ab'.repeat(32),
+      blockMetadata : { height: 100, time: 1700000000, confirmations: 6 }
+    }]]]));
+    const state = resolver.resolve();
+    if(state.status !== 'action-required') throw new Error('expected NeedSignedUpdate');
+    expect(state.needs[0].kind).to.equal('NeedSignedUpdate');
+  });
+});
+
+describe('Resolver confirmation gate fails closed', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+
+  it('treats missing, NaN, fractional, and string confirmations as unconfirmed', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    const [u2] = buildUpdateChain(fixture.did, sourceDocument, fixture.secretKey, [benignPatch(fixture.did)]);
+    const badValues: Array<any> = [undefined, NaN, 6.5, '7'];
+    for(const confirmations of badValues) {
+      const response = Resolver.updates(
+        sourceDocument,
+        [[u2, { height: 100, time: 1700000000, confirmations }]]
+      );
+      expect(response.metadata.versionId, String(confirmations)).to.equal('1');
+      expect(response.didDocument.assertionMethod, String(confirmations))
+        .to.have.lengthOf(sourceDocument.assertionMethod!.length);
+    }
   });
 });


### PR DESCRIPTION
* fix(method): terminal versionId; preserved round metadata; intake signal validation; early minConf gate; closed confirmation check; custom-network, deactivated and SMT-id rejection; decoded key types (audit M2, M4, L7, L8, I3, I5; review MS-06, MS-07, MS-13, MS-21, MS-23, MS-33, MS-42)
* fix(common): bound move and copy from-pointers, size values in UTF-8 bytes, cap aggregate patch size at 1 MiB (audit L10; review MS-24)
* test(method): unmasked duplicate case at 7 confirmations, terminal-version and metadata tests, literal plain-document baseline (review MS-06, MS-21, MS-43, MS-47.6)
* test(common): from-pointer, UTF-8 sizing and aggregate-budget cases (review MS-24)
* test(cli): resolution-options file test now resolves versionId 1 offline (review MS-06)
* docs(method): migration note for full-document sourceHash and mandatory Write capability action (review MS-20)