### PR TITLE
prepare release changesets and close doc and test gaps

### DIFF
--- a/.changeset/aggregation-wire-v2.md
+++ b/.changeset/aggregation-wire-v2.md
@@ -1,0 +1,23 @@
+---
+'@did-btcr2/aggregation': minor
+---
+
+Authenticate the aggregation wire protocol, bind participant signatures to cohort state, and bound service resources.
+
+BREAKING:
+
+- The aggregation wire version is bumped to 2: signed Nostr envelopes are mandatory (unsigned events are dropped) and `ValidationAckBody.signalBytesHex` is required, so mixed-version peers fail loudly on a version mismatch instead of silently dropping each other's messages.
+- Participants refuse to sign a beacon transaction unless input 0 spends the funded outpoint declared on the authorization request, the transaction has exactly one input (the beacon spend), the OP_RETURN signal recomputes from the cohort's validated update set, change returns to the beacon address, and the fee stays within the configured ceiling.
+- `buildRecoverySpend` zeroizes the caller's recovery-secret buffer once the key has been consumed (on the signing path and on the key-mismatch throw). Parameter-validation throws still leave the buffer intact for a corrected retry; callers that need the key beyond one call must pass a copy.
+
+Added:
+
+- MuSig2 intake validation: nonce points are point-checked and partial signatures length-checked, and an invalid partial signature triggers a bounded blame-and-retry with the offender evicted rather than failing the whole cohort.
+- Service resource bounds: a default participant ceiling, opt-in pruning, a fail-closed nonce cache (a full cache rejects new admissions instead of evicting live in-window entries), and DID-keyed rate limiting ahead of nonce admission.
+- Transport hardening: fail-closed event parsing with sentinel validation, sender authentication on cohort-driving handlers, stale-replay rejection, a clamped clock-skew window, and rebinding or dropping HTTP client messages whose inner sender mismatches the authenticated sender.
+- The transport factory accepts and forwards `resolveSenderPk` and `clockSkewSec` for Nostr transports, so factory-built peers can receive a first advert from an unregistered sender.
+
+Fixed:
+
+- Cohort-kill vectors: malformed opt-in keys, non-string proof fields, and wrong-length partial signatures are recorded as per-message rejections instead of escaping as untyped throws that fail the cohort.
+- Validation acknowledgments are bound to the distributed signal hash, and fallback authorization requests are bound to the in-flight session.

--- a/.changeset/api-broadcast-confirm.md
+++ b/.changeset/api-broadcast-confirm.md
@@ -1,0 +1,16 @@
+---
+'@did-btcr2/api': minor
+---
+
+Exact-fee broadcast confirmation, typed update failures, and CAS integrity checks.
+
+BREAKING:
+
+- The update flow (which also carries deactivation) accepts a `confirmBroadcast` callback that is invoked with the exact fee and vsize of the built beacon transaction before anything is signed or broadcast; declining leaves the beacon UTXO unspent. Beacon broadcast is split into `prepareBroadcast`/`broadcast` underneath.
+- Updating a deactivated DID is rejected with a typed `UpdateError` (`INVALID_DID_UPDATE`) before any signing or broadcasting, instead of burning the beacon UTXO on an update resolvers will reject.
+- Resolution failures and missing or non-numeric `versionId` metadata on the update path now throw typed `UpdateError`s instead of generic `Error`s.
+
+Added:
+
+- `expectedDomain` accepts a string or an array of strings on proof verification (AND semantics across multiple domains), matching the cryptosuite.
+- CAS responses are size-capped (`CasConfig.maxResponseBytes`, default 1 MiB) and the retrieved bytes are verified against the requested content hash before parsing; an integrity failure throws `CAS_INTEGRITY_ERROR`.

--- a/.changeset/bitcoin-response-validation.md
+++ b/.changeset/bitcoin-response-validation.md
@@ -1,0 +1,23 @@
+---
+'@did-btcr2/bitcoin': minor
+---
+
+Validate everything a Bitcoin endpoint returns, cap response sizes, and keep credentials out of logs and argv-visible surfaces.
+
+BREAKING:
+
+- `JsonRpcProtocol.parseBatchResponse` now requires the request IDs captured on the `BatchHttpRequest` at build time (new required third parameter). Batch results are matched to calls by those IDs, so interleaved `buildRequest`/`buildBatchRequest` calls between build and parse can no longer shift the ID mapping.
+- REST and RPC responses are structurally validated on the read path: malformed transactions, blocks, UTXOs, address info, tip heights, and broadcast results throw typed `BitcoinRestError`/`BitcoinRpcError` instead of propagating as corrupt data.
+- `BitcoinBlock.get` never resolves to `undefined`: it resolves with validated block data or throws (`BitcoinRestError`).
+- `Vin.prevout` is typed to the real Esplora shape (a `Vout` with `scriptpubkey*` fields), replacing the incorrect `TxInPrevout` type.
+- RPC result validation is verbosity-aware: `getblock` and `getrawtransaction` results are checked against the verbosity of the request, so a response that does not match what was asked for is rejected up front.
+
+Added:
+
+- Response body size caps on the REST and RPC clients (`maxResponseBytes`, default 32 MiB); over-limit or unparsable bodies throw typed errors, and HTTP error bodies are capped before being embedded in thrown error messages.
+- A startup warning when configured credentials (basic auth, URL userinfo, or an Authorization header) would be sent over cleartext HTTP to a non-loopback host, and userinfo redaction for URLs appearing in logs and error messages.
+
+Fixed:
+
+- `btcToSats` rejects non-finite and out-of-range BTC values instead of silently corrupting them through exponential notation.
+- The Esplora tip-height endpoint no longer accepts an empty or non-numeric body as height 0.

--- a/.changeset/cli-credential-hygiene.md
+++ b/.changeset/cli-credential-hygiene.md
@@ -1,0 +1,24 @@
+---
+'@did-btcr2/cli': minor
+---
+
+Credential hygiene, pre-broadcast confirmation, and a fee-rate ceiling.
+
+BREAKING:
+
+- The `--btc-rpc-pass` flag and `GlobalOptions.btcRpcPass` are removed: a password on argv is visible in `ps`, `/proc/<pid>/cmdline`, shell history, and CI logs. Supply the RPC password via the `BTCR2_BTC_RPC_PASS` environment variable, a file named by `BTCR2_BTC_RPC_PASS_FILE`, or a profile `btc.rpcPass` entry holding a literal value or an `env:<VAR>`/`file:<path>` secret reference.
+- `update` and `deactivate` require explicit confirmation before broadcasting: the built transaction's exact fee is displayed and must be confirmed interactively, or pre-confirmed with `-y`/`--yes`. Non-interactive invocations without `--yes` fail closed with `CONFIRMATION_REQUIRED_ERROR` (regtest is exempt).
+- The fee rate (`--fee-rate`, `BTCR2_FEE_RATE`, profile `btc.feeRate`) is capped at 1000 sat/vB with no override; higher values are rejected as fat-fingers.
+- `resolveSecretRef` throws on an `env:` reference naming an unset variable, so a mistyped variable name surfaces immediately instead of as a downstream RPC auth failure.
+
+Added:
+
+- `--min-conf <n>` flag on `resolve`: a discoverability shortcut for the `minConf` resolution option (default 6), useful on regtest/signet demos where waiting for 6 confirmations is impractical.
+- A uniform secret-file permission policy: the keystore, session file, `--passphrase-file`, `key import --secret-file`, and RPC-password files must have mode 0600, 0400, 0440, or 0640 (not enforceable on Windows).
+- `config set` warns when a plaintext RPC password is stored in the config file and nudges toward a secret reference.
+
+Fixed:
+
+- `config doctor`, `config effective`, and the profile/config readers redact embedded endpoint credentials and RPC passwords in output (opt-in `--show-secrets` reveals them deliberately).
+- Profile names and config paths that would reach the prototype chain are rejected.
+- The interactive confirmation prompt tolerates non-blocking TTY reads (EAGAIN) with a bounded idle wait, instead of aborting on an empty first read.

--- a/.changeset/common-json-patch-budget.md
+++ b/.changeset/common-json-patch-budget.md
@@ -1,0 +1,9 @@
+---
+'@did-btcr2/common': minor
+---
+
+Bound JSON Patch validation for untrusted patches.
+
+Added:
+
+- `JSONPatch.validateOperations` now enforces an application budget on patches carried by untrusted DID updates: at most 1024 operations (`MAX_PATCH_OPERATIONS`), pointer paths (and `from` pointers) at most 2048 characters (`MAX_PATCH_PATH_LENGTH`), per-operation values at most 256 KiB serialized (`MAX_PATCH_VALUE_BYTES`), and a 1 MiB aggregate budget per patch (`MAX_PATCH_TOTAL_BYTES`). Oversized or unserializable patches are rejected with a `JSON_PATCH_VALIDATION_ERROR` instead of forcing unbounded patch work.

--- a/.changeset/cryptosuite-proof-hardening.md
+++ b/.changeset/cryptosuite-proof-hardening.md
@@ -1,0 +1,23 @@
+---
+'@did-btcr2/cryptosuite': major
+---
+
+Harden proof creation, verification, and multikey serialization against tampering and temporal misuse.
+
+BREAKING:
+
+- `addProof` no longer mutates its input: it returns a fresh secured document built from a deep copy, and the proof configuration is deep-cloned at proof boundaries, so post-hoc mutation of the caller's document or config cannot alter the secured document (and vice versa).
+- `verifyProof` now enforces temporal validity at the shared verification chokepoint: a malformed or elapsed `proof.expires`, or a `proof.created` too far ahead of the reference time, throws a `PROOF_VERIFICATION_ERROR`. Verification of historically anchored proofs should pass the anchoring block time via the new `referenceTime` option, since evaluation defaults to the wall clock.
+- An empty `expectedDomain` array now throws instead of passing the domain check vacuously.
+
+Added:
+
+- `ProofVerificationOptions` with an optional `referenceTime` against which `proof.expires` and `proof.created` are evaluated (with a five-minute clock-skew tolerance on `created`).
+- `expectedDomain` accepts a single string or an array of strings; multiple domains use AND semantics (every expected domain must be present in the proof's domain list).
+- `PublicMultikeyObject`: the public-only serialization shape returned by `SchnorrMultikey.toJSON()` (and `JSON.stringify`). The secret-bearing shape remains available as `MultikeyObject` via the explicit `exportJSON()`.
+
+Fixed:
+
+- Domain matching in `verifyProof` was inverted: a proof whose domain list contained every expected domain was rejected. Every expected domain must now be present in the proof's domain list.
+- `SchnorrMultikey.toJSON()` serializes public material only, so logging or returning a stringified multikey can no longer leak the secret key.
+- Transient secret bytes pulled from the keypair for signing are wiped after use.

--- a/.changeset/key-manager-defensive-copies.md
+++ b/.changeset/key-manager-defensive-copies.md
@@ -1,0 +1,10 @@
+---
+'@did-btcr2/key-manager': patch
+---
+
+Defensive copies on the key store boundary.
+
+Fixed:
+
+- Caller-supplied tags are cloned on key import and generation, and `getPublicKey`/`getEntry` return copies of the stored bytes and tags, so store state can no longer be mutated through returned references.
+- Secret material is read at the bytes level when storing a key, avoiding the `Secp256k1SecretKey` wrapper's eager (unwipeable) multibase encoding per read.

--- a/.changeset/keypair-secret-custody.md
+++ b/.changeset/keypair-secret-custody.md
@@ -1,0 +1,19 @@
+---
+'@did-btcr2/keypair': minor
+---
+
+Tighten secret-key custody and pin the ECDSA signing contract.
+
+BREAKING:
+
+- `Secp256k1SecretKey.decode()` returns the 32-byte secret key with the multicodec prefix validated and stripped; it previously returned the 34-byte prefix-plus-key value.
+- The `ecdsa` signing scheme is pinned to DER-encoded, low-S signatures over a caller-supplied 32-byte sighash (`prehash: false`), on both `Secp256k1SecretKey.sign`/`CompressedSecp256k1PublicKey.verify` and `signWithScheme`. Callers passing arbitrary-length messages must pre-hash.
+
+Added:
+
+- `SchnorrKeyPair.secretKeyBytes`: a copy of the raw 32-byte secret without constructing the `Secp256k1SecretKey` wrapper (whose eager multibase encoding cannot be wiped). The caller owns the returned copy and should `wipe` it when done.
+
+Fixed:
+
+- `SchnorrKeyPair.secretKey` returns a fresh copy per read, so a caller can no longer `destroy()` or otherwise affect the keypair's stored secret through the getter.
+- Transient secret material (per-sign key copies, BIP341 tweaked keys) is wiped on all exit paths.

--- a/.changeset/method-resolution-hardening.md
+++ b/.changeset/method-resolution-hardening.md
@@ -1,0 +1,24 @@
+---
+'@did-btcr2/method': minor
+---
+
+Fail-closed resolution intake, exact-fee broadcast control, and stricter update validation.
+
+BREAKING:
+
+- The resolver returns plain-JSON documents (class prototypes stripped), so `instanceof DidDocument`/`Btcr2DidDocument` checks on resolved documents no longer hold; document handling is symmetric with any plain-JSON resolver implementation.
+- `BeaconUtils.getBeaconServicesMap` keys entries by the parsed Bitcoin address and stores the original service objects (previously re-parsed copies keyed by the raw endpoint string), so identity-based collections keyed by the service object keep working.
+- Beacon broadcast is split in two: `prepareBroadcast` builds the unsigned signal transaction and reports its exact fee and vsize, and the returned `PreparedBroadcast.broadcast()` signs and broadcasts it. `broadcastSignal` remains as the composed convenience call.
+- Identifiers carrying a custom-network nibble (network values 12-14) are rejected at decode time instead of decoding to an unusable numeric network.
+- Resolution terminates when the requested `versionId` is reached; versions after the target are no longer discovered or applied, and the target version's metadata is preserved.
+- Update proof expiry during resolution is evaluated against the anchoring block time, not the wall clock, so a proof that expired only after its anchor still verifies on replay.
+
+Added:
+
+- `ResolutionOptions.minConf` (default 6, per the spec): beacon signals with fewer confirmations, or with missing, fractional, or otherwise invalid block metadata, are ignored. Confirmation and metadata checks now fail closed at intake.
+- Update validation enforces `capabilityInvocation` authorization (a key listed only under `verificationMethod` cannot authorize an update), DID id binding, `versionId` ordering, beacon rotation rules, and duplicate-metadata rejection.
+
+Fixed:
+
+- Beacon signal discovery validates the OP_RETURN payload by script hex (accepting both the Esplora and Bitcoin Core ASM dialects) and, on the full-node path, requires the signal transaction to spend from the beacon address, rejecting indexer phantom signals.
+- Malformed resolver inputs (bad base64url hashes, malformed `capabilityId` percent-escapes, invalid signal metadata) surface as typed errors instead of raw decode throws; a `capabilityId` component-count check that could never fire now works.

--- a/.changeset/smt-zero-hash-tree.md
+++ b/.changeset/smt-zero-hash-tree.md
@@ -1,0 +1,13 @@
+---
+'@did-btcr2/smt': minor
+---
+
+Build the zero-hash tree once and serve proofs by trie walk.
+
+Added:
+
+- `ZeroHashTree`: a persistent compressed-trie zero-hash SMT. `ZeroHashTree.fromLeaves(leaves)` builds and hashes every subtree once; `.root` exposes the Merkle root and `.proof(index)` serves inclusion or non-inclusion proofs for any 256-bit index by a single trie walk with memoized subtree hashes. `BTCR2MerkleTree` now holds a `ZeroHashTree` across proofs instead of recomputing the sibling set of every level per proof (previously O(256^2 * n) bit operations per proof), so generating proofs for every member of a large cohort is no longer quadratic in the tree depth per proof. The one-shot `zeroHashRoot` and `generateZeroHashProof` wrappers are unchanged in behavior and delegate to `ZeroHashTree`.
+
+Fixed:
+
+- Building a tree with a duplicate leaf index throws a `RangeError` at construction instead of silently collapsing the duplicates into one leaf.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,21 @@
 name: CI
 
 on:
-  # Vets external pull requests too (audit N2): pull_request runs with a
-  # read-only token on forked repos, and same-repo PRs simply get both a push
-  # and a pull_request run.
+  # Vets external pull requests too: pull_request runs with a read-only token
+  # on forked repos. Same-repo PRs would otherwise double-run (once for push,
+  # once for pull_request); the concurrency group below dedupes the two runs
+  # of the same head commit.
   - push
   - pull_request
 
-# No token permissions by default; jobs opt in to exactly what they need
-# (audit N2).
+# Keyed on the head commit: for a pull_request run that is the PR head SHA,
+# for a push run the pushed SHA, so the push and pull_request runs of the
+# same commit cancel each other instead of running twice.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+# No token permissions by default; jobs opt in to exactly what they need.
 permissions: {}
 
 jobs:
@@ -16,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     # The test job executes dependency code (install scripts, build, tests),
-    # so it must not hold a write token (audit N2). All actions are pinned to
-    # full commit SHAs, not mutable major tags (audit N1).
+    # so it must not hold a write token. All actions are pinned to full
+    # commit SHAs, not mutable major tags.
     permissions:
       contents: read
 
@@ -75,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # contents: write is needed to force-push the ci-badges branch (ADR 084);
-    # it is scoped to this job only, which runs no dependency code (audit N2).
+    # it is scoped to this job only, which runs no dependency code.
     permissions:
       contents: write
 

--- a/packages/cli/docs/DEMO.md
+++ b/packages/cli/docs/DEMO.md
@@ -269,6 +269,9 @@ btcr2 create --signing-key demo -n signet      # did:btcr2:k1qyp... (signet)
 btcr2 create --signing-key demo -n mutinynet   # did:btcr2:k1q5p... (mutinynet)
 ```
 
+(On Path B the mainnet line is refused: a dev keystore never touches `bitcoin`. Run it on
+Path A, or skip it.)
+
 **Machine-readable output** for scripting and integration. Because this uses a stored
 key, the envelope also echoes the `keyId` and `publicKey` it resolved:
 
@@ -421,6 +424,24 @@ btcr2 -o json --signing-key demo update \
   | jq '.data.signedUpdate' > signed-update.json
 ```
 
+Before anything is signed or broadcast, `update` builds the beacon transaction and asks you
+to confirm the spend, printing the exact fee the built transaction pays:
+
+```
+About to broadcast an on-chain update:
+  DID:      did:btcr2:k1q5p...
+  Network:  mutinynet
+  Beacon:   did:btcr2:k1q5p...#initialP2WPKH
+  Fee:      565 sats (0.00000565 BTC) at 5 sat/vB for a 113 vB transaction (exact fee of the built transaction)
+Type "yes" to broadcast:
+```
+
+Type `yes` to proceed; anything else aborts with the beacon UTXO still unspent. For a
+scripted (non-interactive) run, pass `-y`/`--yes` to pre-confirm: without a terminal and
+without `--yes` the command fails closed with `CONFIRMATION_REQUIRED_ERROR`. (The prompt is
+skipped entirely on regtest.) `deactivate` has the same gate, with an extra permanence
+warning.
+
 `update` signs the change, spends the funded beacon UTXO, and broadcasts a Bitcoin
 transaction whose `OP_RETURN` carries the update hash. The command's `.data` is an
 enriched result (`.data.txid` is the broadcast transaction id, handy for watching the
@@ -428,8 +449,9 @@ signal confirm); `.data.signedUpdate` is the off-chain half you keep, so we extr
 that into `signed-update.json`. In text mode `update` also prints a `Watch:` explorer link
 for the txid to stderr, so you can click straight through to the transaction.
 
-The broadcast itself is tunable: `--fee-rate <sat/vB>` (default 5) raises the fee under
-congestion, and `--change-address` routes the transaction's change somewhere other than the
+The broadcast itself is tunable: `--fee-rate <sat/vB>` (default 5, maximum 1000) raises the
+fee under congestion, and `--change-address` routes the transaction's change somewhere other
+than the
 beacon, so a DID's successive announcements are not linkable on-chain. Where the update
 artifacts go is a policy, too: `--publish-to-cas` defaults to `never` (sidecar-only, the
 privacy default this demo shows); the appendix covers the opt-in publication path.
@@ -445,17 +467,28 @@ privacy default this demo shows); the appendix covers the opt-in publication pat
 Give the update transaction about 1 block (30-60 seconds) to confirm on Mutinynet. You
 can watch it with the `txid` from Step B at `https://mutinynet.com/tx/<txid>`.
 
+> **`minConf`: how confirmed is confirmed enough?** The resolver only applies an update
+> whose beacon signal has at least `minConf` confirmations, and the default is **6**
+> (the same finality the did:btcr2 specification recommends on public networks). On a
+> demo network with 30-second blocks that is a 3-minute wait, so the walkthrough passes
+> `--min-conf 1` to resolve below. Without it, resolving after a single confirmation
+> **silently returns the previous document version**: the too-fresh signal is ignored,
+> which looks exactly like "the update did nothing". On mainnet, leave the default alone.
+
 ### Step D - resolve v2 (the reveal)
 
 Because a Singleton-beacon update lives off-chain, you resolve it by handing the signed
 update back as **sidecar** data:
 
 ```bash
-btcr2 resolve -i "$DID" -r "$(jq -c '{sidecar:{updates:[.]}}' signed-update.json)"
+btcr2 resolve -i "$DID" --min-conf 1 \
+  -r "$(jq -c '{sidecar:{updates:[.]}}' signed-update.json)"
 ```
 
-(For a bulky sidecar, write the resolution options to a JSON file and pass
-`-p options.json` instead of the inline `-r` string. Same shape, read from disk.)
+(`--min-conf 1` is a shortcut for the `minConf` resolution option; the equivalent generic
+form is `-r '{"minConf":1, "sidecar":...}'`. For a bulky sidecar, write the resolution
+options to a JSON file and pass `-p options.json` instead of the inline `-r` string. Same
+shape, read from disk.)
 
 Expected: the same document, now with your patch applied and `versionId: "2"`:
 
@@ -477,9 +510,13 @@ holds the commitment (a 32-byte hash), but the document change is not on-chain, 
 resolution cannot reconstruct v2:
 
 ```bash
-btcr2 resolve -i "$DID" --cas-timeout 1000
+btcr2 resolve -i "$DID" --min-conf 1 --cas-timeout 1000
 # Signed update not found in CAS (hash: ...).
 ```
+
+(The `--min-conf 1` is needed here for the same reason as in Step D: with the default of 6
+the too-fresh signal is ignored and resolution quietly returns v1 instead of reaching the
+CAS lookup that fails.)
 
 The resolver, finding an on-chain update hash but no sidecar, checks the default public
 IPFS gateway (where your never-published update was never put) and then fails. The
@@ -639,8 +676,10 @@ control:
 
 ```bash
 btcr2 resolve -i "$DID" --btc-rest https://esplora.internal/api      # your own Esplora
+export BTCR2_BTC_RPC_PASS='demo'                    # no argv flag: a password on the
+                                                    # command line is visible in ps
 btcr2 --btc-rpc-url http://127.0.0.1:38332 \
-      --btc-rpc-user demo --btc-rpc-pass demo \
+      --btc-rpc-user demo \
       --btc-rpc-wallet btcr2 \
       update ...                                                     # your own Bitcoin Core
 ```
@@ -701,6 +740,9 @@ rm -rf /tmp/btcr2-demo
 |---|---|
 | `... is unfunded. Send BTC ...` | Fund the beacon address from the faucet, then retry. |
 | `No spendable UTXO ... unconfirmed` | The faucet payment has not confirmed yet. Wait one block. |
+| `resolve` returns the old version after an update confirmed | The signal has fewer than `minConf` confirmations (default 6). Wait for more blocks, or pass `--min-conf 1` on demo networks. |
+| `CONFIRMATION_REQUIRED_ERROR` on `update`/`deactivate` | On-chain spends need an explicit confirmation. Run in a terminal and answer `yes`, or pass `--yes` for scripted runs. |
+| `Broadcast aborted: not confirmed.` | The confirmation prompt was answered with something other than `yes`. Nothing was signed or broadcast; re-run and confirm. |
 | Faucet returns a rate-limit or captcha error | A shared room IP is being throttled. Stagger requests, or use a pre-funded beacon (see Step A). |
 | `Signed update not found in CAS` | You resolved a DID that has an on-chain update without providing the sidecar. Pass it back with `-r '{"sidecar":{"updates":[...]}}'` (that is the privacy feature, not a bug). |
 | `resolve` hangs | Check reachability to `https://mutinynet.com/api` (`btcr2 config doctor -n mutinynet`); override with `--btc-rest <url>` if needed. |
@@ -716,9 +758,9 @@ btcr2 keystore init [--dev] [--force] | status | change-passphrase | unlock [--t
 btcr2 key generate --name <n> --set-active
 btcr2 key list|ls | show <ref> | use <ref> | import [--secret-file <path> | --public <hex>] | export [--secret --out <path>] <ref> | delete|rm [--force] <ref>
 btcr2 create [-t k|x] [-n <network>] [-b <hex>] [--signing-key <ref>]
-btcr2 resolve|read -i <did> [-r <json>] [-p <path>]
-btcr2 update -s <doc-json> --source-version-id <n> -p <patches-json> -m <vm-id> -b <beacon-id-json> [--publish-to-cas <mode>] [--fee-rate <n>] [--change-address <addr>]
-btcr2 deactivate|delete -s <doc-json> --source-version-id <n> -m <vm-id> -b <beacon-id-json> [--publish-to-cas <mode>] [--fee-rate <n>] [--change-address <addr>]
+btcr2 resolve|read -i <did> [-r <json>] [-p <path>] [--min-conf <n>]
+btcr2 update -s <doc-json> --source-version-id <n> -p <patches-json> -m <vm-id> -b <beacon-id-json> [--publish-to-cas <mode>] [--fee-rate <n>] [--change-address <addr>] [--yes]
+btcr2 deactivate|delete -s <doc-json> --source-version-id <n> -m <vm-id> -b <beacon-id-json> [--publish-to-cas <mode>] [--fee-rate <n>] [--change-address <addr>] [--yes]
 btcr2 config init | get [path] | set <path> <value> | unset <path> | list|ls | validate | effective | path | doctor
 btcr2 profile add <name> | use <name> | show [name] | remove|rm <name>
 btcr2 completion [bash|zsh|fish]
@@ -726,10 +768,14 @@ btcr2 completion [bash|zsh|fish]
 ```
 Global flags: -o json|text  --verbose  --quiet  --home <dir>  -c <config>  --profile <name>
               --keystore <path>  --passphrase-file <path>  --signing-key <ref>
-              --btc-rest <url>  --btc-rpc-url <url>  --btc-rpc-user <u>  --btc-rpc-pass <p>
+              --btc-rest <url>  --btc-rpc-url <url>  --btc-rpc-user <u>
               --btc-rpc-wallet <name>  --btc-rest-header <h>  --btc-rpc-header <h>
               --cas-gateway <url>  --cas-rpc-url <url>  --btc-timeout <ms>  --cas-timeout <ms>
 ```
+
+The Bitcoin Core RPC password has no flag (a password on argv is visible in `ps`); supply it
+via `BTCR2_BTC_RPC_PASS`, `BTCR2_BTC_RPC_PASS_FILE`, or a profile `btc.rpcPass` entry (which
+accepts an `env:<VAR>` / `file:<path>` secret reference).
 
 See `btcr2 --help` (or the README's Global flags and Environment variables tables) for the
 complete surface.

--- a/packages/cli/docs/README.md
+++ b/packages/cli/docs/README.md
@@ -37,8 +37,7 @@ command; each command doc lists which globals it actually consumes. The table be
 | `--profile <name>` | profile name | config `defaults.profile`, else the profile named after the operation's network | Selects the active config profile (see [profile.md](./profile.md)). |
 | `--btc-rest <url>` | URL | per-network SDK default (mempool.space-style endpoints; tabulated in [resolve.md](./resolve.md#environment--configuration)) | Override the Bitcoin REST (Esplora) endpoint. |
 | `--btc-rpc-url <url>` | URL | `http://localhost:18443` on regtest; none on other networks | Override the Bitcoin Core RPC endpoint. |
-| `--btc-rpc-user <user>` | string | none | Bitcoin Core RPC username. |
-| `--btc-rpc-pass <pass>` | string, or a secret reference `env:<VAR>` / `file:<path>` | none | Bitcoin Core RPC password. RPC url, user, and pass resolve as one atomic unit per precedence layer (ADR 074). |
+| `--btc-rpc-user <user>` | string | none | Bitcoin Core RPC username. The RPC password has no flag (a password on argv is visible in `ps` and shell history); supply it via `BTCR2_BTC_RPC_PASS`, `BTCR2_BTC_RPC_PASS_FILE`, or the profile's `btc.rpcPass` (which accepts a literal value or an `env:<VAR>` / `file:<path>` secret reference). RPC url, user, and pass resolve as one atomic unit per precedence layer (ADR 074). |
 | `--cas-gateway <url>` | URL | `https://ipfs.io` | IPFS HTTP gateway for CAS reads (read-only). |
 | `--cas-rpc-url <url>` | URL | none | IPFS HTTP RPC endpoint for a writable CAS (reads + writes). Configuring one is what makes `--publish-to-cas auto`/`always` on `update`/`deactivate` meaningful. |
 | `--btc-timeout <ms>` | finite number >= 1 | unset (unbounded) | Bitcoin REST/RPC request timeout in milliseconds. |
@@ -76,7 +75,7 @@ Every `BTCR2_*` variable the CLI consults, from `src/config.ts`, `src/paths.ts`,
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` (also accepts `env:<VAR>` / `file:<path>` secret references) |
+| `BTCR2_BTC_RPC_PASS` | RPC password (no flag equivalent). The value may itself be an `env:<VAR>` / `file:<path>` secret reference. |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file whose contents are the RPC password. No flag equivalent; the final fallback when no layer supplies a password, read lazily only when an RPC config is actually built. |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |

--- a/packages/cli/docs/config.md
+++ b/packages/cli/docs/config.md
@@ -278,7 +278,7 @@ Environment variables consulted:
 | `BTCR2_BTC_REST` | `effective`, `doctor` | Bitcoin REST endpoint override (as `--btc-rest`). |
 | `BTCR2_BTC_RPC_URL` | `effective`, `doctor` | Bitcoin Core RPC endpoint override (as `--btc-rpc-url`). |
 | `BTCR2_BTC_RPC_USER` | `effective`, `doctor` | RPC username (as `--btc-rpc-user`). |
-| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (as `--btc-rpc-pass`; accepts `env:<VAR>` / `file:<path>` secret references). Ignored (with a stderr warning) when a flag or profile layer supplies the RPC url or user, because credentials resolve as one atomic unit per layer. |
+| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (no flag equivalent; the value may itself be an `env:<VAR>` / `file:<path>` secret reference). Ignored (with a stderr warning) when a flag or profile layer supplies the RPC url or user, because credentials resolve as one atomic unit per layer. |
 | `BTCR2_BTC_RPC_PASS_FILE` | `effective`, `doctor` | Path to a file whose contents are the RPC password; consulted only when no layer supplies a password and an RPC config is being built. Subject to the secret-file permission policy (0600/0400/0440/0640). |
 | `BTCR2_CAS_GATEWAY` | `effective`, `doctor` | IPFS HTTP gateway for CAS reads (as `--cas-gateway`). |
 | `BTCR2_CAS_RPC_URL` | `effective`, `doctor` | IPFS HTTP RPC endpoint for a writable CAS (as `--cas-rpc-url`). |
@@ -331,7 +331,7 @@ the active profile for `effective`, `doctor`, and the keystore path in `config p
 `--keystore` overrides the keystore path `config path` reports; `-o/--output` switches text/json;
 `--quiet` suppresses the unknown-path warning from `config set`; `--verbose` prints full error
 objects; and the connection override flags (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`,
-`--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
+`--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
 `--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`) feed the `flag` layer of `effective` and
 `doctor`.
 

--- a/packages/cli/docs/deactivate.md
+++ b/packages/cli/docs/deactivate.md
@@ -89,7 +89,7 @@ built-in default. Exceptions are called out below.
 | `BTCR2_BTC_REST` | Bitcoin REST (Esplora) endpoint | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | Bitcoin Core RPC endpoint | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | Bitcoin Core RPC username | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | Bitcoin Core RPC password (supports `env:<VAR>` / `file:<path>` refs) | `--btc-rpc-pass` |
+| `BTCR2_BTC_RPC_PASS` | Bitcoin Core RPC password (the value may be an `env:<VAR>` / `file:<path>` secret reference) | none (no flag: a password on argv is visible in `ps` and shell history) |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file holding the RPC password (fallback when no layer supplies one) | none |
 | `BTCR2_BTC_TIMEOUT` | Bitcoin REST/RPC timeout in ms (>= 1) | `--btc-timeout` |
 | `BTCR2_CAS_GATEWAY` | Read-only IPFS gateway for CAS reads | `--cas-gateway` |
@@ -149,7 +149,7 @@ Dev (plaintext) keystores need no passphrase but are refused outright for mainne
 See the [docs README](./README.md#global-options) for the shared global flags. Globals this command notably interacts
 with: `--signing-key`, `--keystore`, `--passphrase-file`, `--home`, `-c/--config`, `--profile`,
 `-o/--output`, `--quiet`, `--verbose`, the Bitcoin connection overrides (`--btc-rest`,
-`--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`,
+`--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`, `--btc-rest-header`,
 `--btc-rpc-header`, `--btc-timeout`), and the CAS overrides (`--cas-gateway`, `--cas-rpc-url`,
 `--cas-timeout`; a writable `--cas-rpc-url` is what makes `--publish-to-cas auto|always`
 meaningful).

--- a/packages/cli/docs/quickstart.md
+++ b/packages/cli/docs/quickstart.md
@@ -204,7 +204,7 @@ written by a newer CLI (`schemaVersion` above 1) aborts the network-recording wr
 Shared global flags are documented in the [docs README](./README.md#global-options); `quickstart` notably
 interacts with `--home`, `-c/--config`, `--profile`, `--keystore`, `--passphrase-file`,
 `-o/--output`, `--quiet`, `--verbose`, and (through the doctor probe) the endpoint overrides
-(`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`,
+(`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`,
 `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`, `--cas-gateway`, `--cas-rpc-url`,
 `--cas-timeout`).
 

--- a/packages/cli/docs/resolve.md
+++ b/packages/cli/docs/resolve.md
@@ -32,6 +32,7 @@ There are no subcommands and no positional arguments; the identifier is passed w
 | `-i, --identifier <identifier>` | A `did:btcr2` identifier string: `did:btcr2:` followed by a Bech32m-encoded body whose HRP is `k` (deterministic, 33-byte compressed secp256k1 pubkey) or `x` (external, 32-byte genesis-document hash). The embedded network must decode to one of `bitcoin`, `testnet3`, `testnet4`, `signet`, `mutinynet`, `regtest`. | none (required) | The DID to resolve. Decoded and validated before any I/O: a malformed DID fails immediately (for example `Invalid did: <value>`), and a DID whose network nibble decodes to a custom numeric network (decode-only values `1`-`3`) is rejected with `Unsupported network "<network>" in DID.` (`INVALID_ARGUMENT_ERROR`). |
 | `-r, --resolution-options <json>` | An inline JSON string; see "Resolution options JSON" below for the accepted shape. | none | Resolution options passed straight through to the resolver. Non-JSON input fails with `Invalid resolution options. Must be a valid JSON string.` (`INVALID_ARGUMENT_ERROR`). When both `-r` and `-p` are given, `-r` wins and `-p` is silently ignored. |
 | `-p, --resolution-options-path <path>` | Path to a file containing the same JSON shape as `-r`. | none | File-based alternative to `-r`. An unreadable path or non-JSON file content fails with `Invalid resolution options path. Must be a valid path to a JSON file.` (`INVALID_ARGUMENT_ERROR`). |
+| `--min-conf <n>` | A non-negative integer. | `6` | Minimum confirmations a beacon signal's transaction must have before its update is applied. A discoverability shortcut for the `minConf` resolution option; when both are given, the flag overrides any `minConf` carried in `-r`/`-p`. A non-integer value fails with `Invalid --min-conf value. Must be a non-negative integer.` (`INVALID_ARGUMENT_ERROR`). Lower it (for example `--min-conf 1`) on regtest/signet demos where waiting for 6 confirmations is impractical; leave it at the default on public networks. |
 | `-h, --help` | none | n/a | Print usage for the command and exit. |
 
 Validation order (from source): the identifier is decoded first, then `-r` is parsed, then `-p`.
@@ -49,6 +50,7 @@ an empty object `{}` is equivalent to passing no options.
 | `versionId` | string | ASCII string of the specific DID document version to resolve (versions start at `"1"`). |
 | `versionTime` | string | XML datetime, UTC, no sub-second precision (for example `'2026-07-01T00:00:00Z'`). Resolves the most recent version valid before that time. |
 | `maxDiscoveryRounds` | number | Opt-in upper bound on multi-round beacon-discovery passes. Unset, omitted, or non-positive means unlimited (termination is guaranteed by de-duplicating queried beacon addresses); a positive value is a resource guard, and exceeding it surfaces as an `INTERNAL_ERROR`. |
+| `minConf` | number | Minimum confirmations a beacon signal's transaction must have before its update is applied. Default `6`. Signals with fewer confirmations (or with missing/invalid confirmation metadata) are ignored, so on a freshly confirmed update resolution still returns the earlier document version until the signal reaches `minConf`. The `--min-conf <n>` flag sets the same field. |
 | `sidecar` | object | Off-chain data bundle, see below. |
 
 `sidecar` fields:
@@ -117,7 +119,7 @@ Settings that feed this command:
 | Bitcoin REST endpoint | `--btc-rest <url>` | `BTCR2_BTC_REST` | `profiles.<name>.btc.rest` | per network, see below |
 | Bitcoin Core RPC URL | `--btc-rpc-url <url>` | `BTCR2_BTC_RPC_URL` | `profiles.<name>.btc.rpcUrl` | `http://localhost:18443` (regtest only); none elsewhere |
 | RPC username | `--btc-rpc-user <user>` | `BTCR2_BTC_RPC_USER` | `profiles.<name>.btc.rpcUser` | none |
-| RPC password | `--btc-rpc-pass <pass>` | `BTCR2_BTC_RPC_PASS` | `profiles.<name>.btc.rpcPass` | none |
+| RPC password | none (no flag: a password on argv is visible in `ps` and shell history) | `BTCR2_BTC_RPC_PASS` | `profiles.<name>.btc.rpcPass` (accepts a literal value or an `env:<VAR>` / `file:<path>` secret reference) | none |
 | RPC password file | none | `BTCR2_BTC_RPC_PASS_FILE` | none | none |
 | RPC wallet | `--btc-rpc-wallet <name>` | none | `profiles.<name>.btc.wallet` | none |
 | Extra REST headers | `--btc-rest-header <header>` (repeatable, `'Key: Value'`) | none | `profiles.<name>.btc.headers` | none |
@@ -174,7 +176,7 @@ Behavior details, all confirmed against the source:
 Shared global flags are documented in the [docs README](./README.md#global-options). `resolve` notably interacts
 with: `-o, --output` (text vs json envelope), `--verbose` (full structured error output for
 CLI-typed errors), the connection overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`,
-`--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
+`--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
 `--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`), and the state-location flags (`--home`,
 `-c, --config`, `--profile`). `--quiet`, `--keystore`, `--passphrase-file`, and `--signing-key`
 are accepted but have no effect on this command.
@@ -202,6 +204,9 @@ btcr2 resolve -i did:btcr2:x1qh... -p ./resolution-options.json
 
 # Cap multi-round beacon discovery as a resource guard
 btcr2 resolve -i did:btcr2:k1qq... -r '{"maxDiscoveryRounds":3}'
+
+# Accept a freshly confirmed signal on a regtest/signet demo (default is 6 confirmations)
+btcr2 resolve -i did:btcr2:k1qq... --min-conf 1
 
 # Override the Bitcoin REST endpoint and bound request time
 btcr2 --btc-rest 'https://mutinynet.com/api' --btc-timeout 15000 resolve -i did:btcr2:k1qq...

--- a/packages/cli/docs/update.md
+++ b/packages/cli/docs/update.md
@@ -89,7 +89,7 @@ Environment variables consulted by `update`:
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` (supports `env:<VAR>` and `file:<path>` secret refs) |
+| `BTCR2_BTC_RPC_PASS` | RPC password (no flag equivalent: a password on argv is visible in `ps` and shell history). The value may itself be an `env:<VAR>` or `file:<path>` secret reference. |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file holding the RPC password (fallback when no layer supplies one) |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` (a writable CAS; enables `--publish-to-cas auto|always`) |
@@ -148,7 +148,7 @@ A dev (plaintext) keystore needs no passphrase but is refused for mainnet operat
 See the [docs README](./README.md#global-options) for the shared global flags. Globals this command notably interacts
 with: `--signing-key`, `--keystore`, `--passphrase-file`, `--profile`, `--home`, `-c/--config`,
 `-o/--output`, `--quiet` (suppresses the stderr `Watch:` hint), `--verbose`, the Bitcoin endpoint
-overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`,
+overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`,
 `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`), and the CAS overrides (`--cas-gateway`,
 `--cas-rpc-url`, `--cas-timeout`, which gate `--publish-to-cas`).
 

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -18,10 +18,16 @@ export function registerResolveCommand(
     .requiredOption('-i, --identifier <identifier>', 'did:btcr2 identifier')
     .option('-r, --resolution-options <json>', 'JSON string containing resolution options')
     .option('-p, --resolution-options-path <path>', 'Path to a JSON file containing resolution options')
+    .option(
+      '--min-conf <n>',
+      'Minimum confirmations a beacon signal must have before its update is applied (default: 6). '
+        + 'Shortcut for the minConf resolution option; useful on regtest/signet demos.',
+    )
     .action(async (options: {
       identifier: string;
       resolutionOptions?: string;
       resolutionOptionsPath?: string;
+      minConf?: string;
     }) => {
       const parsed = await validateResolveOptions(options);
       const network = deriveNetwork(parsed.identifier);
@@ -36,6 +42,7 @@ async function validateResolveOptions(options: {
   identifier: string;
   resolutionOptions?: string;
   resolutionOptionsPath?: string;
+  minConf?: string;
 }): Promise<ResolveCommandOptions> {
   // Validate identifier format early
   Identifier.decode(options.identifier);
@@ -62,6 +69,19 @@ async function validateResolveOptions(options: {
         options
       );
     }
+  }
+
+  // The dedicated flag wins over a minConf carried in the -r/-p JSON: an
+  // explicit flag is the more deliberate signal.
+  if (options.minConf !== undefined) {
+    if (!/^\d+$/.test(options.minConf)) {
+      throw new CLIError(
+        'Invalid --min-conf value. Must be a non-negative integer.',
+        'INVALID_ARGUMENT_ERROR',
+        options
+      );
+    }
+    resolutionOptions = { ...resolutionOptions, minConf: Number(options.minConf) };
   }
   return { identifier: options.identifier, options: resolutionOptions };
 }

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -127,6 +127,42 @@ describe('DidBtcr2Cli', () => {
         resolve.parseAsync(['-i', validDid, '-p', '/no/file/here.json'], { from: 'user' })
       ).to.be.rejectedWith(CLIError);
     });
+
+    it('rejects a non-integer --min-conf value', async () => {
+      const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+      const cli = new DidBtcr2Cli(createTestApiFactory());
+      const resolve = getSubcommand(cli, 'resolve');
+      await expect(
+        resolve.parseAsync(['-i', validDid, '--min-conf', 'soon'], { from: 'user' })
+      ).to.be.rejectedWith(CLIError, /--min-conf/);
+    });
+
+    it('passes --min-conf through to resolution options', async () => {
+      const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+      let seenOptions: unknown;
+      const factory = (network?: any) => {
+        const api = createTestApiFactory()(network);
+        const original = api.resolveDid.bind(api);
+        api.resolveDid = async (id: string, options?: any) => {
+          seenOptions = options;
+          return original(id, options);
+        };
+        return api;
+      };
+      const cli = new DidBtcr2Cli(factory as any);
+      const messages: string[] = [];
+      console.log = (msg?: any) => { if (msg !== undefined) messages.push(String(msg)); };
+
+      // versionId "1" is terminal at the genesis document: resolution completes
+      // without beacon discovery, so no Bitcoin connection is required.
+      const resolve = getSubcommand(cli, 'resolve');
+      await resolve.parseAsync(
+        ['-i', validDid, '-r', '{"versionId":"1"}', '--min-conf', '1'],
+        { from: 'user' }
+      );
+      expect(seenOptions).to.deep.equal({ versionId: '1', minConf: 1 });
+      expect(messages.join('\n')).to.include(validDid);
+    });
   });
 
   describe('update', () => {

--- a/packages/method/tests/beacon.spec.ts
+++ b/packages/method/tests/beacon.spec.ts
@@ -5,6 +5,7 @@ import { bytesToHex, randomBytes } from '@noble/hashes/utils';
 import { expect } from 'chai';
 import { SinglePartyBeacon } from '../src/core/beacon/beacon.js';
 import { CASBeacon } from '../src/core/beacon/cas-beacon.js';
+import { CASBeaconError, SMTBeaconError } from '../src/core/beacon/error.js';
 import { BeaconFactory } from '../src/core/beacon/factory.js';
 import type { BeaconService, BeaconSignal, BlockMetadata } from '../src/core/beacon/interfaces.js';
 import { SingletonBeacon } from '../src/core/beacon/singleton-beacon.js';
@@ -154,6 +155,20 @@ describe('SinglePartyBeacon.processSignals', () => {
       expect(result.needs[0]!.kind).to.equal('NeedSignedUpdate');
       expect((result.needs[0] as { updateHash: string }).updateHash).to.equal(updateHashHex);
     });
+
+    it('throws a typed error when the announcement entry for the DID is malformed base64url', () => {
+      // The entry for our DID is not valid base64url: the raw decode throw must
+      // not escape resolution as-is.
+      const announcement: CASAnnouncement = { [DID]: 'not!valid!base64url!' };
+      const announcementHashHex = bytesToHex(hash(canonicalize(announcement)));
+
+      const sidecar = emptySidecar();
+      sidecar.casMap.set(announcementHashHex, announcement);
+
+      expect(() => beacon.processSignals([fakeSignal(announcementHashHex)], sidecar))
+        .to.throw(CASBeaconError, 'Malformed update hash in CAS announcement')
+        .with.property('type', 'INVALID_CAS_ANNOUNCEMENT');
+    });
   });
 
   describe('SMTBeacon', () => {
@@ -233,6 +248,26 @@ describe('SinglePartyBeacon.processSignals', () => {
       expect(() => beacon.processSignals([fakeSignal(rootHex)], sidecar)).to.throw(
         'SMT proof missing required nonce field.'
       );
+    });
+
+    it('throws a typed error when proof hash fields are malformed base64url', () => {
+      // The nonce (and updateId) fail base64url decoding: the raw decode throw
+      // must not escape resolution as-is.
+      const rootHex = '1111111111111111111111111111111111111111111111111111111111111111';
+      const badProof: SMTProof = {
+        id        : rootHex,
+        nonce     : '!!!not-base64url!!!',
+        updateId  : 'also!!!not!!!base64url',
+        collapsed : '0',
+        hashes    : [],
+      };
+
+      const sidecar = emptySidecar();
+      sidecar.smtMap.set(rootHex, badProof);
+
+      expect(() => beacon.processSignals([fakeSignal(rootHex)], sidecar))
+        .to.throw(SMTBeaconError, 'Malformed SMT proof fields.')
+        .with.property('type', 'INVALID_SMT_PROOF');
     });
 
     it('throws when Merkle inclusion proof fails verification', () => {

--- a/packages/smt/README.md
+++ b/packages/smt/README.md
@@ -102,12 +102,11 @@ Serialized proofs follow the did:btcr2 [SMT Proof data structure](https://dcdpr.
 
 ## Low-level: zero-hash API
 
-If you need direct control over indexes and leaf hashes (outside the did:btcr2 leaf convention), use the zero-hash functions that `BTCR2MerkleTree` is built on:
+If you need direct control over indexes and leaf hashes (outside the did:btcr2 leaf convention), use the zero-hash tree that `BTCR2MerkleTree` is built on. `ZeroHashTree` builds the tree **once** (a compressed trie with memoized subtree hashes) and then serves any number of proofs by a single trie walk; prefer it over the per-call wrappers whenever you need more than one proof from the same leaf set:
 
 ```typescript
 import {
-  zeroHashRoot,
-  generateZeroHashProof,
+  ZeroHashTree,
   verifyZeroHash,
   serializeProof,
   didToIndex,
@@ -119,14 +118,31 @@ const leaves = [
   { index: didToIndex('did:btcr2:k1qexample2'), leaf: inclusionLeafHash(nonce2, update2) },
 ];
 
-const root  = zeroHashRoot(leaves);                       // Uint8Array(32)
-const proof = generateZeroHashProof(leaves, leaves[0].index); // { collapsed: bigint, hashes: Uint8Array[] }
+const tree  = ZeroHashTree.fromLeaves(leaves); // builds and hashes every subtree once
+tree.root;                                     // Uint8Array(32)
+const proof = tree.proof(leaves[0].index);     // { collapsed: bigint, hashes: Uint8Array[] }
 
-const ok = verifyZeroHash(proof.collapsed, proof.hashes, leaves[0].index, leaves[0].leaf, root);
+// Proofs are served for any 256-bit index, present or not: a proof for an
+// absent index is the non-inclusion direction (its siblings are the subtrees
+// the absent leaf's path passes).
+const absentProof = tree.proof(someOtherIndex);
+
+const ok = verifyZeroHash(proof.collapsed, proof.hashes, leaves[0].index, leaves[0].leaf, tree.root);
 
 // Serialize to the did:btcr2 wire format:
-const wire = serializeProof(root, proof, { nonce: nonce1, updateId });
+const wire = serializeProof(tree.root, proof, { nonce: nonce1, updateId });
 ```
+
+Two per-call convenience wrappers remain for one-shot use; both build a fresh `ZeroHashTree` internally, so they rebuild the whole tree per call:
+
+```typescript
+import { zeroHashRoot, generateZeroHashProof } from '@did-btcr2/smt';
+
+const root  = zeroHashRoot(leaves);                        // same value as tree.root
+const proof = generateZeroHashProof(leaves, leaves[0].index); // same value as tree.proof(...)
+```
+
+Duplicate leaf indexes are rejected with a `RangeError` at tree construction.
 
 ## API
 
@@ -148,8 +164,9 @@ const wire = serializeProof(root, proof, { nonce: nonce1, updateId });
 
 | Export | Description |
 |---|---|
-| `zeroHashRoot(leaves)` | Compute the root over `ZeroHashEntry[]`. |
-| `generateZeroHashProof(leaves, index)` | Inclusion proof `{ collapsed, hashes }` for one index. |
+| `ZeroHashTree` | Persistent zero-hash tree. `ZeroHashTree.fromLeaves(leaves)` builds the compressed trie once; `.root` is the Merkle root; `.proof(index)` serves inclusion or non-inclusion proofs by trie walk. |
+| `zeroHashRoot(leaves)` | One-shot root over `ZeroHashEntry[]` (builds a fresh `ZeroHashTree` internally). |
+| `generateZeroHashProof(leaves, index)` | One-shot proof `{ collapsed, hashes }` for one index (builds a fresh `ZeroHashTree` internally). |
 | `verifyZeroHash(collapsed, hashes, index, candidate, root)` | The spec's verification algorithm (MSB-first walk). |
 | `CACHED_ZERO` | Precomputed empty-subtree hashes by height, indices `[0, 256]`. |
 | `ZeroHashEntry` | `{ index: bigint, leaf: Uint8Array }`. |

--- a/packages/smt/tests/golden-vectors.spec.ts
+++ b/packages/smt/tests/golden-vectors.spec.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai';
+import {
+  BTCR2MerkleTree,
+  didToIndex,
+  hexToHash,
+  inclusionLeafHash,
+  nonInclusionLeafHash,
+  verifySerializedProof,
+  verifyZeroHash,
+  ZeroHashTree,
+  type SerializedSMTProof,
+} from '../src/index.js';
+
+/**
+ * Golden vectors for the zero-hash Sparse Merkle Tree.
+ *
+ * Every expected value below is a FROZEN golden literal, generated once from a
+ * known-good implementation and then recomputed independently from the spec
+ * construction (SHA-256 only: cachedZero chain, leaf-hash construction, the
+ * MSB-first verification walk) before being frozen here. Their purpose is to
+ * catch tree/proof regressions even when the implementation and its
+ * differential oracles drift together: a change that alters any root, bitmap,
+ * or sibling hash fails this spec no matter how self-consistent it is.
+ *
+ * Construction recap (did:btcr2 SMT): the tree is full-depth (256 levels);
+ * cachedZero[0] = SHA-256(0x00*32 || 0x00*32) and cachedZero[h] =
+ * SHA-256(cachedZero[h-1] || cachedZero[h-1]); an empty subtree at height h
+ * contributes cachedZero[h]; every level is hashed. Leaves are
+ * SHA-256(SHA-256(nonce) || SHA-256(update)) for inclusion and
+ * SHA-256(SHA-256(nonce)) for non-inclusion. Index = SHA-256(did) big-endian;
+ * the root splits on the least-significant index bit.
+ */
+
+/** Fixed vector inputs (hex). */
+const DID1 = 'did:btcr2:k1q5ptvjpcgt0jfgvddau2fllfcpxwa5qtw2umkafp5xqwqr72a7xanvcjf324y';
+const DID2 = 'did:btcr2:k1q5pcyz9x806tq82vysz6tde0lpge4frgmuxx33dxz6zxtkx7ljwg78q7n2tc4';
+const NONCE1 = hexToHash('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f');
+const NONCE2 = hexToHash('ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100');
+/** SHA-256 of the empty string, standing in for canonical signed-update bytes. */
+const UPDATE1 = hexToHash('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+
+/** Deep-shared-prefix indices: all share the low 250 bits (only bit 0 set). */
+const IDX_A = 1n;
+const IDX_B = (1n << 250n) | 1n;
+const IDX_C = (1n << 251n) | 1n;
+
+const hexOf = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex');
+
+describe('golden vectors (frozen)', () => {
+  describe('single-leaf tree', () => {
+    it('reproduces the frozen index, leaf, root, and serialized proof', () => {
+      expect(didToIndex(DID1).toString(16).padStart(64, '0')).to.equal(
+        '5e5dcf1d51ee54d1bdb6c7d1b512f923fbe2f3a492506f0b6baa35b5a8b02e34'
+      );
+      expect(hexOf(inclusionLeafHash(NONCE1, UPDATE1))).to.equal(
+        'd1eee1c59d47515f001d3ce90d70764f1e1f9104e78bfaf35287339c69722ff5'
+      );
+
+      const tree = new BTCR2MerkleTree();
+      tree.addEntries([{ did: DID1, nonce: NONCE1, signedUpdate: UPDATE1 }]);
+      tree.finalize();
+
+      expect(hexOf(tree.rootHash)).to.equal(
+        '083ed55f1a960f229b8bf98d919e42db7e2135f9382b4b7b59f5d339cff73c2a'
+      );
+
+      // A lone leaf has an empty sibling at every level: collapsed is all 256
+      // bits set (base64url of 32 0xff bytes) and hashes is empty.
+      const proof = tree.proof(DID1);
+      const expected: SerializedSMTProof = {
+        id        : 'CD7VXxqWDyKbi_mNkZ5C234hNfk4K0t7WfXTOc_3PCo',
+        collapsed : '__________________________________________8',
+        hashes    : [],
+        nonce     : 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
+        updateId  : 'Xfbg4nYTWdMKgnUFjimfzAOBU0VF9Vz0PkGYP11MlFY',
+      };
+      expect(proof).to.deep.equal(expected);
+      expect(
+        verifySerializedProof(proof, didToIndex(DID1), inclusionLeafHash(NONCE1, UPDATE1))
+      ).to.equal(true);
+    });
+  });
+
+  describe('two-leaf tree at a deep shared prefix (fork at bit 250)', () => {
+    const leaves = [
+      { index: IDX_A, leaf: inclusionLeafHash(NONCE1, UPDATE1) },
+      { index: IDX_B, leaf: inclusionLeafHash(NONCE2, UPDATE1) },
+    ];
+    const tree = ZeroHashTree.fromLeaves(leaves);
+    const ROOT = '8ddeaea140844ac5912b0323822590362a20ce5a02505e6dc41919486daaee6b';
+    // One non-empty sibling (the other leaf's subtree) at the fork level
+    // h = 6: collapsed is all bits set except bit 250.
+    const COLLAPSED = 'fbffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+    it('reproduces the frozen root and inclusion proofs', () => {
+      expect(hexOf(tree.root)).to.equal(ROOT);
+
+      const proofA = tree.proof(IDX_A);
+      expect(proofA.collapsed.toString(16)).to.equal(COLLAPSED);
+      expect(proofA.hashes.map(hexOf)).to.deep.equal(
+        ['e0999a61dcabf22f9e491c57638744d42fc664f71a869f99fa6bff7ed91509db']
+      );
+      expect(verifyZeroHash(proofA.collapsed, proofA.hashes, IDX_A, leaves[0].leaf, tree.root)).to.equal(true);
+
+      const proofB = tree.proof(IDX_B);
+      expect(proofB.collapsed.toString(16)).to.equal(COLLAPSED);
+      expect(proofB.hashes.map(hexOf)).to.deep.equal(
+        ['e300de339036e41b5ef072bbe23ff0c792a2bbfa0f33dc1bcefdf04e030fd09d']
+      );
+      expect(verifyZeroHash(proofB.collapsed, proofB.hashes, IDX_B, leaves[1].leaf, tree.root)).to.equal(true);
+    });
+
+    it('reproduces the frozen non-inclusion proof for an absent index', () => {
+      // Index 0 diverges at the lowest bit, above the whole tree: the entire
+      // tree is the single sibling at the root level (collapsed bit 0 clear).
+      const absent = tree.proof(0n);
+      expect(absent.collapsed.toString(16)).to.equal(
+        'fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe'
+      );
+      expect(absent.hashes.map(hexOf)).to.deep.equal(
+        ['d55af4e9d1422671bfe167f673f7d778f59a7056835f58e1934ab278cbfa5b30']
+      );
+      // The proof describes an empty path: it must NOT verify any leaf.
+      expect(
+        verifyZeroHash(absent.collapsed, absent.hashes, 0n, nonInclusionLeafHash(NONCE1), tree.root)
+      ).to.equal(false);
+    });
+  });
+
+  describe('three-leaf tree at a deep shared prefix (forks at bits 250 and 251)', () => {
+    const leaves = [
+      { index: IDX_A, leaf: inclusionLeafHash(NONCE1, UPDATE1) },
+      { index: IDX_B, leaf: inclusionLeafHash(NONCE2, UPDATE1) },
+      { index: IDX_C, leaf: nonInclusionLeafHash(NONCE1) },
+    ];
+    const tree = ZeroHashTree.fromLeaves(leaves);
+    // Two non-empty siblings per proof (fork levels h = 5 and h = 6):
+    // collapsed is all bits set except bits 250 and 251.
+    const COLLAPSED = 'f3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+    it('reproduces the frozen root and inclusion proofs', () => {
+      expect(hexOf(tree.root)).to.equal(
+        '5955172ae3fc77a2da19c11546ff98eef4ac9a1360b4d4106de1c655a480bd44'
+      );
+
+      const proofA = tree.proof(IDX_A);
+      expect(proofA.collapsed.toString(16)).to.equal(COLLAPSED);
+      expect(proofA.hashes.map(hexOf)).to.deep.equal([
+        'b76bcde675b5ade47453e61097d196badd1bdfea7c349b4b8a364bd4b0d369d3',
+        'e0999a61dcabf22f9e491c57638744d42fc664f71a869f99fa6bff7ed91509db',
+      ]);
+      expect(verifyZeroHash(proofA.collapsed, proofA.hashes, IDX_A, leaves[0].leaf, tree.root)).to.equal(true);
+
+      // C carries a non-inclusion leaf: its proof verifies against
+      // SHA-256(SHA-256(nonce)) and fails against any updateId candidate.
+      const proofC = tree.proof(IDX_C);
+      expect(proofC.collapsed.toString(16)).to.equal(COLLAPSED);
+      expect(proofC.hashes.map(hexOf)).to.deep.equal([
+        '0eaba246bac7ab76735ef1fd7cba73fb8f4c7119fa9c0481ef3c689bff65ee76',
+        'e0999a61dcabf22f9e491c57638744d42fc664f71a869f99fa6bff7ed91509db',
+      ]);
+      expect(verifyZeroHash(proofC.collapsed, proofC.hashes, IDX_C, leaves[2].leaf, tree.root)).to.equal(true);
+      expect(
+        verifyZeroHash(proofC.collapsed, proofC.hashes, IDX_C, inclusionLeafHash(NONCE1, UPDATE1), tree.root)
+      ).to.equal(false);
+    });
+  });
+
+  describe('btcr2 tree with inclusion and non-inclusion entries', () => {
+    it('reproduces the frozen root and both serialized proofs', () => {
+      const tree = new BTCR2MerkleTree();
+      tree.addEntries([
+        { did: DID1, nonce: NONCE1, signedUpdate: UPDATE1 },
+        { did: DID2, nonce: NONCE2 },
+      ]);
+      tree.finalize();
+
+      expect(hexOf(tree.rootHash)).to.equal(
+        '0cf663fd64780cd862ab75bad00e8db242ddbe3297c336a19f3bb7cd9e8e0e56'
+      );
+      expect(didToIndex(DID2).toString(16).padStart(64, '0')).to.equal(
+        '55982336d38135c3ea132486fcf533151e1df2f612a287cf9e3e314dae5cab5b'
+      );
+      expect(hexOf(nonInclusionLeafHash(NONCE2))).to.equal(
+        'b75306f67bf19e03b8ac0877f9cbfda8f7044c2a26e3e5487a97744ca949671d'
+      );
+
+      const proof1 = tree.proof(DID1);
+      const expected1: SerializedSMTProof = {
+        id        : 'DPZj_WR4DNhiq3W60A6NskLdvjKXwzahnzu3zZ6ODlY',
+        collapsed : '__________________________________________4',
+        hashes    : ['c9rSqtPSdn9gNvnvADf--gQe4W6fbsssXokcotlM5TQ'],
+        nonce     : 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
+        updateId  : 'Xfbg4nYTWdMKgnUFjimfzAOBU0VF9Vz0PkGYP11MlFY',
+      };
+      expect(proof1).to.deep.equal(expected1);
+      expect(
+        verifySerializedProof(proof1, didToIndex(DID1), inclusionLeafHash(NONCE1, UPDATE1))
+      ).to.equal(true);
+
+      // Non-inclusion entry: no updateId on the wire proof; it verifies
+      // against SHA-256(SHA-256(nonce)) and rejects any inclusion candidate.
+      const proof2 = tree.proof(DID2);
+      const expected2: SerializedSMTProof = {
+        id        : 'DPZj_WR4DNhiq3W60A6NskLdvjKXwzahnzu3zZ6ODlY',
+        collapsed : '__________________________________________4',
+        hashes    : ['zF2oY6uQLLc7GOy_q8m3LLew52KJmGUlYspw4xJbf80'],
+        nonce     : '_-7dzLuqmYh3ZlVEMyIRAP_u3cy7qpmId2ZVRDMiEQA',
+      };
+      expect(proof2).to.deep.equal(expected2);
+      expect(
+        verifySerializedProof(proof2, didToIndex(DID2), nonInclusionLeafHash(NONCE2))
+      ).to.equal(true);
+      expect(
+        verifySerializedProof(proof2, didToIndex(DID2), inclusionLeafHash(NONCE2, UPDATE1))
+      ).to.equal(false);
+    });
+  });
+});

--- a/packages/smt/tests/zero-hash-tree.spec.ts
+++ b/packages/smt/tests/zero-hash-tree.spec.ts
@@ -147,6 +147,21 @@ describe('ZeroHashTree', () => {
           expect(proof.hashes.map(h => Buffer.from(h).toString('hex')))
             .to.deep.equal(expected.hashes.map(h => Buffer.from(h).toString('hex')));
         }
+        // Non-inclusion direction: (a) a target diverging at the lowest bit
+        // forks above the whole tree and takes it as a single sibling; (b) a
+        // target diverging at the pair's fork bit descends into the sibling
+        // branch and forks inside the compressed gap below it.
+        const targets = [
+          a.index ^ 1n,
+          a.index ^ (1n << BigInt(Math.min(sharedBits + 1, 255))),
+        ];
+        for (const target of targets) {
+          const expected = oracle.generateProof(leaves, target);
+          const proof = tree.proof(target);
+          expect(proof.collapsed).to.equal(expected.collapsed);
+          expect(proof.hashes.map(h => Buffer.from(h).toString('hex')))
+            .to.deep.equal(expected.hashes.map(h => Buffer.from(h).toString('hex')));
+        }
       }
     });
 


### PR DESCRIPTION
* chore(release): per-package changesets with deliberate bumps; cryptosuite major for the non-mutating addProof
* feat(cli): --min-conf flag on resolve
* docs(cli): removed rpc-pass flag replaced with env and file secret refs; minConf default documented; demo walkthrough fixed for the confirmation gate and fee ceiling
* docs(smt): readme covers the precomputed zero-hash tree api
* test(method): malformed cas announcement and smt proof negative cases
* test(smt): frozen golden proof vectors; non-inclusion differential cases
* ci: push and pull_request runs deduped by head sha