### PR TITLE
harden bitcoin client response validation and credential hygiene

### DIFF
--- a/packages/bitcoin/src/client/rest/block.ts
+++ b/packages/bitcoin/src/client/rest/block.ts
@@ -30,7 +30,11 @@ export class BitcoinBlock {
    */
   public async count(): Promise<number> {
     const raw = await this.exec(this.protocol.getBlockTipHeight());
-    const height = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw.trim()) : NaN;
+    const height = typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && raw.trim().length > 0
+        ? Number(raw.trim())
+        : NaN;
     if (!Number.isInteger(height) || height < 0) {
       throw new BitcoinRestError(`Invalid tip height response: ${JSON.stringify(raw)}`);
     }
@@ -39,21 +43,27 @@ export class BitcoinBlock {
 
   /**
    * Returns the Esplora block data for a given blockhash or height.
+   *
+   * Contract: this method either resolves with validated block data or
+   * throws; it never resolves to `undefined`. A lookup for a nonexistent
+   * block fails at the HTTP layer (Esplora answers 404, which the client
+   * turns into an error before this method sees a body), and an invalid or
+   * unresolvable height/hash is rejected by {@link getHash}.
+   *
    * @param {object} params The block hash or height.
    * @param {string} [params.blockhash] The blockhash of the block to query.
    * @param {number} [params.height] The block height of the block to query.
-   * @returns {Promise<EsploraBlock | undefined>} The block data.
-   * @throws {BitcoinRestError} If neither blockhash nor height is provided.
+   * @returns {Promise<EsploraBlock>} The block data.
+   * @throws {BitcoinRestError} If neither blockhash nor height is provided,
+   * the height does not resolve to a valid hash, or the block response is
+   * malformed.
    */
-  public async get({ blockhash, height }: { blockhash?: string; height?: number }): Promise<EsploraBlock | undefined> {
+  public async get({ blockhash, height }: { blockhash?: string; height?: number }): Promise<EsploraBlock> {
     if (!blockhash && height === undefined) {
       throw new BitcoinRestError('blockhash or height required', { blockhash, height });
     }
 
     blockhash ??= await this.getHash(height!);
-    if (!blockhash || typeof blockhash !== 'string') {
-      return undefined;
-    }
 
     const block = await this.exec(this.protocol.getBlock(blockhash));
     const reason = checkEsploraBlock(block);

--- a/packages/bitcoin/src/client/rest/protocol.ts
+++ b/packages/bitcoin/src/client/rest/protocol.ts
@@ -1,6 +1,7 @@
 import { StringUtils } from '@did-btcr2/common';
 import type { RestConfig } from '../../types.js';
 import type { HttpRequest } from '../http.js';
+import { warnIfCleartextCredentials } from '../utils.js';
 
 const HEX64_RE = /^[0-9a-f]{64}$/i;
 
@@ -37,6 +38,15 @@ export class EsploraProtocol {
       'Content-Type' : 'application/json',
       ...config.headers,
     };
+
+    // Warn when configured credentials (an Authorization header or URL
+    // userinfo) will be sent over cleartext HTTP to a non-loopback host.
+    let sendsCredentials = Object.keys(config.headers ?? {}).some(h => h.toLowerCase() === 'authorization');
+    try {
+      const u = new URL(config.host);
+      sendsCredentials ||= Boolean(u.username || u.password);
+    } catch { /* an unparseable host carries no usable credentials */ }
+    warnIfCleartextCredentials('REST', config.host, sendsCredentials);
   }
 
   private static assertHex64(value: string, label: string): void {

--- a/packages/bitcoin/src/client/rpc/index.ts
+++ b/packages/bitcoin/src/client/rpc/index.ts
@@ -50,7 +50,7 @@ export interface RpcMethodMap {
   sendtoaddress:                  { params: [string, number];                                         result: string };
   signmessage:                    { params: [string, string];                                         result: string };
   verifymessage:                  { params: [string, string, string];                                 result: boolean };
-  deriveaddresses:                { params: [string, number[]?];                                      result: DerivedAddresses[] };
+  deriveaddresses:                { params: [string, number[]?];                                      result: DerivedAddresses };
   generatetoaddress:              { params: [number, string];                                         result: string[] };
 }
 
@@ -92,7 +92,7 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
     try {
       const raw = await this.#transport.call(method, parameters as unknown[]);
       const normalized = JSONUtils.isUnprototyped(raw) ? JSONUtils.normalize(raw) : raw;
-      const reason = checkRpcResult(method, normalized);
+      const reason = checkRpcResult(method, normalized, parameters as unknown[]);
       if (reason) {
         throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Invalid ${method} response: ${reason}`, { method });
       }
@@ -207,7 +207,7 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
   }
 
   /** Derives one or more addresses corresponding to an output descriptor. */
-  public async deriveAddresses(descriptor: string, range?: Array<number>): Promise<Array<DerivedAddresses>> {
+  public async deriveAddresses(descriptor: string, range?: Array<number>): Promise<DerivedAddresses> {
     return await this.executeRpc('deriveaddresses', [descriptor, range]);
   }
 
@@ -279,9 +279,9 @@ export class BitcoinCoreRpcClient implements BitcoinRpcClient {
     const results = await this.#transport.batch(
       txids.map(txid => ({ method: 'getrawtransaction', params: [txid, v] as unknown[] }))
     );
-    return results.map(raw => {
+    return results.map((raw, i) => {
       const normalized = JSONUtils.isUnprototyped(raw) ? JSONUtils.normalize(raw) : raw;
-      const reason = checkRpcResult('getrawtransaction', normalized);
+      const reason = checkRpcResult('getrawtransaction', normalized, [txids[i], v]);
       if (reason) {
         throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Invalid getrawtransaction response: ${reason}`, { method: 'getrawtransaction' });
       }

--- a/packages/bitcoin/src/client/rpc/interface.ts
+++ b/packages/bitcoin/src/client/rpc/interface.ts
@@ -47,7 +47,7 @@ export interface BitcoinRpcClient {
   createRawTransaction(inputs: CreateRawTxInputs[], outputs: CreateRawTxOutputs[], locktime?: number, replacable?: boolean): Promise<string>;
 
   /** Derives addresses from a descriptor. */
-  deriveAddresses(descriptor: string, range?: Array<number>): Promise<Array<DerivedAddresses>>;
+  deriveAddresses(descriptor: string, range?: Array<number>): Promise<DerivedAddresses>;
 
   /** Mines a specified number of blocks to a given address. */
   generateToAddress(nblocks: number, address: string): Promise<string[]>;

--- a/packages/bitcoin/src/client/rpc/json-rpc.ts
+++ b/packages/bitcoin/src/client/rpc/json-rpc.ts
@@ -2,8 +2,15 @@ import { BitcoinRpcError } from '../../errors.js';
 import type { RpcConfig } from '../../types.js';
 import type { HttpExecutor} from '../http.js';
 import { defaultHttpExecutor } from '../http.js';
-import { DEFAULT_MAX_RESPONSE_BYTES, readJsonWithLimit, safeText } from '../utils.js';
+import { DEFAULT_MAX_RESPONSE_BYTES, readJsonWithLimit, readTextWithLimit } from '../utils.js';
 import { JsonRpcProtocol } from './protocol.js';
+
+/**
+ * Maximum characters of an HTTP error body embedded in a thrown
+ * {@link BitcoinRpcError}: the body is diagnostic, so a large (but
+ * in-cap) error page must not bloat the error message.
+ */
+const MAX_ERROR_BODY_CHARS = 1024;
 
 export class JsonRpcTransport {
   /**
@@ -40,6 +47,24 @@ export class JsonRpcTransport {
   }
 
   /**
+   * Read an HTTP error body through the same size cap as success bodies,
+   * truncated for use as a diagnostic message. A body that exceeds the cap
+   * throws the typed cap-exceeded error instead of being read unbounded.
+   */
+  private async readErrorBody(res: Response, context: Record<string, unknown>): Promise<string> {
+    let text: string;
+    try {
+      text = await readTextWithLimit(res, this.maxResponseBytes);
+    } catch (error: unknown) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new BitcoinRpcError('INVALID_RESPONSE', -1, `Unreadable RPC response: ${cause}`, context);
+    }
+    return text.length > MAX_ERROR_BODY_CHARS
+      ? `${text.slice(0, MAX_ERROR_BODY_CHARS)}...`
+      : text;
+  }
+
+  /**
    * Execute a single JSON-RPC call.
    */
   async call(method: string, params: unknown[] = []): Promise<unknown> {
@@ -47,7 +72,7 @@ export class JsonRpcTransport {
     const res = await this.execute(request);
 
     if (!res.ok) {
-      const text = await safeText(res);
+      const text = await this.readErrorBody(res, { method });
       throw new BitcoinRpcError(
         'HTTP_ERROR',
         res.status,
@@ -75,7 +100,7 @@ export class JsonRpcTransport {
     const res = await this.execute(request);
 
     if (!res.ok) {
-      const text = await safeText(res);
+      const text = await this.readErrorBody(res, { methods: calls.map(c => c.method) });
       throw new BitcoinRpcError(
         'HTTP_ERROR',
         res.status,
@@ -84,7 +109,7 @@ export class JsonRpcTransport {
       );
     }
 
-    const payloads = await this.readBody<Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>>(
+    const payloads = await this.readBody<unknown>(
       res,
       { methods: calls.map(c => c.method) }
     );

--- a/packages/bitcoin/src/client/rpc/protocol.ts
+++ b/packages/bitcoin/src/client/rpc/protocol.ts
@@ -1,7 +1,7 @@
 import { BitcoinRpcError } from '../../errors.js';
 import type { RpcConfig } from '../../types.js';
 import type { HttpRequest } from '../http.js';
-import { isInsecureRemoteHttp, redactUrlCredentials, toBase64 } from '../utils.js';
+import { redactUrlCredentials, toBase64, warnIfCleartextCredentials } from '../utils.js';
 
 /**
  * An {@link HttpRequest} for a JSON-RPC batch call, carrying the request IDs
@@ -68,8 +68,15 @@ export class JsonRpcProtocol {
           url = u.toString().replace(/\/+$/, '');
         }
       } catch (error: unknown) {
-        // The raw URL may carry userinfo credentials; log only the redacted form.
-        console.error(`Invalid URL in Bitcoin RPC config: ${redactUrlCredentials(url)}`, error);
+        // The raw URL may carry userinfo credentials; log only the redacted
+        // URL and sanitized error fields, never the raw error object: its
+        // `input` property holds the original credential-bearing URL.
+        const { name, code, message } = (error ?? {}) as { name?: unknown; code?: unknown; message?: unknown };
+        console.error(`Invalid URL in Bitcoin RPC config: ${redactUrlCredentials(url)}`, {
+          name    : typeof name === 'string' ? name : 'Error',
+          code    : typeof code === 'string' ? code : 'UNKNOWN',
+          message : typeof message === 'string' ? message : String(error),
+        });
       }
     }
 
@@ -91,16 +98,11 @@ export class JsonRpcProtocol {
     };
 
     // Warn when credentials (basic auth or a caller-supplied Authorization
-    // header) will be sent over cleartext HTTP to a non-loopback host: anyone on
-    // the path can read them.
+    // header) will be sent over cleartext HTTP to a non-loopback host: anyone
+    // on the path can read them.
     const sendsCredentials = authHeader !== undefined
       || Object.keys(cfg.headers ?? {}).some(h => h.toLowerCase() === 'authorization');
-    if (sendsCredentials && isInsecureRemoteHttp(url)) {
-      console.warn(
-        `WARNING: Bitcoin RPC credentials will be sent over cleartext HTTP to ${new URL(url).host}. `
-        + 'Use HTTPS, an SSH tunnel, or a loopback bind instead.',
-      );
-    }
+    warnIfCleartextCredentials('RPC', url, sendsCredentials);
   }
 
   /**
@@ -170,7 +172,7 @@ export class JsonRpcProtocol {
    * @param ids The IDs captured on the {@link BatchHttpRequest} at build time.
    */
   parseBatchResponse(
-    payloads: Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>,
+    payloads: unknown,
     calls: Array<{ method: string; params: unknown[] }>,
     ids: readonly number[],
   ): unknown[] {
@@ -181,7 +183,26 @@ export class JsonRpcProtocol {
         `Batch id count (${ids.length}) does not match call count (${calls.length})`,
       );
     }
-    const byId = new Map(payloads.map(p => [p.id, p]));
+    if (!Array.isArray(payloads)) {
+      throw new BitcoinRpcError(
+        'INVALID_RESPONSE',
+        -1,
+        'Batch response is not an array',
+        { methods: calls.map(c => c.method) }
+      );
+    }
+    const byId = new Map<number, { id: number; result?: unknown; error?: { code: number; message: string } }>();
+    for (const entry of payloads) {
+      if (typeof entry !== 'object' || entry === null || typeof (entry as { id?: unknown }).id !== 'number') {
+        throw new BitcoinRpcError(
+          'INVALID_RESPONSE',
+          -1,
+          'Batch response entry is not an object with a numeric id',
+          { methods: calls.map(c => c.method) }
+        );
+      }
+      byId.set(entry.id, entry);
+    }
 
     return calls.map((call, i) => {
       const payload = byId.get(ids[i]);
@@ -198,13 +219,15 @@ export class JsonRpcProtocol {
   }
 
   /**
-   * Return a copy of the headers with the Authorization value redacted.
-   * Use this for logging or debugging.
+   * Return a copy of the headers with the Authorization value redacted
+   * (matched case-insensitively). Use this for logging or debugging.
    */
   redactedHeaders(): Record<string, string> {
     const copy = { ...this._headers };
-    if (copy.Authorization) {
-      copy.Authorization = 'Basic [REDACTED]';
+    for (const key of Object.keys(copy)) {
+      if (key.toLowerCase() === 'authorization') {
+        copy[key] = copy[key].startsWith('Basic') ? 'Basic [REDACTED]' : '[REDACTED]';
+      }
     }
     return copy;
   }

--- a/packages/bitcoin/src/client/utils.ts
+++ b/packages/bitcoin/src/client/utils.ts
@@ -123,3 +123,16 @@ export function isInsecureRemoteHttp(url: string): boolean {
   }
   return u.protocol === 'http:' && !LOOPBACK_HOSTNAMES.has(u.hostname);
 }
+
+/**
+ * Warn once (at client construction) when credentials will be sent over
+ * cleartext HTTP to a non-loopback host: anyone on the path can read them.
+ * Shared by the RPC and REST transports.
+ */
+export function warnIfCleartextCredentials(service: 'RPC' | 'REST', url: string, sendsCredentials: boolean): void {
+  if (!sendsCredentials || !isInsecureRemoteHttp(url)) return;
+  console.warn(
+    `WARNING: Bitcoin ${service} credentials will be sent over cleartext HTTP to ${new URL(url).host}. `
+    + 'Use HTTPS, an SSH tunnel, or a loopback bind instead.',
+  );
+}

--- a/packages/bitcoin/src/client/validate.ts
+++ b/packages/bitcoin/src/client/validate.ts
@@ -29,10 +29,18 @@ function isNonEmptyString(value: unknown): value is string {
 export function checkTransactionStatus(value: unknown): string | null {
   if (!isPlainObject(value)) return 'status is not an object';
   if (typeof value.confirmed !== 'boolean') return 'status.confirmed is not a boolean';
-  // A confirmed tx must report the block it was mined in; confirmation counts
-  // are derived from this height downstream.
-  if (value.confirmed === true && !isNonNegativeInteger(value.block_height)) {
-    return 'status.block_height is not a non-negative integer for a confirmed transaction';
+  // A confirmed tx must report the block it was mined in and when; confirmation
+  // counts and timestamps are derived from these fields downstream.
+  if (value.confirmed === true) {
+    if (!isNonNegativeInteger(value.block_height)) {
+      return 'status.block_height is not a non-negative integer for a confirmed transaction';
+    }
+    if (!isNonEmptyString(value.block_hash)) {
+      return 'status.block_hash is not a non-empty string for a confirmed transaction';
+    }
+    if (!isNonNegativeInteger(value.block_time)) {
+      return 'status.block_time is not a non-negative integer for a confirmed transaction';
+    }
   }
   return null;
 }
@@ -81,11 +89,22 @@ export function checkAddressInfo(value: unknown): string | null {
   return null;
 }
 
+/**
+ * Effective verbosity of a `getblock`/`getrawtransaction` call: the second
+ * positional parameter when it is an integer, otherwise the client's default.
+ */
+function effectiveVerbosity(params: unknown[] | undefined, fallback: number): number {
+  const v = params?.[1];
+  return typeof v === 'number' && Number.isInteger(v) ? v : fallback;
+}
+
 /** Verbose (`getrawtransaction` v1/v2) transaction from Bitcoin Core. */
-function checkRawTransactionRpc(value: unknown): string | null {
+function checkRawTransactionRpc(value: unknown, verbosity: number): string | null {
   // Verbosity 0 returns a bare hex string.
-  if (typeof value === 'string') return value.length > 0 ? null : 'result is an empty string';
-  if (!isPlainObject(value)) return 'transaction is not an object';
+  if (verbosity === 0) {
+    return isNonEmptyString(value) ? null : 'result is not a non-empty hex string (verbosity 0)';
+  }
+  if (!isPlainObject(value)) return `result is not a decoded transaction object (verbosity ${verbosity})`;
   if (!isNonEmptyString(value.txid)) return 'txid is not a non-empty string';
   if (!Array.isArray(value.vin)) return 'vin is not an array';
   if (!Array.isArray(value.vout)) return 'vout is not an array';
@@ -97,12 +116,24 @@ function checkRawTransactionRpc(value: unknown): string | null {
   return null;
 }
 
-/** `getblock` result: hex string at verbosity 0, decoded object otherwise. */
-function checkBlockRpc(value: unknown): string | null {
-  if (typeof value === 'string') return value.length > 0 ? null : 'result is an empty string';
-  if (!isPlainObject(value)) return 'block is not an object';
+/** `getblock` result, checked against the requested verbosity. */
+function checkBlockRpc(value: unknown, verbosity: number): string | null {
+  // Verbosity 0 returns a bare hex string.
+  if (verbosity === 0) {
+    return isNonEmptyString(value) ? null : 'result is not a non-empty hex string (verbosity 0)';
+  }
+  if (!isPlainObject(value)) return `result is not a decoded block object (verbosity ${verbosity})`;
   if (!isNonEmptyString(value.hash)) return 'block.hash is not a non-empty string';
   if (!isNonNegativeInteger(value.height)) return 'block.height is not a non-negative integer';
+  // Verbosity >= 1 carries a tx list: txids at verbosity 1, decoded
+  // transactions at verbosity 2/3. Consumers iterate this array.
+  if (!Array.isArray(value.tx)) return `block.tx is not an array (verbosity ${verbosity})`;
+  for (const [i, entry] of (value.tx as unknown[]).entries()) {
+    const reason = verbosity === 1
+      ? (isNonEmptyString(entry) ? null : 'not a txid string')
+      : checkRawTransactionRpc(entry, verbosity);
+    if (reason) return `block.tx[${i}]: ${reason}`;
+  }
   return null;
 }
 
@@ -126,8 +157,13 @@ function checkStringArray(value: unknown): string | null {
 /**
  * Structural check on a Bitcoin Core RPC result for the given method.
  * Methods without an entry pass through unchecked (`null`).
+ *
+ * `params` are the request parameters actually sent: `getblock` and
+ * `getrawtransaction` responses are validated against the requested
+ * verbosity (defaulting to the client's own defaults of 3 and 2), so a
+ * hex-string or header-only response cannot pass as a decoded payload.
  */
-export function checkRpcResult(method: string, result: unknown): string | null {
+export function checkRpcResult(method: string, result: unknown, params?: unknown[]): string | null {
   switch (method) {
     case 'getblockcount':
       return isNonNegativeInteger(result) ? null : 'result is not a non-negative integer';
@@ -149,9 +185,9 @@ export function checkRpcResult(method: string, result: unknown): string | null {
       if (typeof result.chain !== 'string') return 'result.chain is not a string';
       return null;
     case 'getblock':
-      return checkBlockRpc(result);
+      return checkBlockRpc(result, effectiveVerbosity(params, 3));
     case 'getrawtransaction':
-      return checkRawTransactionRpc(result);
+      return checkRawTransactionRpc(result, effectiveVerbosity(params, 2));
     case 'gettransaction':
       if (!isPlainObject(result)) return 'result is not an object';
       if (!isNonEmptyString(result.txid)) return 'result.txid is not a non-empty string';

--- a/packages/bitcoin/src/connection.ts
+++ b/packages/bitcoin/src/connection.ts
@@ -74,8 +74,9 @@ export class BitcoinConnection {
   /**
    * Converts Bitcoin (BTC) to satoshis.
    * Uses string-based arithmetic to avoid floating-point precision errors.
-   * @throws {RangeError} If the value is not finite, is out of range, or has
-   * more than 8 decimal places of precision.
+   * @throws {RangeError} If the value is not finite, is out of range, has
+   * more than 8 decimal places of precision, or converts to a satoshi total
+   * outside the safe-integer range (about 90,071,992.54740991 BTC).
    */
   static btcToSats(btc: number): number {
     if (!Number.isFinite(btc)) {
@@ -101,8 +102,13 @@ export class BitcoinConnection {
     if (Math.abs(abs - Number(str)) > tolerance) {
       throw new RangeError(`BTC value ${btc} exceeds 8 decimal places of precision`);
     }
-    const sats = Number(whole) * 1e8 + Number(frac);
-    return negative ? -sats : sats;
+    const sats = negative ? -(Number(whole) * 1e8 + Number(frac)) : Number(whole) * 1e8 + Number(frac);
+    // Beyond the safe-integer range the double cannot name every satoshi, so
+    // the conversion would silently round to a neighboring value.
+    if (!Number.isSafeInteger(sats)) {
+      throw new RangeError(`BTC value ${btc} exceeds the safe-integer satoshi range`);
+    }
+    return sats;
   }
 
   /**

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -31,7 +31,7 @@ export type { FeeEstimator } from './fee-estimator.js';
 // Helpers
 export { getNetwork } from './network.js';
 export type { BTCNetwork } from './network.js';
-export { toBase64, safeText, redactUrlCredentials, isInsecureRemoteHttp } from './client/utils.js';
+export { toBase64, safeText, redactUrlCredentials, isInsecureRemoteHttp, warnIfCleartextCredentials } from './client/utils.js';
 export {
   DEFAULT_MAX_RESPONSE_BYTES,
   readJsonWithLimit,

--- a/packages/bitcoin/tests/client-robustness.spec.ts
+++ b/packages/bitcoin/tests/client-robustness.spec.ts
@@ -22,7 +22,7 @@ function jsonExecutor(body: unknown): HttpExecutor {
 }
 
 describe('client robustness', () => {
-  describe('response size cap (M11)', () => {
+  describe('response size cap', () => {
     it('REST rejects a body whose declared Content-Length exceeds the cap', async () => {
       const executor: HttpExecutor = async () => new Response('{}', {
         status  : 200,
@@ -100,9 +100,61 @@ describe('client robustness', () => {
         expect(err.type).to.equal('INVALID_RESPONSE');
       }
     });
+
+    it('RPC applies the size cap to HTTP error bodies on single calls', async () => {
+      const executor: HttpExecutor = async () => new Response('x'.repeat(1024), {
+        status     : 500,
+        statusText : 'Error',
+        headers    : { 'Content-Type': 'text/plain' },
+      });
+      const rpc = new BitcoinCoreRpcClient({ host: 'http://node', maxResponseBytes: 16 }, executor);
+      try {
+        await rpc.getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('exceeds');
+      }
+    });
+
+    it('RPC applies the size cap to HTTP error bodies on batches', async () => {
+      const executor: HttpExecutor = async () => new Response('x'.repeat(1024), {
+        status     : 500,
+        statusText : 'Error',
+        headers    : { 'Content-Type': 'text/plain' },
+      });
+      const rpc = new BitcoinCoreRpcClient({ host: 'http://node', maxResponseBytes: 16 }, executor);
+      try {
+        await rpc.getRawTransactions([VALID_TXID, 'b'.repeat(64)]);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('exceeds');
+      }
+    });
+
+    it('RPC truncates a large in-cap error body embedded in the thrown error', async () => {
+      const executor: HttpExecutor = async () => new Response('y'.repeat(4096), {
+        status     : 500,
+        statusText : 'Error',
+        headers    : { 'Content-Type': 'text/plain' },
+      });
+      const rpc = new BitcoinCoreRpcClient({ host: 'http://node' }, executor);
+      try {
+        await rpc.getBlockCount();
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('HTTP_ERROR');
+        expect(err.message.length).to.be.lessThan(4096);
+        expect(err.message).to.match(/\.{3}$/);
+      }
+    });
   });
 
-  describe('REST structural validation (M11)', () => {
+  describe('REST structural validation', () => {
     const rest = (body: unknown) => new BitcoinRestClient({ host: 'http://node' }, jsonExecutor(body));
 
     it('rejects a transaction missing vin/vout arrays', async () => {
@@ -130,6 +182,36 @@ describe('client robustness', () => {
         expect.fail('Expected to throw');
       } catch (err: any) {
         expect(err.message).to.include('block_height');
+      }
+    });
+
+    it('rejects a confirmed transaction without a block hash', async () => {
+      const status = { confirmed: true, block_height: 100, block_time: 1700000000 };
+      try {
+        await rest(restTx({ status })).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('block_hash');
+      }
+    });
+
+    it('rejects a confirmed transaction without a block time', async () => {
+      const status = { confirmed: true, block_height: 100, block_hash: 'b'.repeat(64) };
+      try {
+        await rest(restTx({ status })).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('block_time');
+      }
+    });
+
+    it('rejects a confirmed transaction with a non-numeric block time', async () => {
+      const status = { confirmed: true, block_height: 100, block_hash: 'b'.repeat(64), block_time: 'soon' };
+      try {
+        await rest(restTx({ status })).transaction.get(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.message).to.include('block_time');
       }
     });
 
@@ -187,6 +269,23 @@ describe('client robustness', () => {
       }
     });
 
+    it('rejects an empty or whitespace-only tip height body', async () => {
+      for (const body of [ '', '   ', '\n' ]) {
+        const executor: HttpExecutor = async () => new Response(body, {
+          status  : 200,
+          headers : { 'Content-Type': 'text/plain' },
+        });
+        const client = new BitcoinRestClient({ host: 'http://node' }, executor);
+        try {
+          await client.block.count();
+          expect.fail(`Expected to throw for body ${JSON.stringify(body)}`);
+        } catch (err: any) {
+          expect(err).to.be.instanceOf(BitcoinRestError);
+          expect(err.message).to.include('tip height');
+        }
+      }
+    });
+
     it('rejects a malformed block hash for a height lookup', async () => {
       const executor: HttpExecutor = async () => new Response('../../etc/passwd', {
         status  : 200,
@@ -225,7 +324,7 @@ describe('client robustness', () => {
     });
   });
 
-  describe('RPC structural validation (M11)', () => {
+  describe('RPC structural validation', () => {
     const rpc = (result: unknown) => new BitcoinCoreRpcClient({ host: 'http://node' }, jsonExecutor({ result }));
 
     it('rejects a non-integer getblockcount result', async () => {
@@ -268,6 +367,86 @@ describe('client robustness', () => {
       }
     });
 
+    it('rejects a hex-string getrawtransaction result when verbosity 2 was requested', async () => {
+      try {
+        await rpc('deadbeef'.repeat(8)).getRawTransaction(VALID_TXID);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('decoded transaction');
+      }
+    });
+
+    it('accepts a hex-string getrawtransaction result at verbosity 0', async () => {
+      const hex = 'deadbeef'.repeat(8);
+      expect(await rpc(hex).getRawTransaction(VALID_TXID, 0)).to.equal(hex);
+    });
+
+    it('rejects an empty-string getrawtransaction result at verbosity 0', async () => {
+      try {
+        await rpc('').getRawTransaction(VALID_TXID, 0);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
+
+    it('rejects a hex-string getblock result when verbosity 3 was requested', async () => {
+      try {
+        await rpc('deadbeef'.repeat(8)).getBlock({ blockhash: VALID_TXID, verbosity: 3 });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('decoded block');
+      }
+    });
+
+    it('rejects a header-only getblock result at verbosity 3', async () => {
+      try {
+        await rpc({ hash: VALID_TXID, height: 100 }).getBlock({ blockhash: VALID_TXID, verbosity: 3 });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('block.tx');
+      }
+    });
+
+    it('rejects a verbosity-3 block whose tx entries are not decoded transactions', async () => {
+      const block = { hash: VALID_TXID, height: 100, tx: [VALID_TXID] };
+      try {
+        await rpc(block).getBlock({ blockhash: VALID_TXID, verbosity: 3 });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('block.tx[0]');
+      }
+    });
+
+    it('accepts a well-formed verbosity-3 block', async () => {
+      const block = { hash: VALID_TXID, height: 100, tx: [{ txid: VALID_TXID, vin: [], vout: [] }] };
+      const result = await rpc(block).getBlock({ blockhash: VALID_TXID, verbosity: 3 }) as any;
+      expect(result.tx).to.have.length(1);
+    });
+
+    it('accepts a verbosity-1 block with txid strings and rejects decoded entries', async () => {
+      const block = { hash: VALID_TXID, height: 100, tx: [VALID_TXID] };
+      const result = await rpc(block).getBlock({ blockhash: VALID_TXID, verbosity: 1 }) as any;
+      expect(result.tx).to.deep.equal([VALID_TXID]);
+      const mismatch = { hash: VALID_TXID, height: 100, tx: [{ txid: VALID_TXID, vin: [], vout: [] }] };
+      try {
+        await rpc(mismatch).getBlock({ blockhash: VALID_TXID, verbosity: 1 });
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('block.tx[0]');
+      }
+    });
+
+    it('accepts a hex-string getblock result at verbosity 0', async () => {
+      const hex = 'deadbeef'.repeat(8);
+      expect(await rpc(hex).getBlock({ blockhash: VALID_TXID, verbosity: 0 })).to.equal(hex);
+    });
+
     it('rejects a signrawtransactionwithwallet result missing complete', async () => {
       try {
         await rpc({ hex: 'aa' }).signRawTransaction('aa');
@@ -308,9 +487,23 @@ describe('client robustness', () => {
       const verbose = await rpc(tx).getRawTransaction(VALID_TXID, 2);
       expect(verbose).to.have.property('txid', VALID_TXID);
     });
+
+    it('accepts a flat string array from deriveaddresses', async () => {
+      const addresses = ['bc1qaaa', 'bc1qbbb'];
+      expect(await rpc(addresses).deriveAddresses('desc', [0, 1])).to.deep.equal(addresses);
+    });
+
+    it('rejects a nested array from deriveaddresses', async () => {
+      try {
+        await rpc([['bc1qaaa']]).deriveAddresses('desc', [0, 1]);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.type).to.equal('INVALID_RESPONSE');
+      }
+    });
   });
 
-  describe('btcToSats edge cases (L14)', () => {
+  describe('btcToSats edge cases', () => {
     it('preserves the sign of negative fractional values', () => {
       expect(BitcoinConnection.btcToSats(-0.5)).to.equal(-50_000_000);
       expect(BitcoinConnection.btcToSats(-0.00000001)).to.equal(-1);
@@ -333,10 +526,17 @@ describe('client robustness', () => {
       expect(() => BitcoinConnection.btcToSats(1.000000005)).to.throw(RangeError);
     });
 
-    it('does not false-positive on large values within double representation error', () => {
+    it('converts large values exactly within the safe-integer satoshi range', () => {
       expect(BitcoinConnection.btcToSats(21000000.99999999)).to.equal(2100000099999999);
-      expect(BitcoinConnection.btcToSats(99999999.99999999)).to.equal(10000000000000000);
-      expect(BitcoinConnection.btcToSats(123456789.12345678)).to.equal(12345678912345678);
+      expect(BitcoinConnection.btcToSats(90071992.54740991)).to.equal(9007199254740991);
+      expect(BitcoinConnection.btcToSats(-90071992.54740991)).to.equal(-9007199254740991);
+    });
+
+    it('rejects values whose satoshi total leaves the safe-integer range', () => {
+      expect(() => BitcoinConnection.btcToSats(90071992.54740992)).to.throw(RangeError, /safe-integer/);
+      expect(() => BitcoinConnection.btcToSats(99999999.99999999)).to.throw(RangeError, /safe-integer/);
+      expect(() => BitcoinConnection.btcToSats(123456789.12345678)).to.throw(RangeError, /safe-integer/);
+      expect(() => BitcoinConnection.btcToSats(-99999999.99999999)).to.throw(RangeError, /safe-integer/);
     });
   });
 });

--- a/packages/bitcoin/tests/credential-hygiene.spec.ts
+++ b/packages/bitcoin/tests/credential-hygiene.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { BitcoinRestClient } from '../src/client/rest/index.js';
+import { EsploraProtocol } from '../src/client/rest/protocol.js';
 import { JsonRpcProtocol } from '../src/client/rpc/protocol.js';
 import type { HttpExecutor, HttpRequest } from '../src/client/http.js';
 import { isInsecureRemoteHttp, redactUrlCredentials } from '../src/client/utils.js';
@@ -15,7 +16,7 @@ function captureWarn(fn: () => void): string[] {
 
 describe('credential hygiene', () => {
 
-  describe('JsonRpcProtocol cleartext-credential warning (M7)', () => {
+  describe('JsonRpcProtocol cleartext-credential warning', () => {
     it('warns when basic auth is sent over cleartext HTTP to a remote host', () => {
       const warnings = captureWarn(() => {
         new JsonRpcProtocol({ host: 'http://node.example.com:8332', username: 'u', password: 'p' });
@@ -60,7 +61,51 @@ describe('credential hygiene', () => {
     });
   });
 
-  describe('redactUrlCredentials (L11)', () => {
+  describe('EsploraProtocol cleartext-credential warning', () => {
+    it('warns when a configured Authorization header goes to a remote cleartext host', () => {
+      const warnings = captureWarn(() => {
+        new EsploraProtocol({ host: 'http://node.example.com:3000', headers: { Authorization: 'Bearer xyz' } });
+      });
+      expect(warnings).to.have.lengthOf(1);
+      expect(warnings[0]).to.match(/cleartext HTTP/);
+      expect(warnings[0]).to.not.contain('xyz');
+    });
+
+    it('warns when a lowercase authorization header goes to a remote cleartext host', () => {
+      const warnings = captureWarn(() => {
+        new EsploraProtocol({ host: 'http://node.example.com:3000', headers: { authorization: 'Bearer xyz' } });
+      });
+      expect(warnings).to.have.lengthOf(1);
+    });
+
+    it('warns for credentials embedded in the URL userinfo', () => {
+      const warnings = captureWarn(() => {
+        new EsploraProtocol({ host: 'http://user:pass@node.example.com:3000' });
+      });
+      expect(warnings).to.have.lengthOf(1);
+    });
+
+    it('stays quiet for loopback hosts, HTTPS, and credential-free HTTP', () => {
+      for (const config of [
+        { host: 'http://localhost:3000', headers: { Authorization: 'Bearer xyz' } },
+        { host: 'http://127.0.0.1:3000', headers: { Authorization: 'Bearer xyz' } },
+        { host: 'https://node.example.com:3000', headers: { Authorization: 'Bearer xyz' } },
+        { host: 'http://node.example.com:3000' },
+      ]) {
+        const warnings = captureWarn(() => { new EsploraProtocol(config); });
+        expect(warnings, JSON.stringify(config)).to.have.lengthOf(0);
+      }
+    });
+
+    it('warns once when constructed through BitcoinRestClient', () => {
+      const warnings = captureWarn(() => {
+        new BitcoinRestClient({ host: 'http://node.example.com:3000', headers: { Authorization: 'Bearer xyz' } });
+      });
+      expect(warnings).to.have.lengthOf(1);
+    });
+  });
+
+  describe('redactUrlCredentials', () => {
     it('strips userinfo from a parseable URL', () => {
       expect(redactUrlCredentials('http://user:pass@node.example.com:8332/'))
         .to.equal('http://node.example.com:8332/');
@@ -76,7 +121,7 @@ describe('credential hygiene', () => {
     });
   });
 
-  describe('isInsecureRemoteHttp (M7 helper)', () => {
+  describe('isInsecureRemoteHttp', () => {
     it('classifies hosts correctly', () => {
       expect(isInsecureRemoteHttp('http://node.example.com')).to.be.true;
       expect(isInsecureRemoteHttp('http://localhost:8332')).to.be.false;
@@ -85,22 +130,33 @@ describe('credential hygiene', () => {
     });
   });
 
-  describe('invalid RPC URL logging (L11)', () => {
+  describe('invalid RPC URL logging', () => {
     it('logs the redacted URL, never the credentials', () => {
       const original = console.error;
-      const messages: string[] = [];
-      console.error = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+      const argsList: unknown[][] = [];
+      console.error = (...args: unknown[]) => { argsList.push(args); };
       try {
         new JsonRpcProtocol({ host: 'http://user:supersecret@:' });
       } finally {
         console.error = original;
       }
-      expect(messages).to.have.lengthOf(1);
-      expect(messages[0]).to.not.contain('supersecret');
+      expect(argsList).to.have.lengthOf(1);
+      const args = argsList[0];
+      // Inspect the full serialized form of every logged argument, plus any
+      // `input` property an error object might carry: the credential-bearing
+      // URL must not appear under console inspection either.
+      const serialized = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+      expect(serialized).to.not.contain('supersecret');
+      expect(serialized).to.not.contain('user');
+      for (const arg of args) {
+        if (typeof arg === 'object' && arg !== null) {
+          expect(arg).to.not.have.property('input');
+        }
+      }
     });
   });
 
-  describe('BitcoinRestClient error handling (L11)', () => {
+  describe('BitcoinRestClient error handling', () => {
     function mockExecutor(response: { status: number; body: string; contentType?: string }): { executor: HttpExecutor; seen: HttpRequest[] } {
       const seen: HttpRequest[] = [];
       const executor: HttpExecutor = async (req) => {

--- a/packages/bitcoin/tests/json-rpc.spec.ts
+++ b/packages/bitcoin/tests/json-rpc.spec.ts
@@ -266,6 +266,40 @@ describe('JsonRpcProtocol', () => {
         expect(err.message).to.include('does not match call count');
       }
     });
+
+    it('throws a typed error for a non-array payload (object, string, null)', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = [
+        { method: 'getblockcount', params: [] as unknown[] },
+        { method: 'getblockhash', params: [100] as unknown[] },
+      ];
+      const req = protocol.buildBatchRequest(calls);
+      for (const body of [{ id: 1, result: 1 }, 'oops', null]) {
+        try {
+          protocol.parseBatchResponse(body, calls, req.ids);
+          expect.fail(`Expected to throw for ${JSON.stringify(body)}`);
+        } catch (err: any) {
+          expect(err).to.be.instanceOf(BitcoinRpcError);
+          expect(err.type).to.equal('INVALID_RESPONSE');
+          expect(err.message).to.include('not an array');
+        }
+      }
+    });
+
+    it('throws a typed error for an array with a malformed entry', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = [{ method: 'getblockcount', params: [] as unknown[] }];
+      const req = protocol.buildBatchRequest(calls);
+      for (const body of [[null], ['oops'], [{ result: 1 }]]) {
+        try {
+          protocol.parseBatchResponse(body, calls, req.ids);
+          expect.fail(`Expected to throw for ${JSON.stringify(body)}`);
+        } catch (err: any) {
+          expect(err).to.be.instanceOf(BitcoinRpcError);
+          expect(err.type).to.equal('INVALID_RESPONSE');
+        }
+      }
+    });
   });
 
   describe('redactedHeaders()', () => {
@@ -274,6 +308,15 @@ describe('JsonRpcProtocol', () => {
       const headers = protocol.redactedHeaders();
       expect(headers.Authorization).to.equal('Basic [REDACTED]');
       expect(headers['Content-Type']).to.equal('application/json');
+    });
+
+    it('redacts authorization headers regardless of name casing', () => {
+      for (const name of ['authorization', 'AUTHORIZATION', 'Authorization']) {
+        const protocol = new JsonRpcProtocol({ host: 'http://node:8332', headers: { [name]: 'Bearer secret-token' } });
+        const headers = protocol.redactedHeaders();
+        expect(headers[name], name).to.equal('[REDACTED]');
+        expect(JSON.stringify(headers)).to.not.contain('secret-token');
+      }
     });
 
     it('returns clean headers when no auth is present', () => {
@@ -443,6 +486,25 @@ describe('JsonRpcTransport', () => {
       const results = await transport.batch([]);
       expect(results).to.deep.equal([]);
       expect(seen).to.have.length(0);
+    });
+
+    it('throws a typed error when a batch response body is not an array', async () => {
+      const executor: HttpExecutor = async () => new Response(JSON.stringify({ result: 'not-a-batch' }), {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json' },
+      });
+      const transport = new JsonRpcTransport({ host: 'http://node:8332' }, executor);
+      try {
+        await transport.batch([
+          { method: 'getblockcount', params: [] },
+          { method: 'getblockhash', params: [100] },
+        ]);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.type).to.equal('INVALID_RESPONSE');
+        expect(err.message).to.include('not an array');
+      }
     });
 
     it('falls back to single call for batch of one', async () => {

--- a/packages/bitcoin/tests/rest-client.spec.ts
+++ b/packages/bitcoin/tests/rest-client.spec.ts
@@ -9,6 +9,7 @@ import type { HttpExecutor, HttpRequest } from '../src/client/http.js';
 
 const VALID_TXID = 'a'.repeat(64);
 const VALID_HASH = 'b'.repeat(64);
+const CONFIRMED_STATUS = { confirmed: true, block_height: 100, block_hash: VALID_HASH, block_time: 1700000000 };
 
 /** Creates a mock executor that records requests and returns configured responses. */
 function mockExecutor(
@@ -48,14 +49,14 @@ function createMockSubClient() {
     if (req.url.includes('/tx') && req.method === 'POST') return VALID_TXID;
     if (req.url.includes('/tx/')) return { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } };
     if (req.url.includes('/utxo')) {
-      return [{ txid: VALID_TXID, vout: 0, value: 5000, status: { confirmed: true, block_height: 100 } }];
+      return [{ txid: VALID_TXID, vout: 0, value: 5000, status: CONFIRMED_STATUS }];
     }
     if (req.url.includes('/address/') && req.url.includes('/txs/chain')) {
-      return [{ txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } }];
+      return [{ txid: VALID_TXID, vin: [], vout: [], status: CONFIRMED_STATUS }];
     }
     if (req.url.includes('/address/') && req.url.endsWith('/txs/mempool')) return [];
     if (req.url.includes('/address/') && req.url.endsWith('/txs')) {
-      return [{ txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } }];
+      return [{ txid: VALID_TXID, vin: [], vout: [], status: CONFIRMED_STATUS }];
     }
     if (req.url.includes('/address/')) return { address: 'addr1', chain_stats: {}, mempool_stats: {} };
     return {};
@@ -464,7 +465,7 @@ describe('BitcoinAddress', () => {
     const protocol = new EsploraProtocol({ host: 'https://test.com' });
     const exec = async () => [
       { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: false } },
-      { txid: VALID_TXID, vin: [], vout: [], status: { confirmed: true, block_height: 100 } },
+      { txid: VALID_TXID, vin: [], vout: [], status: CONFIRMED_STATUS },
     ];
     const address = new BitcoinAddress(protocol, exec);
     expect(await address.isFundedAddress('addr1')).to.equal(true);
@@ -478,7 +479,7 @@ describe('BitcoinAddress', () => {
   });
 
   it('works end-to-end through BitcoinRestClient with executor', async () => {
-    const utxos = [{ txid: VALID_TXID, vout: 0, value: 5000, status: { confirmed: true, block_height: 100 } }];
+    const utxos = [{ txid: VALID_TXID, vout: 0, value: 5000, status: CONFIRMED_STATUS }];
     const { executor } = mockExecutor({ body: utxos });
     const rest = new BitcoinRestClient({ host: 'http://node' }, executor);
 


### PR DESCRIPTION
* fix(bitcoin-rpc): verbosity-aware results; capped error bodies; batch array guard; flat deriveaddresses
* fix(bitcoin-rest): confirmed-status block metadata; empty tip-height rejection; cleartext warning; throw-only get
* fix(bitcoin): sanitized error logging; case-insensitive header redaction; safe-integer btcToSats
* test(bitcoin): tiny-cap error regression, verbosity mismatches, redaction cases, batch body shapes, conversion bounds