### PR TITLE
anchor proof temporal checks to block time and tighten key custody

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -1,5 +1,6 @@
 import type { NetworkName } from '@did-btcr2/bitcoin';
 import type { DocumentBytes, KeyBytes, PatchOperation } from '@did-btcr2/common';
+import { INVALID_DID_UPDATE, UpdateError } from '@did-btcr2/common';
 import type { Signer } from '@did-btcr2/keypair';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 import type { KeyIdentifier } from '@did-btcr2/key-manager';
@@ -239,9 +240,9 @@ export class DidBtcr2Api {
         const meta = resolution.didResolutionMetadata;
         const detail = meta?.error ? `: ${meta.error}` : '.';
         const extra = meta?.errorMessage ? ` ${meta.errorMessage}` : '';
-        throw new Error(
+        throw new UpdateError(
           `Failed to resolve DID ${did} for update${detail}${extra}`,
-          { cause: meta }
+          INVALID_DID_UPDATE, { did, resolutionMetadata: meta }
         );
       }
       doc = doc ?? resolution.didDocument as Btcr2DidDocument;
@@ -249,15 +250,17 @@ export class DidBtcr2Api {
       if (versionId === undefined) {
         const rawVersionId = resolution.didDocumentMetadata?.versionId;
         if (rawVersionId === undefined || rawVersionId === null) {
-          throw new Error(
+          throw new UpdateError(
             `Resolution of DID ${did} succeeded but returned no versionId in metadata. `
-            + 'Provide sourceVersionId explicitly.'
+            + 'Provide sourceVersionId explicitly.',
+            INVALID_DID_UPDATE, { did }
           );
         }
         const parsed = Number(rawVersionId);
         if (!Number.isFinite(parsed)) {
-          throw new Error(
-            `Resolution of DID ${did} returned a non-numeric versionId: ${String(rawVersionId)}.`
+          throw new UpdateError(
+            `Resolution of DID ${did} returned a non-numeric versionId: ${String(rawVersionId)}.`,
+            INVALID_DID_UPDATE, { did, versionId: rawVersionId }
           );
         }
         versionId = parsed;
@@ -269,8 +272,9 @@ export class DidBtcr2Api {
     // The marker is the `deactivated` property on the document,
     // which resolution also surfaces as didDocumentMetadata.deactivated.
     if (doc?.deactivated === true) {
-      throw new Error(
-        `DID ${did} is deactivated and cannot be updated. Deactivation is permanent.`
+      throw new UpdateError(
+        `DID ${did} is deactivated and cannot be updated. Deactivation is permanent.`,
+        INVALID_DID_UPDATE, { did }
       );
     }
 

--- a/packages/api/src/crypto.ts
+++ b/packages/api/src/crypto.ts
@@ -257,7 +257,8 @@ export class DataIntegrityProofApi {
    * @param document The document to verify the proof for.
    * @param expectedPurpose The expected proof purpose.
    * @param mediaType The media type of the document.
-   * @param expectedDomain The expected domain for the proof.
+   * @param expectedDomain The expected domain(s) for the proof. Multiple domains
+   *   use AND semantics: every expected domain must be present in the proof.
    * @param expectedChallenge The expected challenge for the proof.
    * @param proof Optional explicit proof instance; defaults to current.
    * @returns The result of verifying the proof.
@@ -266,7 +267,7 @@ export class DataIntegrityProofApi {
     document: string,
     expectedPurpose: string,
     mediaType?: string,
-    expectedDomain?: string,
+    expectedDomain?: string | string[],
     expectedChallenge?: string,
     proof?: BIP340DataIntegrityProof,
   ): VerificationResult {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,7 +22,7 @@ export type {
   SchnorrKeyPairObject,
   SignatureBytes
 } from '@did-btcr2/common';
-export type { MultikeyObject } from '@did-btcr2/cryptosuite';
+export type { MultikeyObject, PublicMultikeyObject } from '@did-btcr2/cryptosuite';
 export type { DidResolutionResult, DidService, DidVerificationMethod } from '@web5/dids';
 
 // Local modules

--- a/packages/api/tests/data-integrity-proof-api.spec.ts
+++ b/packages/api/tests/data-integrity-proof-api.spec.ts
@@ -77,6 +77,30 @@ describe('DataIntegrityProofApi', () => {
     expect(result).to.have.property('verified');
   });
 
+  it('verifyProof() accepts an array of expected domains (AND semantics)', () => {
+    const kp = kpApi.generate();
+    const mk = mkApi.create('#key-1', 'did:btcr2:test', kp);
+    const cs = csApi.create(mk);
+    const proofInst = dipApi.create(cs);
+    const signed = dipApi.addProof(
+      makeDocument() as any,
+      { ...makeConfig(), domain: ['did:btcr2:test', 'did:btcr2:other'] },
+      proofInst
+    );
+    const serialized = JSON.stringify(signed);
+
+    const ok = dipApi.verifyProof(
+      serialized, 'assertionMethod', 'application/json',
+      ['did:btcr2:test', 'did:btcr2:other'], undefined, proofInst
+    );
+    expect(ok.verified).to.be.true;
+
+    expect(() => dipApi.verifyProof(
+      serialized, 'assertionMethod', 'application/json',
+      ['did:btcr2:test', 'did:btcr2:missing'], undefined, proofInst
+    )).to.throw(/Domain mismatch/);
+  });
+
   // --- stateful ---
 
   it('use() sets the current proof instance', () => {

--- a/packages/cryptosuite/src/cryptosuite/index.ts
+++ b/packages/cryptosuite/src/cryptosuite/index.ts
@@ -7,6 +7,7 @@ import {
   canonicalize,
   CryptosuiteError,
   DateUtils,
+  JSONUtils,
   MethodError,
   PROOF_GENERATION_ERROR,
   PROOF_SERIALIZATION_ERROR,
@@ -18,7 +19,8 @@ import { base58btc } from 'multiformats/bases/base58';
 import { BIP340DataIntegrityProof } from '../data-integrity-proof/index.js';
 import type { DataIntegrityProofObject, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from '../data-integrity-proof/interface.js';
 import type { SchnorrMultikey } from '../multikey/index.js';
-import type { Cryptosuite, VerificationResult } from './interface.js';
+import type { Cryptosuite, ProofVerificationOptions, VerificationResult } from './interface.js';
+import { MAX_PROOF_CLOCK_SKEW_MS } from './interface.js';
 
 /**
  * An implementation of a {@link Cryptosuite} using BIP340 Schnorr signatures and JCS canonicalization.
@@ -71,13 +73,15 @@ export class BIP340Cryptosuite implements Cryptosuite {
     document: UnsecuredDocument,
     config: DataIntegrityProofOptions
   ): DataIntegrityProofObject {
-    // Build the proof as a fresh object: the caller's config is neither mutated
-    // nor aliased into the returned proof, so post-hoc mutation of the caller's
+    // Build the proof as a fresh deep copy: the caller's config is neither
+    // mutated nor aliased into the returned proof (nested values such as a
+    // domain array are cloned too), so post-hoc mutation of the caller's
     // config cannot alter the secured document (and vice versa).
+    const clonedConfig = JSONUtils.clone(config);
     const proof: DataIntegrityProofObject = {
-      ...config,
+      ...clonedConfig,
       // Set the context using the document context or the existing config context
-      '@context' : (document['@context'] as string | string[] | undefined) ?? config['@context'],
+      '@context' : JSONUtils.clone((document['@context'] as string | string[] | undefined) ?? clonedConfig['@context']),
     } as DataIntegrityProofObject;
 
     // Create a canonical form of the proof configuration
@@ -106,13 +110,64 @@ export class BIP340Cryptosuite implements Cryptosuite {
   }
 
   /**
-   * Verify a proof for a secure document.
+   * Verify a proof for a secure document. Temporal checks run here, at the
+   * shared verification chokepoint, so every caller (Data Integrity wrapper,
+   * resolver replay, aggregation intake, api facade) enforces them:
+   * `proof.expires` must be a valid XMLSchema DateTime strictly after the
+   * reference time, and `proof.created` must be a valid XMLSchema DateTime no
+   * more than {@link MAX_PROOF_CLOCK_SKEW_MS} ahead of the reference time.
    * @param {SecuredDocument} secureDocument The secured document to verify.
+   * @param {ProofVerificationOptions} [options] Optional verification options.
+   *   `referenceTime` defaults to the wall clock; pass an anchoring block time
+   *   when replaying anchored history.
    * @returns {VerificationResult} The result of the verification.
+   * @throws {CryptosuiteError} if the proof is expired, has a malformed
+   *   expires/created, or was created too far in the future of the reference time.
    */
-  verifyProof(secureDocument: SecuredDocument): VerificationResult {
+  verifyProof(secureDocument: SecuredDocument, options?: ProofVerificationOptions): VerificationResult {
     // Destructure the proof from the secure document and create an unsecured document without the proof
     const { proof, ...unsecureDocument } = secureDocument;
+
+    // The reference time defaults to the wall clock; historical replays pass
+    // the anchoring block time so proofs expired only after their anchor verify.
+    const referenceTime = options?.referenceTime ?? new Date();
+
+    // Check if the proof carries an expiry
+    if(proof.expires) {
+      // Validate the format
+      if(!DateUtils.isValidXsdDateTime(proof.expires)) {
+        throw new CryptosuiteError(
+          'Invalid proof: "expires" must be a valid XMLSchema DateTime string',
+          PROOF_VERIFICATION_ERROR, { proof }
+        );
+      }
+      // A proof must not verify at or past its expiry, relative to the reference time
+      if(DateUtils.dateStringToTimestamp(proof.expires).getTime() <= referenceTime.getTime()) {
+        throw new CryptosuiteError(
+          'Proof expired: reference time is at or past proof.expires',
+          PROOF_VERIFICATION_ERROR, { proof }
+        );
+      }
+    }
+
+    // Check if the proof carries a creation timestamp
+    if(proof.created) {
+      // Validate the format
+      if(!DateUtils.isValidXsdDateTime(proof.created)) {
+        throw new CryptosuiteError(
+          'Invalid proof: "created" must be a valid XMLSchema DateTime string',
+          PROOF_VERIFICATION_ERROR, { proof }
+        );
+      }
+      // A proof created too far ahead of the reference time is rejected; the
+      // tolerance covers ordinary clock skew between signer and verifier.
+      if(DateUtils.dateStringToTimestamp(proof.created).getTime() > referenceTime.getTime() + MAX_PROOF_CLOCK_SKEW_MS) {
+        throw new CryptosuiteError(
+          'Invalid proof: "created" is too far in the future of the reference time',
+          PROOF_VERIFICATION_ERROR, { proof }
+        );
+      }
+    }
 
     // Destructure the proofValue from the proof and create a config without the proofValue
     const { proofValue, ...config } = proof;

--- a/packages/cryptosuite/src/cryptosuite/interface.ts
+++ b/packages/cryptosuite/src/cryptosuite/interface.ts
@@ -18,6 +18,27 @@ export interface VerificationResult {
 }
 
 /**
+ * Clock-skew tolerance applied when bounding a proof's `created` timestamp
+ * against the verification reference time: a proof whose `created` is no more
+ * than this far ahead of the reference time is accepted. Five minutes covers
+ * ordinary clock skew between signer and verifier.
+ */
+export const MAX_PROOF_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+/**
+ * Options for proof verification.
+ */
+export interface ProofVerificationOptions {
+  /**
+   * The time against which `proof.expires` and `proof.created` are evaluated.
+   * Defaults to the wall clock (`new Date()`). Verifiers replaying anchored
+   * history (for example a DID resolver) should pass the anchoring block time
+   * so a proof that expired only after its anchor still verifies.
+   */
+  referenceTime?: Date;
+}
+
+/**
  * Interface representing a {@link https://www.w3.org/TR/vc-data-integrity/#cryptographic-suites | Cryptographic Suite}
  * from the {@link https://www.w3.org/TR/vc-data-integrity/ | Verifiable Credential Data Integrity 1.0 spec}.
  * @interface Cryptosuite
@@ -48,11 +69,14 @@ export interface Cryptosuite {
   createProof(insecureDocument: UnsecuredDocument, config: DataIntegrityProofOptions): DataIntegrityProofObject;
 
   /**
-   * Verify a proof for a secured document.
+   * Verify a proof for a secured document. Temporal checks (`proof.expires`,
+   * `proof.created`) are enforced here so every caller shares them.
    * @param {SecuredDocument} secureDocument The secured document to verify.
+   * @param {ProofVerificationOptions} [options] Optional verification options (reference time).
    * @returns {VerificationResult} The result of the verification.
+   * @throws {CryptosuiteError} if the proof is expired, malformed, or created too far in the future.
    */
-  verifyProof(secureDocument: SecuredDocument): VerificationResult;
+  verifyProof(secureDocument: SecuredDocument, options?: ProofVerificationOptions): VerificationResult;
 
   /**
    * Transform a document (secured or unsecured) into canonical form.

--- a/packages/cryptosuite/src/data-integrity-proof/index.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/index.ts
@@ -1,6 +1,6 @@
-import { DataIntegrityProofError, DateUtils, PROOF_GENERATION_ERROR, PROOF_VERIFICATION_ERROR } from '@did-btcr2/common';
+import { DataIntegrityProofError, JSONUtils, PROOF_GENERATION_ERROR, PROOF_VERIFICATION_ERROR } from '@did-btcr2/common';
 import type { BIP340Cryptosuite } from '../cryptosuite/index.js';
-import type { VerificationResult } from '../cryptosuite/interface.js';
+import type { ProofVerificationOptions, VerificationResult } from '../cryptosuite/interface.js';
 import type { DataIntegrityProof, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from './interface.js';
 
 /**
@@ -43,8 +43,10 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
     // TODO: Adjust the domain check to match the spec (domain as a list of urls)
     // Check if the config has a domain
     if (config.domain) {
-      // Check that it matches the proof domain Check domain from the proof object and check:
-      if(proof.domain !== config.domain)
+      // Check that it matches the proof domain (deep comparison: the proof was
+      // built from a deep copy of the config, so array domains are equal by
+      // value, not by reference)
+      if(!JSONUtils.deepEqual(proof.domain, config.domain))
         throw new DataIntegrityProofError(
           'Domain mismatch: proof.domain !== config.domain',
           PROOF_GENERATION_ERROR, {config, proof}
@@ -61,10 +63,12 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
         );
     }
 
-    // Attach the proof to a fresh copy of the document, securing it. The caller's
-    // document is not mutated in place, so a proof object can never be retroactively
-    // swapped onto (or off of) a document the caller still holds.
-    const signedDocument = { ...unsignedDocument, proof } as SecuredDocument<T>;
+    // Attach the proof to a fresh deep copy of the document, securing it. The
+    // caller's document is not mutated in place and no nested value is aliased
+    // into the secured copy, so a proof object can never be retroactively
+    // swapped onto (or off of) a document the caller still holds, and post-hoc
+    // nested mutation of the caller's document cannot alter the secured one.
+    const signedDocument = { ...JSONUtils.clone(unsignedDocument), proof } as SecuredDocument<T>;
 
     // Return the secured document
     return signedDocument;
@@ -75,8 +79,14 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
    * @param {string} mediaType The media type of the document.
    * @param {string} document The stringified document to verify.
    * @param {string} expectedPurpose The expected purpose of the proof.
-   * @param {string[]} expectedDomain The expected domain of the proof.
+   * @param {string | string[]} expectedDomain The expected domain(s) of the proof.
+   *   Multiple domains use AND semantics: every expected domain must be present
+   *   in the proof's domain list. An empty array is rejected (it would pass
+   *   vacuously, failing open).
    * @param {string} expectedChallenge The expected challenge of the proof.
+   * @param {ProofVerificationOptions} [options] Optional verification options;
+   *   forwarded to the cryptosuite's temporal checks (`referenceTime` defaults
+   *   to the wall clock).
    * @returns {VerificationResult} The result of verifying the proof.
    */
   verifyProof(
@@ -85,6 +95,7 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
     mediaType?: string,
     expectedDomain?: string | string[],
     expectedChallenge?: string,
+    options?: ProofVerificationOptions,
   ): VerificationResult {
     // Parse the document
     const signedDocument = JSON.parse(document) as SecuredDocument;
@@ -125,6 +136,16 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
       // Normalize both sides to arrays: proof.domain and expectedDomain may each
       // be a single string or a list of strings.
       const expectedDomains = Array.isArray(expectedDomain) ? expectedDomain : [expectedDomain];
+
+      // An empty expectation list would pass the every() check below vacuously,
+      // failing open; reject it as a caller error instead.
+      if(expectedDomains.length === 0) {
+        throw new DataIntegrityProofError(
+          'Invalid expectedDomain: must contain at least one domain',
+          PROOF_VERIFICATION_ERROR, { expectedDomain }
+        );
+      }
+
       const proofDomains = Array.isArray(proof.domain) ? proof.domain : (proof.domain ? [proof.domain] : []);
 
       // Every expected domain must be present in the proof's domain list.
@@ -136,26 +157,9 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
       }
     }
 
-    // Check if the proof carries an expiry
-    if(proof.expires) {
-      // Validate the format
-      if(!DateUtils.isValidXsdDateTime(proof.expires)) {
-        throw new DataIntegrityProofError(
-          'Invalid proof: "expires" must be a valid XMLSchema DateTime string',
-          PROOF_VERIFICATION_ERROR, { proof }
-        );
-      }
-      // A captured proof must not verify past its expiry
-      if(DateUtils.dateStringToTimestamp(proof.expires).getTime() <= Date.now()) {
-        throw new DataIntegrityProofError(
-          'Proof expired: current time is past proof.expires',
-          PROOF_VERIFICATION_ERROR, { proof }
-        );
-      }
-    }
-
-    // Verify the proof
-    const result = this.cryptosuite.verifyProof(signedDocument);
+    // Verify the proof (temporal checks on proof.expires / proof.created run
+    // inside the cryptosuite, evaluated against options.referenceTime)
+    const result = this.cryptosuite.verifyProof(signedDocument, options);
 
     // Add the mediaType to the verification result
     result.mediaType = mediaType;

--- a/packages/cryptosuite/src/data-integrity-proof/interface.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/interface.ts
@@ -1,4 +1,4 @@
-import type { Cryptosuite, VerificationResult } from '../cryptosuite/interface.js';
+import type { Cryptosuite, ProofVerificationOptions, VerificationResult } from '../cryptosuite/interface.js';
 
 /**
  * An unsecured document: any JSON object to which a Data Integrity proof can be
@@ -91,15 +91,19 @@ export interface DataIntegrityProof {
    * @param {string} document The stringified secured document to verify.
    * @param {string} expectedPurpose The expected proof purpose.
    * @param {string} mediaType The media type of the document.
-   * @param {string[]} expectedDomain The expected proof domain.
+   * @param {string | string[]} expectedDomain The expected proof domain(s).
+   *   Multiple domains use AND semantics: every expected domain must be present
+   *   in the proof's domain list. An empty array is rejected.
    * @param {string} expectedChallenge The expected proof challenge.
+   * @param {ProofVerificationOptions} [options] Optional verification options (reference time).
    * @returns {VerificationResult} The result of verifying the proof.
    */
   verifyProof(
     document: string,
     expectedPurpose: string,
     mediaType?: string,
-    expectedDomain?: string[],
+    expectedDomain?: string | string[],
     expectedChallenge?: string,
+    options?: ProofVerificationOptions,
   ): VerificationResult;
 }

--- a/packages/cryptosuite/src/multikey/index.ts
+++ b/packages/cryptosuite/src/multikey/index.ts
@@ -11,7 +11,8 @@ import type {
   DidParams,
   FromPublicKey,
   Multikey,
-  MultikeyObject
+  MultikeyObject,
+  PublicMultikeyObject
 } from './interface.js';
 
 interface MultikeyParams extends DidParams {
@@ -164,7 +165,9 @@ export class SchnorrMultikey implements Multikey {
       throw new MultikeyError('Cannot sign: no secretKey', 'SIGN_ERROR');
     }
 
-    const secretBytes = this.secretKey.bytes;
+    // Bytes-level access: avoids constructing a Secp256k1SecretKey wrapper (and
+    // its eager multibase encoding) per signing call. Wiped in finally below.
+    const secretBytes = this.#keyPair.secretKeyBytes!;
     try {
       return schnorr.sign(data, secretBytes, randomBytes(32));
     } finally {
@@ -208,22 +211,21 @@ export class SchnorrMultikey implements Multikey {
 
   /**
    * @readonly
-   * Get signing ability of the Multikey: true if a local Secp256k1SecretKey
-   * is present (note: the SchnorrKeyPair.secretKey getter throws when absent;
-   * that throw is the historical error contract - see multikey tests) or if
-   * an external signer is available.
+   * Get signing ability of the Multikey: true if a local Secp256k1SecretKey is
+   * present or an external signer is available. Never throws: a public-key-only
+   * pair with no external signer simply reports false.
    */
   get signer(): boolean {
-    return !!this.#externalSigner || !!this.#keyPair.secretKey;
+    return !!this.#externalSigner || this.#keyPair.hasSecretKey;
   }
 
   /**
    * Safe JSON representation. Only includes public material: the embedded keyPair
    * serializes public-key-only. Called implicitly by JSON.stringify().
    * Use {@link exportJSON} for full serialization including the secret key.
-   * @returns {MultikeyObject} The multikey as a JSON object (public material only).
+   * @returns {PublicMultikeyObject} The multikey as a JSON object (public material only).
    */
-  public toJSON(): MultikeyObject {
+  public toJSON(): PublicMultikeyObject {
     return {
       id                 : this.id,
       controller         : this.controller,
@@ -237,7 +239,7 @@ export class SchnorrMultikey implements Multikey {
   /**
    * Exports the full multikey as a JSON object. Contains secret key material:
    * the result must never appear in logs, error payloads, or telemetry.
-   * @returns {MultikeyObject} The multikey as a JSON object including the secret key.
+   * @returns {MultikeyObject} The full multikey serialization including the secret key.
    * @throws {KeyPairError} If the keyPair carries no secret key.
    */
   public exportJSON(): MultikeyObject {

--- a/packages/cryptosuite/src/multikey/interface.ts
+++ b/packages/cryptosuite/src/multikey/interface.ts
@@ -3,9 +3,10 @@ import type { CompressedSecp256k1PublicKey, SchnorrKeyPair, Secp256k1SecretKey }
 import type { DidVerificationMethod } from '@web5/dids';
 
 /**
- * JSON shape of a SchnorrMultikey. `keyPair` is public-key-only when produced by
- * `SchnorrMultikey.toJSON()` (the safe, implicit serialization) and carries the
- * full secret material only when produced by the explicit `exportJSON()`.
+ * JSON shape of a SchnorrMultikey's full serialization, as produced by the
+ * explicit `SchnorrMultikey.exportJSON()`: `keyPair` carries the secret
+ * material. For the safe, public-only shape produced by `toJSON()` /
+ * JSON.stringify(), see {@link PublicMultikeyObject}.
  */
 export type MultikeyObject = {
   id: string;
@@ -13,6 +14,20 @@ export type MultikeyObject = {
   fullId: string;
   signer: boolean;
   keyPair: SchnorrKeyPairObject | { publicKey: PublicKeyObject };
+  verificationMethod: DidVerificationMethod;
+}
+
+/**
+ * JSON shape of a SchnorrMultikey's public-only serialization, as produced by
+ * `SchnorrMultikey.toJSON()` (and implicitly by JSON.stringify()): `keyPair`
+ * carries public material only, so this shape is always safe to log or return.
+ */
+export type PublicMultikeyObject = {
+  id: string;
+  controller: string;
+  fullId: string;
+  signer: boolean;
+  keyPair: { publicKey: PublicKeyObject };
   verificationMethod: DidVerificationMethod;
 }
 export interface DidParams {

--- a/packages/cryptosuite/tests/cryptosuite.spec.ts
+++ b/packages/cryptosuite/tests/cryptosuite.spec.ts
@@ -5,6 +5,7 @@ import type {
 import {
   BIP340Cryptosuite,
   BIP340DataIntegrityProof,
+  MAX_PROOF_CLOCK_SKEW_MS,
   SchnorrMultikey
 } from '../src/index.js';
 
@@ -78,6 +79,61 @@ describe('Cryptosuite', () => {
     it('should return canonicalized document string', () => {
       const canonicalDocument = cryptosuite.transformDocument(unsecuredDocument, config);
       expect(canonicalDocument).to.be.a.string;
+    });
+  });
+
+  describe('Verify Proof temporal validation', () => {
+    const securedWith = (proofOptions: Partial<DataIntegrityProofOptions>) => {
+      const proof = cryptosuite.createProof(unsecuredDocument, { ...config, ...proofOptions });
+      return { ...unsecuredDocument, proof };
+    };
+
+    it('verifies a proof whose expires is after the reference time but in the past relative to now', () => {
+      const secured = securedWith({ expires: '2024-01-01T00:00:00Z' });
+      const result = cryptosuite.verifyProof(secured, { referenceTime: new Date('2023-06-01T00:00:00Z') });
+      expect(result.verified).to.be.true;
+    });
+
+    it('rejects a proof whose expires equals the reference time exactly', () => {
+      const secured = securedWith({ expires: '2030-06-01T00:00:00Z' });
+      expect(() => cryptosuite.verifyProof(secured, { referenceTime: new Date('2030-06-01T00:00:00Z') }))
+        .to.throw(/expired/);
+    });
+
+    it('rejects a proof whose expires is malformed', () => {
+      const secured = securedWith({ expires: '2030-06-01T00:00:00Z' });
+      secured.proof.expires = 'not-a-date';
+      expect(() => cryptosuite.verifyProof(secured, { referenceTime: new Date('2023-06-01T00:00:00Z') }))
+        .to.throw(/expires/);
+    });
+
+    it('rejects a proof created beyond the clock-skew tolerance', () => {
+      const referenceTime = new Date('2030-06-01T00:00:00Z');
+      const created = new Date(referenceTime.getTime() + MAX_PROOF_CLOCK_SKEW_MS + 60_000);
+      const secured = securedWith({ created: created.toISOString() });
+      expect(() => cryptosuite.verifyProof(secured, { referenceTime }))
+        .to.throw(/created/);
+    });
+
+    it('accepts a proof created within the clock-skew tolerance', () => {
+      const referenceTime = new Date('2030-06-01T00:00:00Z');
+      const created = new Date(referenceTime.getTime() + MAX_PROOF_CLOCK_SKEW_MS - 60_000);
+      const secured = securedWith({ created: created.toISOString() });
+      const result = cryptosuite.verifyProof(secured, { referenceTime });
+      expect(result.verified).to.be.true;
+    });
+
+    it('rejects a proof whose created is malformed', () => {
+      const secured = securedWith({ created: '2030-06-01T00:00:00Z' });
+      secured.proof.created = 'not-a-date';
+      expect(() => cryptosuite.verifyProof(secured, { referenceTime: new Date('2030-06-01T00:00:00Z') }))
+        .to.throw(/created/);
+    });
+
+    it('defaults the reference time to the wall clock', () => {
+      const secured = securedWith({ expires: '2999-01-01T00:00:00Z' });
+      const result = cryptosuite.verifyProof(secured);
+      expect(result.verified).to.be.true;
     });
   });
 });

--- a/packages/cryptosuite/tests/data-integrity-proof.spec.ts
+++ b/packages/cryptosuite/tests/data-integrity-proof.spec.ts
@@ -110,6 +110,17 @@ describe('Data Integrity Proof', () => {
         JSON.stringify(securedDocument), 'attestationMethod', undefined, 'https://example.com'
       )).to.throw(/Domain mismatch/);
     });
+
+    it('throws for an empty expected domain list (fail-closed)', () => {
+      // An empty array would pass the every() check vacuously; it must be
+      // rejected instead of silently verifying.
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, domain: 'https://example.com' }
+      );
+      expect(() => diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, []
+      )).to.throw(/expectedDomain/);
+    });
   });
 
   describe('expiry enforcement', () => {
@@ -143,6 +154,17 @@ describe('Data Integrity Proof', () => {
         JSON.stringify(securedDocument), 'attestationMethod'
       )).to.throw(/expires/);
     });
+
+    it('verifies an expired proof when the reference time precedes expiry (historical replay)', () => {
+      const securedDocument = diProof.addProof(
+        { ...pristineDocument }, { ...pristineConfig, expires: '2024-01-01T00:00:00Z' }
+      );
+      const result = diProof.verifyProof(
+        JSON.stringify(securedDocument), 'attestationMethod', undefined, undefined, undefined,
+        { referenceTime: new Date('2023-06-01T00:00:00Z') }
+      );
+      expect(result.verified).to.be.true;
+    });
   });
 
   describe('input isolation', () => {
@@ -168,6 +190,36 @@ describe('Data Integrity Proof', () => {
       cfg.domain = 'https://attacker.example';
 
       expect(secured.proof.domain).to.equal('https://example.com');
+    });
+
+    it('post-hoc nested mutation of the caller config does not alter the secured proof', () => {
+      const cfg = { ...config, domain: ['https://a.example'] };
+      const secured = diProof.addProof({ ...unsecuredDocument }, cfg);
+
+      cfg.domain.push('https://attacker.example');
+
+      expect(secured.proof.domain).to.deep.equal(['https://a.example']);
+    });
+
+    it('post-hoc nested mutation of the caller document does not alter the secured document', () => {
+      const doc = {
+        ...unsecuredDocument,
+        credentialSubject : { id: 'did:example:1', alumniOf: { id: 'did:example:2', name: 'Example University' } }
+      } as any;
+      const secured = diProof.addProof(doc, { ...config }) as any;
+
+      doc.credentialSubject.alumniOf.name = 'tampered';
+
+      expect(secured.credentialSubject.alumniOf.name).to.equal('Example University');
+    });
+
+    it('mutating the secured proof does not alter the caller config', () => {
+      const cfg = { ...config, domain: ['https://a.example'] };
+      const secured = diProof.addProof({ ...unsecuredDocument }, cfg);
+
+      (secured.proof.domain as string[]).push('https://attacker.example');
+
+      expect(cfg.domain).to.deep.equal(['https://a.example']);
     });
   });
 });

--- a/packages/cryptosuite/tests/multikey.spec.ts
+++ b/packages/cryptosuite/tests/multikey.spec.ts
@@ -1,4 +1,4 @@
-import { JSONUtils, KeyPairError, MultikeyError } from '@did-btcr2/common';
+import { JSONUtils, MultikeyError } from '@did-btcr2/common';
 import type { Signer } from '@did-btcr2/keypair';
 import { LocalSigner, SchnorrKeyPair, Secp256k1SecretKey, CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { expect } from 'chai';
@@ -136,9 +136,24 @@ describe('SchnorrMultikey', () => {
       expect(multikey.publicKey.equals(publicKey)).to.be.true;
     });
 
-    it('should throw KeyPairError', () => {
+    it('should throw MultikeyError', () => {
       expect(() => multikey.sign(message))
-        .to.throw(KeyPairError, 'Secret key not available');
+        .to.throw(MultikeyError, 'Cannot sign: no secretKey');
+    });
+
+    it('signer getter returns false without throwing', () => {
+      expect(multikey.signer).to.be.false;
+    });
+
+    it('toJSON does not throw, carries no secret material, and reports signer: false', () => {
+      const json = multikey.toJSON();
+      expect(json.signer).to.be.false;
+      expect(json.keyPair).to.not.have.property('secretKey');
+
+      // JSON.stringify path (implicit toJSON) must also be safe
+      const stringified = JSON.stringify(multikey);
+      expect(stringified).to.not.include('secretKey');
+      expect(JSON.parse(stringified).signer).to.be.false;
     });
 
     it('should verify that a valid schnorr signature was produced by the Multikey', () => {
@@ -346,6 +361,13 @@ describe('SchnorrMultikey', () => {
     it('signer getter returns true even with a public-key-only keyPair', () => {
       const multikey = SchnorrMultikey.fromSigner(id, controller, localSigner);
       expect(multikey.signer).to.be.true;
+    });
+
+    it('toJSON reports signer: true and no secret material for a signer-backed public-only multikey', () => {
+      const multikey = SchnorrMultikey.fromSigner(id, controller, localSigner);
+      const json = multikey.toJSON();
+      expect(json.signer).to.be.true;
+      expect(json.keyPair).to.not.have.property('secretKey');
     });
 
     it('produces a verifiable schnorr signature delegating through the signer', () => {

--- a/packages/key-manager/src/local-key-manager.ts
+++ b/packages/key-manager/src/local-key-manager.ts
@@ -216,14 +216,18 @@ export class LocalKeyManager implements KeyManager {
       throw new KeyManagerError(`Key already exists: ${id}`, 'KEY_FOUND');
     }
 
-    // Build key entry: secret key may not be available for watch-only pairs
+    // Build key entry: secret key may not be available for watch-only pairs.
+    // Tags are copied so later mutation of the caller's object cannot alter the
+    // stored entry.
     const entry: KeyEntry = {
       publicKey : keyPair.publicKey.compressed,
-      ...(options.tags && { tags: options.tags }),
+      ...(options.tags && { tags: { ...options.tags } }),
     };
 
-    if (keyPair.hasSecretKey) {
-      entry.secretKey = keyPair.secretKey.bytes;
+    // Bytes-level access: avoids constructing a Secp256k1SecretKey wrapper per read
+    const secretBytes = keyPair.secretKeyBytes;
+    if (secretBytes) {
+      entry.secretKey = secretBytes;
     }
 
     this.#store.set(id, entry);
@@ -292,9 +296,11 @@ export class LocalKeyManager implements KeyManager {
     const id = this.#generateUrn(kp.publicKey.compressed);
 
     const entry: KeyEntry = {
-      secretKey : kp.secretKey.bytes,
+      // Bytes-level access: a freshly generated pair always carries a secret key
+      secretKey : kp.secretKeyBytes!,
       publicKey : kp.publicKey.compressed,
-      ...(options.tags && { tags: options.tags }),
+      // Copied so later mutation of the caller's object cannot alter the entry
+      ...(options.tags && { tags: { ...options.tags } }),
     };
 
     this.#store.set(id, entry);

--- a/packages/key-manager/tests/local-key-manager.spec.ts
+++ b/packages/key-manager/tests/local-key-manager.spec.ts
@@ -50,6 +50,17 @@ describe('LocalKeyManager', () => {
       expect(kms.listKeys()).to.deep.equal([id]);
     });
 
+    it('copies the caller tags object on import (later mutation does not affect the stored entry)', () => {
+      const kms = new LocalKeyManager();
+      const tags: Record<string, string> = { label: 'original' };
+      const id = kms.importKey(SchnorrKeyPair.generate(), { tags });
+
+      tags.label = 'tampered';
+      tags.injected = 'nope';
+
+      expect(kms.getEntry(id).tags).to.deep.equal({ label: 'original' });
+    });
+
     it('computes publicKey when only secretKey provided', () => {
       const kms = new LocalKeyManager();
       const kp = SchnorrKeyPair.generate();
@@ -260,6 +271,17 @@ describe('LocalKeyManager', () => {
       const kms = new LocalKeyManager();
       const id = kms.generateKey({ tags: { purpose: 'test' } });
       expect(kms.listKeys()).to.deep.equal([id]);
+    });
+
+    it('copies the caller tags object on generate (later mutation does not affect the stored entry)', () => {
+      const kms = new LocalKeyManager();
+      const tags: Record<string, string> = { purpose: 'test' };
+      const id = kms.generateKey({ tags });
+
+      tags.purpose = 'tampered';
+      tags.injected = 'nope';
+
+      expect(kms.getEntry(id).tags).to.deep.equal({ purpose: 'test' });
     });
 
     it('generated key can sign and verify', () => {

--- a/packages/keypair/src/pair.ts
+++ b/packages/keypair/src/pair.ts
@@ -82,8 +82,16 @@ export class SchnorrKeyPair implements KeyPair {
   }
 
   /**
-   * Get the Secp256k1SecretKey.
-   * @returns {Secp256k1SecretKey} The Secp256k1SecretKey object
+   * Get a copy of the Secp256k1SecretKey.
+   *
+   * Copy/custody contract: each read constructs a fresh Secp256k1SecretKey, so
+   * a caller cannot destroy() or otherwise affect the keypair's stored secret
+   * through the getter; the returned instance is caller-owned. Note the wrapper
+   * eagerly encodes the secret into an immutable multibase string, which cannot
+   * be wiped. Call sites that only need the raw bytes should use
+   * {@link secretKeyBytes} instead: it avoids constructing the wrapper object
+   * and its eager multibase encoding.
+   * @returns {Secp256k1SecretKey} A copy of the Secp256k1SecretKey object
    * @throws {KeyPairError} If the secret key is not available
    */
   get secretKey(): Secp256k1SecretKey {
@@ -98,6 +106,21 @@ export class SchnorrKeyPair implements KeyPair {
     // Return a copy of the secret key so a caller cannot destroy() or otherwise
     // affect the keypair's stored secret through the getter.
     return new Secp256k1SecretKey(this.#secretKey.bytes);
+  }
+
+  /**
+   * Get a copy of the secret key bytes without constructing a
+   * {@link Secp256k1SecretKey} wrapper (no eager multibase encoding, no extra
+   * object). Prefer this over `secretKey.bytes` at call sites that only need
+   * the bytes.
+   *
+   * Custody: the caller owns the returned copy and should wipe it (see `wipe`
+   * in `./utils.js`) as soon as the operation that needed it completes.
+   * @returns {KeyBytes | undefined} A copy of the secret key bytes, or undefined when no secret key is present.
+   */
+  get secretKeyBytes(): KeyBytes | undefined {
+    // The Secp256k1SecretKey bytes getter already returns a fresh copy
+    return this.#secretKey?.bytes;
   }
 
   /**

--- a/packages/keypair/tests/pair.spec.ts
+++ b/packages/keypair/tests/pair.spec.ts
@@ -148,6 +148,25 @@ describe('SchnorrKeyPair instantiated', () => {
     });
   });
 
+  describe('secretKeyBytes accessor', () => {
+    it('should return the secret bytes for full key pairs', () => {
+      const kp = new SchnorrKeyPair({ secretKey: bytes.secretKey });
+      expect(kp.secretKeyBytes).to.deep.equal(bytes.secretKey);
+    });
+
+    it('should return a caller-owned copy (mutation does not affect the keypair)', () => {
+      const kp = new SchnorrKeyPair({ secretKey: bytes.secretKey });
+      const copy = kp.secretKeyBytes!;
+      copy.fill(0);
+      expect(kp.secretKeyBytes).to.deep.equal(bytes.secretKey);
+    });
+
+    it('should return undefined for public-key-only pairs (never throws)', () => {
+      const kp = new SchnorrKeyPair({ publicKey: bytes.publicKey });
+      expect(kp.secretKeyBytes).to.be.undefined;
+    });
+  });
+
   describe('public-key-only getters', () => {
     const kp = new SchnorrKeyPair({ publicKey: bytes.publicKey });
 

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -25,6 +25,7 @@ import {
   BIP340DataIntegrityProof,
   SchnorrMultikey
 } from '@did-btcr2/cryptosuite';
+import type { VerificationResult } from '@did-btcr2/cryptosuite';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
 import { DidBtcr2 } from '../did-btcr2.js';
 import { Appendix } from '../utils/appendix.js';
@@ -549,7 +550,7 @@ export class Resolver {
           );
         }
         // Apply the update to the currentDocument and set it in the response
-        response.didDocument = this.applyUpdate(response.didDocument, update);
+        response.didDocument = this.applyUpdate(response.didDocument, update, blocktime);
 
         // Resolution metadata reflects APPLIED updates only. A duplicate
         // re-announcement (handled above) must not clobber confirmations/updated
@@ -652,14 +653,18 @@ export class Resolver {
 
   /**
    * Implements subsection {@link https://dcdpr.github.io/did-btcr2/operations/resolve.html#apply-update | 7.2.f.3 Apply Update}.
-   * @param {DidDocument} currentDocument The current DID Document to apply the update to.
+   * @param {Btcr2DidDocument} currentDocument The current DID Document to apply the update to.
    * @param {SignedBTCR2Update} update The BTCR2 Signed Update to apply.
-   * @returns {DidDocument} The updated DID Document after applying the update.
+   * @param {Date} blocktime The anchoring block time; proof expiry is evaluated
+   *   against it (not the wall clock), so a proof that expired only after its
+   *   anchor block still verifies during historical replay.
+   * @returns {Btcr2DidDocument} The updated DID Document after applying the update.
    * @throws {ResolveError} If the update is invalid or cannot be applied.
    */
   private static applyUpdate(
     currentDocument: Btcr2DidDocument,
-    update: SignedBTCR2Update
+    update: SignedBTCR2Update,
+    blocktime: Date
   ): Btcr2DidDocument {
     // Get the capability id from the to update proof.
     const capabilityId = update.proof?.capability;
@@ -731,8 +736,23 @@ export class Resolver {
     // Construct a DataIntegrityProof with the cryptosuite
     const diProof = new BIP340DataIntegrityProof(cryptosuite);
 
-    // Call the verifyProof method
-    const verificationResult = diProof.verifyProof(canonicalUpdate, 'capabilityInvocation');
+    // Call the verifyProof method, evaluating proof expiry against the anchoring
+    // block time rather than the wall clock: a DID whose updates carry expiring
+    // proofs must remain resolvable after the proofs expire.
+    let verificationResult: VerificationResult;
+    try {
+      verificationResult = diProof.verifyProof(
+        canonicalUpdate, 'capabilityInvocation', undefined, undefined, undefined, { referenceTime: blocktime }
+      );
+    } catch (error) {
+      // A thrown proof error (expired proof, malformed expires/created, ...) must
+      // surface as a typed resolution error, not escape resolution raw.
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ResolveError(
+        `Invalid update: proof verification failed: ${message}`,
+        INVALID_DID_UPDATE, { update, proofError: message }
+      );
+    }
 
     // If the result is not verified, throw INVALID_DID_UPDATE error
     if (!verificationResult.verified) {

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -3,7 +3,8 @@ import { randomBytes } from 'crypto';
 import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, INVALID_DID_UPDATE, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
 import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
-import { LocalSigner, CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { LocalSigner, CompressedSecp256k1PublicKey, SchnorrKeyPair } from '@did-btcr2/keypair';
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
 import { BTCR2MerkleTree, hashToHex } from '@did-btcr2/smt';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -2144,5 +2145,74 @@ describe('Resolver confirmation gate fails closed', () => {
       expect(response.didDocument.assertionMethod, String(confirmations))
         .to.have.lengthOf(sourceDocument.assertionMethod!.length);
     }
+  });
+});
+
+describe('Resolver proof expiry evaluated against the anchor block time', () => {
+  const fixture = deterministicData[2]; // regtest k1 DID
+
+  /**
+   * Sign an update exactly as Updater.sign does, but with extra proof options
+   * (here: expires) merged into the Data Integrity config.
+   */
+  function signWithProofOptions(
+    did: string,
+    sourceDocument: DidDocument,
+    secretKey: string,
+    extraProofOptions: Record<string, unknown>
+  ): SignedBTCR2Update {
+    const vm = sourceDocument.verificationMethod![0]!;
+    const unsigned = Updater.construct(sourceDocument, benignPatch(did), 1);
+    const keyPair = new SchnorrKeyPair({ secretKey: hexToBytes(secretKey) });
+    const hashIdx = vm.id.indexOf('#');
+    const multikey = new SchnorrMultikey({ id: vm.id.slice(hashIdx), controller: vm.controller, keyPair });
+    const config = {
+      '@context' : [
+        'https://w3id.org/security/v2',
+        'https://w3id.org/zcap/v1',
+        'https://w3id.org/json-ld-patch/v1',
+        'https://btcr2.dev/context/v1'
+      ],
+      cryptosuite        : 'bip340-jcs-2025',
+      type               : 'DataIntegrityProof' as const,
+      verificationMethod : vm.id,
+      proofPurpose       : 'capabilityInvocation',
+      capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+      capabilityAction   : 'Write',
+      ...extraProofOptions,
+    };
+    return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+  }
+
+  it('resolves an update whose proof expired after its anchor block (historical replay)', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    // expires is in the past relative to the wall clock, but after the anchor
+    // block time delivered by driveSingleBeacon (1700000000 = 2023-11-14T22:13:20Z).
+    const update = signWithProofOptions(fixture.did, sourceDocument, fixture.secretKey, {
+      expires : '2024-01-01T00:00:00Z'
+    });
+
+    const resolved = driveSingleBeacon(fixture.did, [update]);
+    expect(resolved.metadata.versionId).to.equal('2');
+    expect(resolved.didDocument.assertionMethod).to.have.lengthOf(sourceDocument.assertionMethod!.length + 1);
+  });
+
+  it('rejects an update whose proof expired before its anchor block with a typed error', () => {
+    const sourceDocument = resolveDeterministic(fixture.did);
+    // expires before the anchor block time (1700000000 = 2023-11-14): the proof
+    // was already invalid when the update was anchored.
+    const update = signWithProofOptions(fixture.did, sourceDocument, fixture.secretKey, {
+      expires : '2023-01-01T00:00:00Z'
+    });
+
+    let thrown: any;
+    try {
+      driveSingleBeacon(fixture.did, [update]);
+    } catch(error) {
+      thrown = error;
+    }
+    expect(thrown, 'expected a typed error').to.exist;
+    expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+    expect(thrown.message).to.match(/expired/);
   });
 });


### PR DESCRIPTION
* fix(cryptosuite): shared proof temporal checks against a reference time; empty domains rejected; deep-cloned proof boundaries; non-throwing public-only signer probe; PublicMultikeyObject for toJSON
* fix(keypair): bytes-level secret accessor; custody documented
* fix(key-manager): caller tags cloned on import and generate
* fix(method): proof expiry checked against anchor block time; proof errors as INVALID_DID_UPDATE
* fix(api): typed UpdateError on updateDid; array expectedDomain