### PR TITLE
authorization, signal, and signing integrity hardening

### DIFF
--- a/docs/adr/086-beacon-signal-recognition.md
+++ b/docs/adr/086-beacon-signal-recognition.md
@@ -1,0 +1,199 @@
+---
+title: "ADR 086: Beacon Signal Recognition - Decode the Serialized Script and Require a Beacon Spend"
+---
+
+# ADR 086: Beacon Signal Recognition - Decode the Serialized Script and Require a Beacon Spend
+
+**Status:** Accepted (supersedes [ADR 056](056-beacon-signal-format-validation.md))
+
+**Date:** 2026-08-19
+
+**Branch / PR:** `fix/critical-high-security-findings`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 044](044-beacon-change-output-address.md), [ADR 055](055-resolver-provide-trust-boundary.md), [ADR 056](056-beacon-signal-format-validation.md)
+
+## Context
+
+Beacon signal discovery is the entry point of the resolver's read path
+(`packages/method/src/core/beacon/signal-discovery.ts`). It has two implementations
+against two different backends: `indexer` reads an Esplora REST address listing, and
+`fullnode` traverses blocks over Bitcoin Core RPC. Whatever either one recognizes as a
+signal becomes an update the resolver applies; whatever it fails to recognize is an
+update the resolver never sees, and the caller is handed the previous document with no
+indication that anything is missing.
+
+The specification defines the object being recognized in two parts. Terminology defines
+**Signal Bytes** as "the 32 bytes of information that are included within the last
+transaction output of a Beacon Signal", whose output script "has the following form:
+`[OP_RETURN, OP_PUSH_BYTES, <signal_bytes>]`", and defines a **Beacon Signal** as
+"Bitcoin transactions that **spend from** a Beacon Address and include a transaction
+output of the format defined in Signal Bytes". The Beacon Address definition says the
+same thing from the other side: "spends of UTXO controlled by this address are identified
+as Beacon Signals." The resolve operation's Process Beacon Signals step restates the
+output rule: "use those Beacon Addresses to find Bitcoin transactions whose last output
+script contains Signal Bytes."
+
+[ADR 056](056-beacon-signal-format-validation.md) implemented only the output half of
+that definition, and implemented it against a rendering rather than against the wire
+bytes. Its shared decoder, `extractOpReturnSignal(asm)`, accepted a scriptPubKey if and
+only if its `asm` string was exactly the three tokens `OP_RETURN`, `OP_PUSHBYTES_32`, and
+a 64-character hex payload. Two gaps followed, and both fail open: a real signal is
+discarded or a fake one is admitted, and in either case resolution returns a stale
+document with no error, so a rotated or revoked key still reads as authorized.
+
+**`asm` is a per-backend rendering, not a wire format.** Esplora prints a data push with
+its opcode name (`OP_RETURN OP_PUSHBYTES_32 <hash>`); Bitcoin Core prints the pushed data
+as bare hex (`OP_RETURN <hash>`). ADR 056's three-token rule is Esplora's dialect, so
+every genuine signal arriving over Bitcoin Core RPC failed the token check and was
+dropped. The rule was invisible to the test suite because the RPC-path fixtures rendered
+their `asm` in Esplora's dialect, a shape no Bitcoin Core node emits: the tests passed
+while a live node found nothing.
+
+**Recognition rested on the output alone.** `indexer` calls `address.getTxs`, which
+returns every transaction touching the address in either direction, and accepted any of
+them whose last output was a well-formed 32-byte `OP_RETURN`. It never inspected the input
+side. Anyone able to pay dust to a beacon address could therefore attach a 32-byte
+`OP_RETURN` of their choosing and have it discovered as that beacon's signal. The resolver
+then emits a data need for an update that nobody can supply, so resolution cannot complete
+for as long as that output stays on chain: a permanent denial of resolution for the price
+of one dust output and no keys at all. Chained with a document that admits a
+lower-privilege signing key, it also lets a party who cannot spend the beacon UTXO get a
+rogue update announced.
+
+The `fullnode` path had a third, unrelated defect that made the whole path moot: it
+extracted the signal from the locking script of the output *being spent* rather than from
+the spending transaction's last output. An output being spent carries a payment script,
+never a signal, so that path found nothing for any DID under any input.
+
+## Decision
+
+### 1. Recognize a signal from the serialized script, not from `asm`
+
+`extractOpReturnSignal(asm)` becomes `extractOpReturnSignalHash(scriptPubKey)`
+(`signal-discovery.ts:42`), which matches `/^6a20([0-9a-f]{64})$/i` (`:20`) against the
+raw script hex and returns the lowercased payload, or `null`. Both backends return that
+field verbatim (Esplora as `scriptpubkey`, Bitcoin Core as `scriptPubKey.hex`), and it is
+the exact inverse of the encode side, `opReturnScript` (`core/beacon/beacon.ts:255`),
+which `op-return-script.spec.ts` pins byte for byte. Recognition therefore matches the
+bytes actually committed to the chain and carries no backend dialect. Both paths read the
+transaction's last output (`:140` and `:268`), which is the spec's rule and the same
+invariant [ADR 044](044-beacon-change-output-address.md) decision 4 preserves on the write
+side by placing change before the signal.
+
+**This is a portability fix, not a tightening.** The new regex accepts exactly the set
+ADR 056's asm rule accepted: `OP_PUSHBYTES_32` is rendered only for opcode `0x20` and
+`OP_RETURN` only for `0x6a`, so "the asm is exactly those three tokens" and "the script is
+exactly `6a20<32 bytes>`" pick out the same scripts. Everything ADR 056 rejected is still
+rejected: a bare `OP_RETURN`, a push of the wrong size, a second push, a non-hex payload,
+and a script where `OP_RETURN` is not the leading opcode. `OP_PUSHDATA1` (`6a4c20...`)
+remains rejected as non-conforming: the spec's `OP_PUSH_BYTES` is the direct-push opcode
+family, and a `0x4c`-prefixed encoding of 32 bytes is the non-minimal way to write the
+same push. An `OP_RETURN` that is not the transaction's last output is non-conforming for
+the same reason and is never examined.
+
+The rename is deliberate. The parameter's meaning changed from a rendering to a
+serialization, and a caller that kept passing `asm` to the old name would have silently
+received `null` forever. Renaming turns that into a compile error. The function is
+re-exported from the package root (`method/src/index.ts:8`), so this is a breaking export
+change for `@did-btcr2/method`.
+
+### 2. An indexer signal must spend from the beacon address
+
+`BeaconSignalDiscovery.spendsFromAddress(tx, address, bitcoin)` (`:82-107`) gates the
+`indexer` push (`:167`). It returns true when at least one non-coinbase input's spent
+output belongs to the beacon address. Coinbase inputs spend no prior output, so they can
+never spend from a beacon and are skipped. This completes the spec's definition: the
+output shape says what a signal *contains*, the input side says whose signal it *is*.
+The `fullnode` path already required a beacon-spending input, since that is how it
+associates a transaction with a service at all, so this decision changes the indexer path
+only.
+
+**The cost is bounded and paid last.** The spent output is read from `vin[].prevout`,
+which Esplora embeds on both the address listing and the transaction endpoint, so the
+common path costs no additional I/O. When a backend omits the field, the funding
+transaction is fetched and its `vout[vin.vout]` used instead (`:96-99`). That is at most
+one extra fetch per candidate input, incurred only for transactions that already passed
+the free script-shape check (which is why the gate is ordered after it), and bounded above
+by the address page size, since discovery only ever examines one page of address history.
+
+**A prevout that cannot be resolved fails the resolution rather than skipping the
+signal.** A fetch failure propagates. The alternative, treating an unresolvable input as
+"not a beacon spend" and moving on, means a backend having a bad minute silently drops
+real signals and hands the caller a stale document: precisely the failure shape this whole
+decision set exists to remove. An error the caller can see and retry is recoverable; a
+document silently missing a revocation is not.
+
+## Consequences
+
+- **The fullnode path discovers signals at all now.** It reads the hash once per
+  transaction from that transaction's last output (`:268-276`) instead of from the output
+  being spent, and credits a beacon at most once per transaction (`:280`), since a signal
+  is now resolved per transaction rather than per input and a transaction spending two of
+  one beacon's UTXOs would otherwise apply the same update twice. Anything driving this
+  path now sees updates it previously never saw, including deactivations. Before, it
+  returned zero signals for every DID and every caller, without an error.
+- A transaction that only *pays* a beacon address is no longer discovered as a signal,
+  whatever its `OP_RETURN` carries. A transaction that spends from the beacon still is,
+  whether or not it pays anything back to the beacon.
+- On a backend that does not embed `prevout`, discovery issues up to one extra
+  `transaction.get` per candidate input, and a failure of that fetch now fails resolution.
+- `extractOpReturnSignal` no longer exists under that name or that parameter. All affected
+  packages are 0.x, so the rename rides the next minor.
+- Recognition is now covered against both backends' real wire shapes rather than against
+  one backend's rendering, so a dialect difference cannot pass the suite and fail on a
+  live node.
+
+### Accepted residual: beacon addresses are compared as case-sensitive strings
+
+`spendsFromAddress` compares `prevout?.scriptpubkey_address === address` (`:101`), and the
+fullnode path keys its service lookup on the address string the same way (`:322`). The
+beacon address on both sides comes verbatim from `BeaconUtils.parseBitcoinAddress`
+(`core/beacon/utils.ts:24-29`), which strips the `bitcoin:` scheme and any BIP21 query
+string and normalizes nothing else.
+
+BIP-173 declares an all-uppercase bech32 string valid and requires decoders to accept both
+cases, and the repo's own address decoder agrees: `Address(network).decode` from
+`@scure/btc-signer` returns the identical `wpkh` script for `bc1q...` and `BC1Q...`.
+Esplora and Bitcoin Core both render `scriptpubkey_address` lowercase. So a DID document
+whose beacon service endpoint uses the uppercase form matches no spent output on either
+path, yields zero signals, and resolves to a stale document with no error.
+
+Scoping this honestly: the defect is pre-existing on the fullnode path, whose lookup was
+already a verbatim string key, and newly reachable on the indexer path, which had no
+address comparison before this ADR. It is reachable only through a hand-authored or
+externally supplied document: every in-repo endpoint generator emits the lowercase form
+(`BeaconUtils.createBeaconService`), and the write path already refuses such an endpoint
+loudly, deriving the lowercase address and throwing `SIGNER_KEY_MISMATCH`
+(`core/beacon/beacon.ts:646-652`). It is accepted rather than fixed here because it is a
+different defect class (address normalization) from the two decisions above, and folding
+it in would have mixed a read-path correctness fix with a change to how addresses are
+parsed everywhere.
+
+Fix direction: normalize once, inside `parseBitcoinAddress`, by lowercasing an address
+that is all-uppercase and decodes as bech32 or bech32m, and leaving base58 addresses
+untouched (base58check is case-sensitive, and lowercasing one corrupts it).
+
+## Rejected alternatives
+
+- **Accept both asm dialects, for example by reading `tokens[2] || tokens[1]`.** It makes
+  the live node work, but it silently admits a multi-push `OP_RETURN` and so drops ADR
+  056's guard, and it leaves the next backend's dialect to be discovered in production
+  rather than in the type system. The serialized script is the one thing every backend
+  agrees on.
+- **Keep the asm check and normalize the asm per backend.** Recognition would then depend
+  on knowing which backend answered, which the discovery code deliberately does not know:
+  it is handed a `BitcoinConnection`, not a dialect.
+- **Compare the spent output's script instead of its address.** Strictly stronger, since
+  a script comparison is immune to address rendering entirely and would subsume the
+  case-sensitivity residual above. It lost on scope, not on merit: it requires threading
+  network parameters into the comparison and re-keying the fullnode service map off
+  scripts rather than addresses, which is a larger change than the one being made and
+  would have been landed alongside an unrelated correctness fix. It remains the preferred
+  long-term shape.
+- **Skip an input whose prevout cannot be resolved.** A backend that omits `prevout` would
+  then drop every signal for every DID with no error, restoring the exact fail-open
+  outcome that decision 2 exists to close.
+- **Also require the signal transaction to pay the beacon address.** Not what the
+  specification says, and it would reject conforming signals:
+  [ADR 044](044-beacon-change-output-address.md) makes the change destination a
+  caller-supplied privacy lever precisely so a beacon need not pay itself back.

--- a/docs/adr/087-bitcoin-rpc-password-channels.md
+++ b/docs/adr/087-bitcoin-rpc-password-channels.md
@@ -1,0 +1,228 @@
+---
+title: "ADR 087: The Bitcoin RPC Password Has No Command-Line Flag"
+---
+
+# ADR 087: The Bitcoin RPC Password Has No Command-Line Flag
+
+**Status:** Accepted
+
+**Date:** 2026-08-19
+
+**Branch / PR:** `fix/critical-high-security-findings`
+
+**Supersedes:** [ADR 077](077-cli-rpc-secret-handling.md)
+
+**References:** [ADR 047](047-cli-encrypted-keystore.md), [ADR 074](074-cli-config-resolution-correctness.md), [ADR 076](076-cli-io-passthrough-knobs.md), [ADR 080](080-keystore-lifecycle-and-dev-keystores.md)
+
+## Context
+
+The cli accepted the Bitcoin Core RPC password as a global command-line option,
+`--btc-rpc-pass <pass>`. A value passed there is readable by any local user for
+the lifetime of the process, through `ps` and `/proc/<pid>/cmdline`, and it
+outlives the process in shell history, in CI job logs, and in whatever process
+accounting the host keeps. None of those are places a credential can be revoked
+from. The same global surface carries `--btc-rpc-wallet`, so in practice the RPC
+credential grants wallet-level access to the node: the exposure is not limited to
+read-only chain queries.
+
+[ADR 077](077-cli-rpc-secret-handling.md) addressed the two other weaknesses of
+this credential (it printed in the clear from `config get`/`config list`, and it
+had to live literally in `config.json`) by adding display redaction and an
+`env:<VAR>` / `file:<path>` secret reference plus a `BTCR2_BTC_RPC_PASS_FILE`
+fallback. It treated the flag itself as given: its context section describes the
+password as flowing "correctly through the flag -> env -> profile ->
+per-network-default precedence", and removal of the flag does not appear even
+among its rejected alternatives. That leaves ADR 077 describing a flag layer that
+this decision retires, which is why this ADR supersedes it rather than amending
+it. Everything else ADR 077 decided (redaction by default with `--show-secrets`,
+the secret-ref forms, the documented plaintext-at-rest tradeoff, and the refusal
+to encrypt `config.json` or fold RPC credentials into the keystore) stands
+unchanged.
+
+The keystore passphrase, the cli's other secret, has never been accepted from a
+flag: `acquirePassphrase` reads it from `BTCR2_KEYSTORE_PASSPHRASE`, from a file
+named by `--passphrase-file`, or from an interactive prompt
+(`packages/cli/src/keystore/passphrase.ts:42-70`). The RPC password was the one
+secret in the cli that argv could carry.
+
+## Decision
+
+### 1. The flag is removed, and so is the field that parsed it
+
+`--btc-rpc-pass` is gone from the global option list (`packages/cli/src/cli.ts:56`,
+where a comment now stands in its place explaining why nothing may be registered
+there), and `btcRpcPass` is gone from `GlobalOptions`
+(`packages/cli/src/types.ts:100`), the interface that models what commander parses
+off argv. The type no longer has a slot for an argv-supplied password, so
+re-introducing one is a type change and not an oversight.
+
+The three surviving channels, none of which touch argv:
+
+- `BTCR2_BTC_RPC_PASS`, read by `readEnvOverrides` (`packages/cli/src/config.ts:273`).
+- `BTCR2_BTC_RPC_PASS_FILE`, naming a file whose contents are the password
+  (`config.ts:809-814`), with at most one trailing newline trimmed so a file
+  written by `echo` matches an inline value.
+- A profile `btc.rpcPass` (`config.ts:360`) holding either a literal or an
+  `env:<VAR>` / `file:<path>` secret reference resolved by `resolveSecretRef`
+  (`config.ts:797-807`).
+
+`ConnectionOverrides.btcRpcPass` (`config.ts:31`) is deliberately kept. It is the
+internal carrier that the env and profile layers populate, and `defaultApiFactory`
+is a programmatic entry point that an embedding application may call with its own
+credentials. Only the argv-parsed type lost the field.
+
+### 2. What ADR 074's atomic credential unit now implies
+
+[ADR 074](074-cli-config-resolution-correctness.md) made the RPC url, username,
+and password resolve as one unit: `resolveRpcUnit` (`config.ts:557-576`) picks the
+highest-precedence layer that supplies a url, or failing that the highest that
+supplies a username or password, and takes all three values from that one layer,
+so a host from one layer is never handed another layer's credentials.
+
+The removed flag was the only way to put a password into the **flag** layer, whose
+`pass` slot (`config.ts:563`) is now permanently `undefined`. The consequence is
+subtle enough to be worth stating outright:
+
+> A `--btc-rpc-url` given on the command line selects the flag layer, so
+> `BTCR2_BTC_RPC_PASS` is discarded along with the rest of the env layer. Its
+> password comes from `BTCR2_BTC_RPC_PASS_FILE`, which is applied after the unit
+> resolves (`config.ts:667`, `resolveSecretRef(rpcUnit?.pass) ?? readRpcPassFile()`)
+> and is therefore the one layer-independent password channel.
+
+That is not new behavior. The unit always dropped a lower layer's password when a
+higher layer supplied the url; it is simply now the only path for a flag-given
+url, so it is recorded here and pinned by a regression test. The pairings that
+work:
+
+| url from | password from |
+|----------|---------------|
+| `--btc-rpc-url` (flag) | `BTCR2_BTC_RPC_PASS_FILE` |
+| `BTCR2_BTC_RPC_URL` (env) | `BTCR2_BTC_RPC_PASS`, or the pass file |
+| profile `btc.rpcUrl` | profile `btc.rpcPass` (literal or `env:`/`file:` ref), or the pass file |
+| no layer (network default host, e.g. regtest) | whichever layer supplies a credential, else the pass file |
+
+### 3. Scope: what still reaches argv, and the rule going forward
+
+Removing the flag does not put every secret off argv, and this ADR refuses to
+claim otherwise. Three channels remain. They are recorded here as **accepted
+operator-facing channels**, deliberately kept, not as holes that were closed:
+
+1. **Credentials in the RPC url.** `--btc-rpc-url http://user:pass@host` is
+   accepted with no validation (the cli parses no URL anywhere) and the userinfo
+   is extracted into a Basic `Authorization` header at
+   `packages/bitcoin/src/client/rpc/protocol.ts:71-80`. This is the conventional
+   Bitcoin Core RPC url form, and it is documented and deliberately redacted
+   everywhere it is printed: `scrubUrlUserinfo` masks it regardless of key name
+   (`packages/cli/src/output.ts:23-25`), and the behavior is stated in
+   `packages/cli/docs/config.md:60` and `:183` and in
+   `packages/cli/docs/profile.md:94` and `:123`. Residual worth knowing: if the
+   url fails to parse, `protocol.ts:82` logs the raw host, userinfo included, to
+   stderr.
+2. **Header passthrough options.** `--btc-rpc-header 'Authorization: ...'`
+   (`packages/cli/src/cli.ts:68`) and the identical `--btc-rest-header`
+   (`cli.ts:66`) carry arbitrary header values, which is the point of them
+   ([ADR 076](076-cli-io-passthrough-knobs.md)); `packages/cli/README.md:293`
+   documents the REST one as the way to pass an API key. A generic header
+   passthrough cannot be typed as secret-bearing or not, so this stays.
+3. **`config set` with a literal.** `btcr2 config set profiles.<name>.btc.rpcPass
+   <literal>` takes the secret as a positional argv value
+   (`packages/cli/src/commands/config.ts:56`), stores it as a raw string
+   (`commands/config.ts:203`), and writes it to `config.json` in cleartext at mode
+   0600 (`config.ts:158`); `resolveSecretRef` returns any value that is not
+   `env:`-prefixed or `file:`-prefixed verbatim (`config.ts:806`). ADR 077
+   deliberately kept a literal `rpcPass` working for local and regtest workflows,
+   and that decision is unchanged. An operator who wants the secret off argv uses
+   an `env:`/`file:` reference, or edits the file.
+
+The rule this ADR sets for everything after it:
+
+> **No new CLI option or positional argument may take a secret as its value.** A
+> secret reaches the cli through an environment variable, through a file
+> reference (`--*-file`, `env:`/`file:`, `BTCR2_*_FILE`), or through an
+> interactive prompt.
+
+Options that *name* a secret without carrying one remain fine: `--passphrase-file`
+and `--secret-file` take a path, `--secret` and `--show-secrets` are booleans. The
+three channels above are grandfathered by this ADR; they are not a precedent for
+new ones.
+
+### 4. A structural guard, and what it does not cover
+
+`packages/cli/tests/cli-helpers.spec.ts:161-180` walks the whole command tree from
+the root program and asserts that no value-taking option's long-flag leaf appears
+in a six-name list (`pass`, `password`, `passphrase`, `secret`, `token`,
+`credential`). It catches a re-added `--btc-rpc-pass` and the obvious new flag.
+What it does not cover, verified:
+
+- Leaf extraction is `(option.long ?? option.short ?? '').split('-').pop()`
+  (`:171`) and membership is exact, so `--auth` (leaf `auth`, absent from the
+  list), `--api-key` (leaf `key`), and a short-only `-p <password>` (leaf `p`) all
+  pass the guard.
+- It iterates `command.options` only and never `command.registeredArguments`, so
+  it is structurally incapable of seeing a positional. Channel (3) above,
+  `config set <path> <value>`, is invisible to it.
+
+Meanwhile `packages/cli/src/output.ts:11` already ships a stronger matcher for the
+same concept, `SECRET_KEY = /(pass|secret|token|auth|api[-_]?key|credential|bearer)/i`,
+a case-insensitive substring regex used to redact printed config values. Two lists
+for one notion inside one package will drift.
+
+The intended follow-up, not done here: export a single secret-name list from
+`output.ts`, consume it from both the redactor and the guard, and extend the guard
+to walk `registeredArguments` so a future secret-valued positional is caught. Note
+that this is not a pure code move: the redactor's substring regex applied to whole
+flags would flag `--passphrase-file`, which takes a value and is safe, so the
+unified guard has to keep the "a path or a boolean carries no secret" exception
+explicit, either by matching on the flag leaf or by an allowlist of known-safe
+value-taking options.
+
+## Consequences
+
+- `--btc-rpc-pass` is now an unknown option: commander fails parsing with
+  `commander.unknownOption` and exit code 1 before any command action runs, so the
+  password never reaches the connection config. Scripts and CI jobs that passed the
+  flag break loudly rather than silently continuing without a password. The cli's
+  accepted-flags surface is a breaking surface, so this rides the next cli minor
+  under 0.x.
+- An operator who pairs a flag-supplied `--btc-rpc-url` with `BTCR2_BTC_RPC_PASS`
+  now gets an unauthenticated RPC client and an authentication failure from the
+  node, rather than a wrong-credential leak: the atomic unit already prevented
+  cross-layer mixing. The fix is `BTCR2_BTC_RPC_PASS_FILE`, or moving the url into
+  the same layer as the password.
+- Every doc that tabulated the flag was updated to say there is no flag and why:
+  the cli README's global-flag and env tables, `docs/README.md`, `docs/config.md`,
+  `docs/resolve.md`, `docs/update.md`, `docs/deactivate.md`, `docs/quickstart.md`,
+  and `docs/DEMO.md`.
+- Programmatic callers are unaffected: `defaultApiFactory(network, { btcRpcPass })`
+  still works, since `ConnectionOverrides` kept the field.
+- The claim "the RPC password is off argv" is accurate for the dedicated flag only.
+  Three operator-facing argv channels remain, listed above, each requiring
+  deliberate operator action.
+- ADR 077's redaction defaults, secret-ref forms, and plaintext-at-rest tradeoff
+  are unchanged. Only its flag layer is retired.
+
+## Rejected alternatives
+
+- **Keep the flag but accept only `env:`/`file:` references.** The reference would
+  be safe on argv, but a literal would have to be rejected at parse time, and by
+  then the operator has already typed the password into a shell that recorded it.
+  A rejection after the fact does not unwrite `~/.bash_history` or the process
+  listing of the run that produced it. Removing the option is the only change that
+  makes the argv path impossible.
+- **Keep the flag and print a warning.** A warning on stderr does not remove the
+  value from `/proc/<pid>/cmdline` for the life of the process, and unattended
+  runs never read it.
+- **Reject userinfo in `--btc-rpc-url` as well.** Rejecting it only when it arrives
+  on the flag layer is implementable and stays open as future work, but it would
+  fail the most common paste-a-working-url workflow at the exact moment an operator
+  is trying to reach their own node, in exchange for a channel that is already
+  documented and redacted in every printed surface. Deferred; a warn-then-proceed
+  is the likelier future shape.
+- **Invert the guard to an allowlist of value-taking options.** Structurally the
+  strongest form, and it would catch `--auth`, `--api-key`, and a short-only
+  `-p <password>`. Deferred rather than refused: the cli's global surface is still
+  growing, and every benign new option would need an allowlist entry. Sharing one
+  secret-name list and walking positionals is the cheaper next ratchet.
+- **Encrypt `config.json`, or move `rpcPass` into the keystore.** Already rejected
+  by ADR 077 for the same reasons (it duplicates the keystore's job and couples
+  network config to keystore unlock), and nothing in this decision changes that.

--- a/docs/adr/088-read-path-update-authorization.md
+++ b/docs/adr/088-read-path-update-authorization.md
@@ -1,0 +1,208 @@
+---
+title: "ADR 088: Enforce capabilityInvocation Membership When Resolution Applies an Update"
+---
+
+# ADR 088: Enforce capabilityInvocation Membership When Resolution Applies an Update
+
+**Status:** Accepted
+
+**Date:** 2026-08-19
+
+**Branch / PR:** `fix/critical-high-security-findings`
+
+**References:** [ADR 016](016-sans-io-resolver.md), [ADR 051](051-update-verifies-signing-key.md), [ADR 055](055-resolver-provide-trust-boundary.md), [ADR 057](057-did-document-validation-standards.md), [ADR 085](085-typed-error-policy.md)
+
+## Context
+
+Resolution of a did:btcr2 identifier replays every announced update against the document
+as it stood at the previous version ([ADR 016](016-sans-io-resolver.md)). The step that
+decides whether an update counts is `Resolver.applyUpdate`
+(`packages/method/src/core/resolver.ts:596`): it dereferences the proof's root capability
+and checks that the capability's `invocationTarget` and `controller` are this DID, reads
+`proof.verificationMethod`, locates that method with `DidBtcr2.getSigningMethod`, verifies
+the Data Integrity proof against the method's published key, applies the JSON Patch, and
+checks the resulting document against `update.targetHash`.
+
+Nothing in that sequence tied the named method to an authorization. `getSigningMethod`
+searches `didDocument.verificationMethod`, which is the document's key directory, not a
+grant of authority. Every key a controller publishes appears there, including keys
+published to be used for something other than updating the DID. The verification
+relationships (`authentication`, `assertionMethod`, `capabilityInvocation`,
+`capabilityDelegation`) are the only mechanism a DID document has for saying "this key may
+authenticate but must not rewrite me", and the read path ignored them entirely.
+
+The result was a full, persistent takeover of a DID by a key deliberately excluded from
+update authority. A controller publishes `#device` under `authentication` so a device can
+log in; whoever holds `#device` signs an update whose patch adds `#device` to
+`capabilityInvocation`, announces it through the beacon, and resolution accepts it. From
+that version on the attacker is an authorized controller and the original key cannot
+revoke the grant, since revocation is itself an update the attacker can outpace. Driven
+against the real state machine, that sequence resolved successfully to version 3 with the
+attacker's key listed in `capabilityInvocation`.
+
+The specification's resolve algorithm already required the missing half. Its "Check
+`update.proof`" step says to locate the method in `current_document.verificationMethod`
+**and** to raise `INVALID_DID_UPDATE` if `current_document.capabilityInvocation` does not
+contain `update.proof.verificationMethod`. Only the first conjunct was implemented.
+
+The write path never had this hole: `DidBtcr2.update` (`packages/method/src/did-btcr2.ts:175`)
+has always refused a `verificationMethodId` that is absent from the source document's
+`capabilityInvocation`, and [ADR 051](051-update-verifies-signing-key.md) additionally
+binds the signer's key to that method. But the write path is a convenience for honest
+callers. An attacker constructs the update by hand, or calls the static `Updater.sign`
+directly, and neither costs anything. Only the read path decides what the network sees, so
+an authorization rule that lives solely on the write path is not an authorization rule at
+all. This is the same read-path/write-path asymmetry that [ADR 055](055-resolver-provide-trust-boundary.md)
+addressed for caller-supplied resolution data.
+
+## Decision
+
+### 1. Resolution refuses an update whose proof method is not authorized
+
+`applyUpdate` asserts that the contemporary document's `capabilityInvocation` names
+`proof.verificationMethod` before doing anything with the proof
+(`packages/method/src/core/resolver.ts:639-651`). A failure raises the typed
+`ResolveError` with type `INVALID_DID_UPDATE` ([ADR 085](085-typed-error-policy.md)),
+carrying `{ verificationMethodId, capabilityInvocation }` so a caller can see both the
+method that was claimed and the list it was measured against.
+
+Two properties of the placement matter as much as the check:
+
+- **It runs before the signature is used.** The assertion sits between the
+  `verificationMethod` existence check and `getSigningMethod`/`verifyProof`, and the patch
+  is not applied until later in the same function (`resolver.ts:680`). The document it
+  reads is the pre-patch document: `applyUpdate` has a single call site
+  (`resolver.ts:490`) which passes the current `response.didDocument`. An attacker
+  therefore cannot grant itself the relationship inside the very update it is signing;
+  the grant has to already exist in the version being updated. Membership is evaluated per
+  version, so ordinary rotation still works: a key that update N adds to
+  `capabilityInvocation` may sign update N+1.
+- **It runs before the method is located.** `getSigningMethod` throws a `@web5/dids`
+  `DidError`, not a `ResolveError`. Checking authorization first means an unauthorized
+  method always surfaces as one typed `INVALID_DID_UPDATE`, whether or not it also appears
+  in `verificationMethod[]`. A `proof.verificationMethod` that is not a usable string also
+  fails closed here rather than reaching `getSigningMethod`, whose `??` fallback would
+  otherwise have quietly selected the method named by `assertionMethod[0]`.
+
+### 2. Both sides of the comparison are normalized to an absolute method id
+
+The module-private `relationshipMethodId(documentId, entry)`
+(`packages/method/src/core/resolver.ts:171-176`) reduces a verification relationship entry
+to the absolute DID URL of the method it names: an embedded verification method object
+becomes its `id`, a string reference is the id itself, and a bare fragment such as
+`#key-0` is resolved against `documentId`. Both the proof's `verificationMethod` and every
+`capabilityInvocation` entry go through it before comparison.
+
+This is required for correctness, not convenience. DID Core permits a relationship entry
+to be either a string reference or an embedded verification method, and permits relative
+DID URLs, so a literal string comparison would refuse spec-valid documents. The case is
+not hypothetical for EXTERNAL (`x1`) identifiers: a genesis document written with relative
+references keeps that form through the placeholder substitution done at resolution, while
+its `verificationMethod[].id` values and the update proof both carry absolute URLs.
+Exact-only matching would render such a DID permanently unresolvable, which is a worse
+failure than the one being fixed.
+
+The normalization is deliberately narrow, and its safety rests on two properties:
+
+- Only a `#`-prefixed string has the document id prepended. Every other string is returned
+  unchanged, so an entry naming the same fragment on a **different** DID stays a full URL
+  and can never collapse onto this document's method. A regression test covers exactly
+  that shape.
+- A malformed entry yields `undefined` rather than a placeholder string, and the proof
+  side must be defined for the update to be authorized
+  (`authorizedMethodId !== undefined && ...`), so two unusable values never compare equal
+  to each other. The check fails closed.
+
+Unwrapping is one level deep and non-recursive by construction, so no crafted nesting can
+drive it.
+
+Nine regression cases in `packages/method/tests/resolver.spec.ts` cover both directions:
+the five refusals (the authentication-only takeover, a method under no relationship, a
+document whose `capabilityInvocation` a prior update removed, the foreign-DID fragment, a
+non-string `verificationMethod`) and four guards proving the check is not over-broad (the
+identity key, a key granted invocation by the previous update, a bare-fragment reference,
+and an embedded method object).
+
+## Consequences
+
+- **This changes resolution outcomes for already-published DIDs, not just code.** A DID
+  whose history contains an update signed by a key outside the contemporary
+  `capabilityInvocation` no longer resolves. `applyUpdate` throws and nothing in the
+  resolver catches it, so the whole resolution fails rather than returning the document
+  truncated at the last authorized version. That is the intended reading of the spec (such
+  a history was never authorized), but it means a controller who signed in good faith with
+  a key outside the list now has an unresolvable DID and no in-band way to repair it.
+- **An `x1` genesis document that omits `capabilityInvocation` entirely becomes
+  permanently un-updatable.** Such a document is valid today: the `DidDocument` constructor
+  copies the four relationship arrays verbatim for the EXTERNAL branch
+  (`packages/method/src/utils/did-document.ts:238-244`), with none of the `#initialKey`
+  auto-fill the KEY branch performs (`:231-237`); `sanitize` then deletes the undefined
+  keys, and `isValidVerificationRelationships` only validates the relationship keys that
+  are actually present (`:409-420`). Before this decision, any key in `verificationMethod[]`
+  could update such a DID on the read path. Now `capabilityInvocation?.some(...)` is
+  `undefined`, every update is refused, and no update can add the array because adding it
+  would itself need an authorization that does not exist. `DidBtcr2.update` already
+  refused these documents, so nothing changes for callers going through the SDK write
+  path; what changes is that a hand-crafted update against such a DID no longer resolves.
+  There is no recovery short of a new identifier. Creation tooling should refuse or warn on
+  a genesis document with no `capabilityInvocation`; that guard is follow-up work, not part
+  of this decision.
+- **A read/write coherence gap this decision widened.** The read path now accepts
+  bare-fragment references and embedded verification method objects; the write path
+  (`packages/method/src/did-btcr2.ts:175`) is still an exact string match,
+  `vr === verificationMethodId`. A document using either form therefore resolves but cannot
+  be updated through `DidBtcr2.update`:
+  - an embedded method object never equals a string, so the membership check refuses the
+    update whatever the caller passes;
+  - a bare-fragment entry refuses an absolute `verificationMethodId` at the same line, and
+    if the caller instead passes the bare fragment, the membership check passes but
+    `getSigningMethod` then fails to find the method, because
+    `Appendix.extractDidFragment` (`packages/method/src/utils/appendix.ts:25-29`) does not
+    extract a fragment at all: it is the identity function on non-empty strings, so the
+    lookup compares the document's absolute `vm.id` to the caller's string exactly.
+
+  The failure is fail-closed in every branch: a refused update, never an accepted one, and
+  never an unverifiable announcement paid for on-chain. Closing the gap is not a one-line
+  change, because `getSigningMethod` is public API re-exported through `@did-btcr2/api`
+  (`packages/api/src/method.ts:435`) and would have to change alongside `update()` and the
+  resolver. The direction is a single relationship-aware method-resolution helper shared by
+  the read path, `DidBtcr2.update`, and `getSigningMethod`, with `extractDidFragment`
+  either made to do what its name says or removed. It is deferred here because it alters a
+  published API contract and this decision does not need it to be safe.
+- Callers can distinguish the refusal programmatically: `ResolveError` with
+  `type === 'INVALID_DID_UPDATE'` and a `data` payload naming the method and the list.
+  Existing handlers that only match on the type string see no new error class.
+- The runtime cost is one linear scan of `capabilityInvocation` per applied update, with no
+  additional cryptography and no additional I/O, so the sans-I/O property of the resolver
+  is unaffected.
+- Residual: the read path still does not check the proof's `capabilityAction`, which the
+  write path always sets to `'Write'`. That is a separate authorization dimension and is
+  left for its own decision.
+
+## Rejected Alternatives
+
+- **Put the check inside `getSigningMethod`.** It looks like the natural home, but that
+  function is public API re-exported through `@did-btcr2/api`, it defaults to
+  `#initialKey`, and it has an `assertionMethod[0]` fallback; callers legitimately use it
+  to fetch a key for purposes other than invocation, so hard-wiring `capabilityInvocation`
+  into it would break them. It also throws a `@web5/dids` `DidError` rather than a typed
+  resolution error. Placing the assertion at the resolver's decision point keeps the change
+  scoped to the read path and keeps the error typed.
+- **Compare strings exactly, with no normalization.** Stricter and simpler, but it refuses
+  documents DID Core explicitly allows (embedded methods, relative references) and would
+  make some `x1` DIDs permanently unresolvable rather than merely un-updatable. Refusing a
+  valid document at read time is a worse outcome than the small, non-recursive
+  normalization surface accepted here.
+- **Recursively dereference relationship entries and compare method material.** Entries
+  name a method id and the spec's check is a containment test over ids, so following
+  references to compare keys adds attack surface (nesting depth, cycles) for no additional
+  authority signal. One unwrap level is sufficient and is bounded by construction.
+- **Record the anomaly in resolution metadata and still return a document.** Resolution has
+  to yield exactly one document; a "possibly unauthorized" one is not something a verifier
+  can act on, and every caller that does not read the metadata would remain fully
+  vulnerable. The spec mandates an error, and an error is the only outcome that actually
+  removes the takeover.
+- **Grandfather histories published before this change.** Any cutoff needs a trusted date
+  that a permissionless system cannot supply, and the window it opens is precisely the
+  window an attacker would aim for. Accepting that some existing DIDs stop resolving is the
+  honest cost of enforcing the rule at all.

--- a/docs/adr/089-aggregation-signing-preconditions.md
+++ b/docs/adr/089-aggregation-signing-preconditions.md
@@ -1,0 +1,330 @@
+---
+title: "ADR 089: Aggregation Signing Preconditions for Cohort Members"
+---
+
+# ADR 089: Aggregation Signing Preconditions for Cohort Members
+
+**Status:** Accepted
+
+**Date:** 2026-08-19
+
+**Branch / PR:** `fix/critical-high-security-findings`
+
+**References:** [ADR 038](038-musig2-key-custody.md), [ADR 039](039-cohort-condition-model.md),
+[ADR 040](040-multi-cohort-service-runner.md), [ADR 042](042-fault-tolerant-beacon-output.md),
+[ADR 043](043-k-of-n-fallback-protocol.md), [ADR 044](044-beacon-change-output-address.md),
+[ADR 045](045-analytical-vsize-aggregation-fees.md),
+[ADR 059](059-unbounded-beacon-discovery-default.md), [ADR 066](066-x1-transport-authentication.md)
+
+## Context
+
+An aggregate beacon round has one asymmetry at its center: the coordinator builds everything and
+the members sign it. The coordinator collects the members' updates, aggregates them (a CAS
+Announcement Map or a Sparse Merkle Tree), derives the 32-byte beacon signal, selects a UTXO at
+the cohort's beacon address, and constructs the transaction. Each member then contributes either a
+MuSig2 partial signature on the optimistic key path or, when that path stalls, a standalone BIP-340
+signature over the k-of-n script-path leaf ([ADR 042](042-fault-tolerant-beacon-output.md),
+[ADR 043](043-k-of-n-fallback-protocol.md)). Both commit to the whole transaction under
+`SIGHASH_DEFAULT`, including outputs no member chose.
+
+Before this decision a member checked two things: that its own slot in the distributed data was
+correct (its update hash appears in the CAS map, or its SMT proof verifies), and that *some* output
+of the transaction was an `OP_RETURN` carrying the announced signal. Neither check connected to the
+other, and neither connected to what a resolver would actually read:
+
+- The announced `signalBytesHex` arrived verbatim on the distribution message and was never
+  recomputed from the data the member had just validated. "My update is in this map" and "this map
+  is what gets anchored" were independent statements, and only the first was checked. A coordinator
+  could hand a member a map that includes it while anchoring the signal of a map that omits it, and
+  every member-side check passed.
+- Resolution reads a beacon signal from the transaction's **last** output only:
+  `packages/method/src/core/beacon/signal-discovery.ts:140` (indexer path) and `:268` (full-node
+  path) both take `vout.slice(-1)[0]`. Scanning every output therefore accepted transactions whose
+  last output announced a different aggregation.
+- A fallback authorization request carried its own transaction, and nothing compared it to the
+  transaction of the optimistic round, so a member could be induced to authorize two competing
+  spends of one UTXO through two different witnesses.
+- On the service side, several receive handlers let an underlying cohort or signing-session
+  invariant throw on sender-supplied input, and the runner turns any error escaping `receive()`
+  into `removeCohort` plus a rejected completion. The per-cohort failure isolation of
+  [ADR 040](040-multi-cohort-service-runner.md) does not help when the message is the thing that
+  fails the cohort: one message from anyone able to reach the service ended an in-flight round.
+
+This record fixes the preconditions a member applies before it signs and, just as importantly,
+states what a member deliberately does not check, and why that is defensible.
+
+## Decision
+
+### 1. A member's signature is bound to the data that member validated
+
+`AggregateBeaconStrategy` gains a required member, `deriveSignal(result)`
+(`packages/aggregation/src/core/beacon-strategy.ts:60-72`). It recomputes the 32-byte signal from
+the validation result the strategy just produced, using the same formula the service used on the
+cohort:
+
+- CAS returns `hash(canonicalize(casAnnouncement))` (`beacon-strategy.ts:99-104`), which is the
+  derivation the service performs when it builds the announcement
+  (`packages/aggregation/src/core/cohort.ts:380`). JCS sorts keys, so map insertion order cannot
+  make the two disagree.
+- SMT returns `base64UrlToHash(smtProof.id)` (`beacon-strategy.ts:148-158`), the root the member's
+  inclusion (or cooperative non-inclusion) proof was just verified against.
+
+The participant marks the round validated only when the strategy's own result is true **and** the
+announced `signalBytesHex` equals the derived value
+(`packages/aggregation/src/participant/participant.ts:519-528`), and every signing path requires
+that flag (decision 2). Validation now covers both halves of the statement a member needs: this
+data is right, and this data is what gets anchored.
+
+The check lives on the strategy, not inline in each `validateParticipantView`, so the participant
+enforces the binding for **every** beacon type. A custom strategy registered through
+`registerBeaconStrategy` cannot silently reopen the gap by forgetting it, and a strategy with
+nothing to derive from returns `undefined`, which the participant treats as a validation failure.
+A strategy that cannot bind its signal fails closed rather than signing unbound. The derivation
+must come from the validated data, never from the announced signal echoed back out of the message
+body, which would bind the data to itself and authorize anything.
+
+This is a **compile break for any external strategy implementor**: `deriveSignal` is a required
+interface member, so an out-of-tree `AggregateBeaconStrategy` fails to typecheck until it
+implements one. That is deliberate; a silently-optional member would leave the binding to whoever
+remembers it.
+
+### 2. A signable beacon transaction has a fixed shape
+
+`#assertSignableBeaconTx` (`packages/aggregation/src/participant/participant.ts:663-747`) runs on
+both signing paths (`approveNonce` and `approveFallback`) and refuses to sign unless all of the
+following hold:
+
+1. the member validated the distributed data and the announced signal is bound to it (decision 1);
+2. the transaction spends **exactly one** input;
+3. the **last** output's script is byte-for-byte `OP_RETURN OP_PUSHBYTES_32 <validated signal>`;
+4. that output's amount is zero;
+5. it is the transaction's only `OP_RETURN` output;
+6. the sum of the outputs does not exceed the value of the input.
+
+Rule 3 is the load-bearing one and it comes straight from the read path. Because discovery reads
+only the last output (`signal-discovery.ts:140`, `:268`), a signal placed anywhere else announces
+nothing any resolver will ever read, and a member asked to sign such a transaction is being asked
+to authorize a no-op while some other aggregation occupies the position that counts. Pinning the
+exact script bytes also makes "I signed this" and "resolvers will read this" one statement, since
+the required bytes are precisely the shape the extraction routine accepts.
+[ADR 044](044-beacon-change-output-address.md) decision 4 already fixed the signal as the last
+output on the build side; this makes it a signing precondition rather than a builder convention.
+
+Rule 2 is not cosmetic. The protocol conveys a single prevout script and value, which is less than
+a BIP-341 sighash over multiple inputs needs, so a multi-input transaction is one a member can
+neither check nor correctly sign. Refusing it outright replaces a silently wrong sighash with a
+typed error. Rules 4, 5 and 6 keep the transaction to a shape that can confirm and whose implied
+fee is a real number.
+
+These rules are an **interop contract on any coordinator implementation**, not only on ours: a
+coordinator that assembles beacon transactions differently (signal not last, a second data output,
+multiple inputs) will collect no signatures from a conforming member. Our own builder,
+`buildAggregationBeaconTx` (`packages/method/src/core/beacon/beacon.ts`), already emits exactly
+this shape (one input, change first, `OP_RETURN` last at value zero).
+
+### 3. Change destination and fee are not member-checkable; the beacon address already surrendered custody
+
+A member does **not** check where the change goes or how large the fee is. A recommendation
+considered for this code was to require "exactly one change output paying the cohort beacon
+address" plus an input-minus-change figure inside an agreed fee envelope, on the theory that a
+coordinator could otherwise build `[OP_RETURN <valid signal>, <entire balance to itself>]` and
+collect honest signatures for a drainer. **The change-destination half of that prescription is
+rejected. The fee half is accepted in principle and deferred as a follow-up (see below).**
+
+**Why the change-destination rule is refused.** It directly contradicts
+[ADR 044](044-beacon-change-output-address.md) decisions 1 and 5, which made the change destination
+a caller-supplied address defaulting to the beacon address, precisely so that change rotation is
+available as a privacy lever, and which name the operator's funding wallet as the legitimate
+change destination for an operator-funded cohort. That is not an aspiration: it is implemented as
+the `changeAddress` option on `buildAggregationBeaconTx`
+(`packages/method/src/core/beacon/beacon.ts:384-396`). A member has no way to distinguish a
+rotated change address from a drain address, because there is nothing to distinguish: both are
+"an address the funder named that is not the beacon address". The rule would therefore forbid a
+shipped, deliberate design while blocking nothing an attacker cannot do another way.
+
+**The argument that does not work, and must not be repeated.** It is tempting to say the
+coordinator is the funder by construction, so a drain only takes the coordinator's own money.
+Nothing in the code or the protocol establishes that:
+
+- Nothing authenticates who funded the beacon address. `fetchSpendableUtxo`
+  (`packages/method/src/core/beacon/beacon.ts:349-352`) selects whatever spendable UTXO sits at the
+  address; the chain records no notion of a legitimate funder.
+- Anyone can pay a Bitcoin address, and under ADR 044's default the change of each round returns to
+  the beacon address, so a cohort's balance accumulates from whatever sources reached it.
+- Running a coordinator is not privileged. `AggregationService` needs a DID and a public key; any
+  party with a keypair can advertise a cohort.
+- Participant funding is documented, not hypothetical: `packages/method/docs/aggregation.md:752-757`
+  describes a "first-update funding" pattern in which a participant's own transaction funds the
+  beacon address.
+
+**The argument that does work.** The beacon address's script tree has already surrendered custody
+before any transaction is built. The output commits to two script leaves alongside the MuSig2
+internal key ([ADR 042](042-fault-tolerant-beacon-output.md)):
+
+- the CSV recovery leaf, `<recoverySequence> CHECKSEQUENCEVERIFY DROP <recoveryKey> CHECKSIG`
+  (`packages/aggregation/src/core/recovery-policy.ts:183-198`), spendable **unilaterally** by the
+  holder of the recovery key the cohort advert named, once the relative timelock elapses; and
+- the k-of-n fallback leaf (`recovery-policy.ts:154-166`), spendable **immediately** by any k
+  cohort members, with k defaulting to n-1 when the advert does not set it
+  (`recovery-policy.ts:119-128`).
+
+So anyone who funds a cohort beacon address, operator, participant or bystander, has already handed
+the advertised recovery-key holder (after a delay) and any k members (at once) everything at that
+address. A coordinator that drains the UTXO through a signed round removes the timelock delay; it
+does not take anything that was not already exposed by the act of funding. Refusing to sign would
+not protect the funds, because the fallback leaf can spend them without the honest members'
+cooperation in the first place. This is a property of the fault-tolerant output design, and it is
+the thing operators and funders must be told before they send coins to a cohort address: **funding
+a beacon address is trusting the recovery-key holder and any k members with the balance.**
+
+**Residual, stated plainly.** With no fee ceiling, a member will sign a transaction whose fee is
+anything up to the input value minus the outputs. The griefing variant of the attack (burn the
+entire UTXO as fees, announcing nothing of value to anyone) is therefore not structurally refused;
+only the drain-to-an-address variant is genuinely indistinguishable from legitimate change. The
+recommended follow-up is an **absolute fee cap on the participant side**, checked in
+`#assertSignableBeaconTx` against the input value and the analytical vsize the fee model already
+computes ([ADR 045](045-analytical-vsize-aggregation-fees.md)). Unlike the resource guards this
+repository ships off by default ([ADR 059](059-unbounded-beacon-discovery-default.md)), that cap is
+a validity guard on money the member is being asked to help commit, not a tunable resource bound,
+so it belongs **on by default** with a sane ceiling rather than as an opt-in limit.
+
+**The participant-funded gap.** All of the above holds only while the participant-funded model
+remains unreachable. `buildRecoveryLeaves` throws `UNSUPPORTED_FUNDING_MODEL` for
+`participant-funded` (`packages/aggregation/src/core/recovery-policy.ts:226-230`), and that throw
+sits upstream of the only place the MuSig2 key-path tweak is ever set:
+`AggregationCohort.computeBeaconAddress` calls `buildRecoveryLeaves` before assigning `tapTweak`
+(`packages/aggregation/src/core/cohort.ts:244` and `:262`), and that method is what both the
+service (when it finalizes the cohort) and every participant (inside `validateMembership`) call to
+obtain the beacon address. A participant-funded cohort therefore cannot derive an address, cannot
+reach the ready phase, and cannot produce any signature at all. When participant funding is
+implemented, per-participant funds are at stake in a way they are not today, and the change and fee
+envelope must be reconsidered as part of that work: the reasoning above expires with the throw.
+
+### 4. A fallback signature is bound to the optimistic round
+
+A `FALLBACK_AUTHORIZATION_REQUEST` is accepted only when it carries the optimistic round's session
+id and a byte-identical transaction (`packages/aggregation/src/participant/participant.ts:919-922`),
+and `approveFallback` re-asserts the transaction comparison at the signature boundary
+(`#assertMatchesOptimisticTx`, `participant.ts:750-760`). Without it, a coordinator that has already
+collected a member's optimistic partial signature for transaction A can obtain that member's
+script-path signature for a different transaction B, and then holds two competing spends of one
+UTXO: a complete key-path signature for A and a k-of-n script-path witness for B, free to broadcast
+whichever suits it.
+
+The comparison runs **before** the secret-nonce wipe and the phase change, not after. The wipe was
+previously unconditional, so a single unsolicited message from anyone able to reach the member
+destroyed the member's in-flight optimistic round for free. A member that has sent its validation
+but was never sent an authorization request has no optimistic transaction on record and is not held
+to the comparison: it authorizes exactly one transaction either way, and refusing there would break
+the legitimate case the fallback exists for, a member that never heard from the coordinator.
+
+**Known residual: the fallback sighash is not bound to the member's own beacon output.**
+`approveFallback` computes the BIP-341 script-path sighash over the coordinator-supplied
+`req.prevOutScriptHex` (`participant.ts:954` and `:970`) and never compares it to the member's own
+cohort. This is asymmetric with the optimistic path, where a key-path partial signature is computed
+under the member's locally derived `tapTweak` and is worthless against any other output. A fallback
+signature is a plain BIP-340 signature whose only cohort-specific ingredients are the leaf script
+and the asserted prevout, and `buildFallbackLeaf` derives the leaf from the sorted cohort key set
+and k alone (`recovery-policy.ts:162-166`), so two cohorts run by **different services over the same
+member set with the same k have byte-identical fallback leaves**. A service can therefore ask its
+members to fallback-sign a transaction that spends another cohort's UTXO (naming that cohort's
+outpoint, script and value) while anchoring its own signal, and k signatures suffice to complete
+that spend. The fix is one comparison: require the request's `prevOutScriptHex` to equal the output
+script of `state.cohort.beaconAddress`, which the member computed for itself in
+`validateMembership` (`packages/aggregation/src/core/cohort.ts:279-298`) and already holds. It is
+recorded here as a follow-up rather than folded into this change, and it is the highest-value of
+the residuals in this record.
+
+### 5. `receive()` never throws
+
+`AggregationService.receive()` carries an invariant: **no single inbound message, from anyone able
+to reach the service, may fail a cohort.** Every receive handler validates what the message claims
+(membership in the cohort, whether this sender has already answered this round or session, and the
+cryptographic validity of what it carries) **before** it touches cohort or signing state, and
+records a `Rejection` for what it drops instead of letting an underlying invariant throw. The
+invariant is stated on the method rather than delegated to a list of handlers, so it continues to
+hold as handlers are added or extended. Operator-facing action methods (`acceptParticipant`,
+`startSigning` and their siblings) still throw: those report programming errors in the caller, not
+untrusted input, and the runner's catch-all remains as a backstop for genuine internal faults.
+
+Nonce contributions and partial signatures are verified **on arrival** rather than at round
+completion (`packages/aggregation/src/core/signing-session.ts` exposes the checks that nonce
+aggregation and final-signature assembly ran internally). This is what makes a bad contribution
+blame its sender instead of failing the round: the contribution is not stored, so the same sender
+can immediately send a correct one and still complete the round it was blamed in. The cost is that
+a round whose members never send valid contributions now stalls instead of failing fast, which is
+exactly the posture already in place for a silent member and is covered by the existing
+`phaseTimeoutMs`, `cohortTtlMs` and `autoFallbackOnStall` settings.
+
+Because the receive path records a rejection for messages from non-members, the rejection log is
+written by anyone who can reach the service, and it is therefore bounded unconditionally at
+`MAX_RETAINED_REJECTIONS` (`packages/aggregation/src/service/service.ts`). This is not the class of
+limit this repository ships off by default ([ADR 059](059-unbounded-beacon-discovery-default.md)):
+it refuses no protocol traffic, it only discards diagnostics, and what it bounds is memory an
+unauthenticated sender can force the service to hold. Two weaknesses of the current bound are
+accepted for now and recorded:
+
+- it is a module constant, not caller-configurable, unlike the update-size cap declared immediately
+  above it (`maxUpdateSizeBytes`, defaulting to `DEFAULT_MAX_UPDATE_SIZE_BYTES`), which a caller can
+  size to its deployment; and
+- it drops the **oldest** entries with no overflow counter, so a caller that drains lazily loses the
+  first evidence of an attack and cannot tell that anything was lost. A counter, or dropping the
+  newest once full, would preserve the opening of the sequence; neither is implemented here.
+
+## Consequences
+
+- A member's signature now asserts a single connected statement: "the data I validated is the data
+  this transaction anchors, in the position a resolver reads, spending one input I was told about."
+  Coordinator equivocation between distributed data and anchored signal is closed for both built-in
+  beacon types and for any future one, because the binding is enforced by the participant over the
+  strategy interface.
+- `AggregateBeaconStrategy.deriveSignal` is a required member: out-of-tree strategies fail to
+  compile until they implement it. `PendingValidation.matches` is now false in cases it was
+  previously true (validated slot, unbound signal), so the default approve-if-matches policy
+  rejects those rounds, and a custom policy that approves anyway is still refused at the signature
+  boundary. `approveNonce` and `approveFallback` raise typed errors for transactions they previously
+  signed. These ride an `@did-btcr2/aggregation` minor bump under 0.x semantics.
+- Coordinators are constrained: signal last, exactly one data output, one input, no value burned in
+  the signal output, outputs within the input. Multi-input beacon spends are refused outright rather
+  than mis-signed; supporting them later requires the authorization message to carry every prevout
+  script and value, which the signing session's sighash already accepts as arrays.
+- Cohort funding is a custody decision, not merely an operational one. Whoever funds a beacon
+  address trusts the advertised recovery-key holder and any k members with the balance. That should
+  be stated wherever operators are told how to fund a cohort.
+- A cohort can no longer be killed by one message, at the price of stalling instead of failing fast
+  when contributions never arrive; deployments must set the timeout and auto-fallback knobs so
+  stalls terminate in bounded time.
+- Follow-ups this record deliberately leaves open, in priority order: bind the fallback sighash's
+  prevout script to the member's own beacon output (decision 4); add a default-on absolute fee cap
+  on the participant side (decision 3); make the rejection bound configurable and count overflow
+  (decision 5); revisit change and fee validation in full when the participant-funded model is
+  implemented (decision 3).
+
+## Rejected alternatives
+
+- **"Exactly one change output paying the cohort beacon address", plus an input-minus-change fee
+  envelope.** Rejected for the change destination (see decision 3): it contradicts
+  [ADR 044](044-beacon-change-output-address.md) decisions 1 and 5, forbids the shipped change
+  rotation lever and the operator's funding wallet as a destination, and protects funds that the
+  beacon output's own script tree has already surrendered to the recovery-key holder and to any k
+  members. Accepted in principle for the fee ceiling, deferred as a follow-up.
+- **Recomputing the signal inside each strategy's `validateParticipantView`.** Keeps the change
+  local, but leaves the binding optional for every future strategy: an implementor who returns
+  `matches: true` without the comparison silently reopens the equivocation. A separate required
+  member lets the participant, which is the party with something at stake, enforce it once for all
+  beacon types and fail closed when a strategy cannot derive.
+- **Deriving the expected signal from the announced value in the message body.** Trivially
+  self-satisfying: it binds the data to itself and authorizes anything. Called out explicitly in the
+  strategy documentation so an implementor does not reach for it.
+- **Checking only that the signal appears in some output (the previous behavior).** Accepts
+  transactions whose last output announces a different aggregation, which is the equivocation of
+  decision 1 achieved without touching the distributed data at all. The position is part of the
+  announcement, not a formatting detail.
+- **Continuing to fail the cohort on an invalid contribution ("fail fast").** Turns every validation
+  error into a denial of service that any reachable party can trigger, and defeats the
+  blame-and-retry intent already present in the signing session. Stalling plus the existing timeouts
+  is the same posture the protocol already takes for a member that says nothing at all.
+- **Making the rejection-log bound opt-in, consistent with the resource guards this repository
+  defaults to off.** Rejected because the log is written by unauthenticated senders and bounding it
+  refuses no protocol traffic: only diagnostics are discarded. An unbounded log would be a memory
+  exhaustion vector available to anyone who can reach the service.

--- a/docs/adr/090-aggregation-transport-sender-authentication.md
+++ b/docs/adr/090-aggregation-transport-sender-authentication.md
@@ -1,0 +1,309 @@
+---
+title: "ADR 090: Bind a Message's Claimed Sender to Its Authenticated Key on Every Aggregation Receive Path"
+---
+
+# ADR 090: Bind a Message's Claimed Sender to Its Authenticated Key on Every Aggregation Receive Path
+
+**Status:** Accepted
+
+**Date:** 2026-08-19
+
+**Branch / PR:** `fix/critical-high-security-findings`
+
+**References:** [ADR 027](027-aggregation-security-hardening.md), [ADR 028](028-http-transport-additive.md), [ADR 038](038-musig2-key-custody.md), [ADR 046](046-extract-aggregation-package.md), [ADR 050](050-split-aggregation-packages.md), [ADR 062](062-identifier-encoding-hardening.md), [ADR 066](066-x1-transport-authentication.md), [ADR 088](088-read-path-update-authorization.md)
+
+**Relationship to ADR 066:** this ADR **extends** ADR 066; it does not supersede it. Every
+decision 066 records (A through D, D1 through D9) stands unchanged: `capabilityInvocation[0]`
+is still the aggregation communication key, the genesis still rides in-band on the opt-in, the
+server still refuses trust-on-first-use, and the HTTP `POST /v1/messages` bootstrap ordering is
+untouched. What changes is scope. ADR 066 stated the inner-to-outer sender bind as a general
+transport-auth property but implemented it on exactly one route, and it recorded that
+`NostrTransport` "authenticates by event signature, so an `x1` participant already completes a
+cohort." That second claim was too generous: the event signature authenticates the *event*, not
+the DID asserted inside it. This ADR closes that gap and generalizes the rule to every receive
+path on every transport.
+
+## Context
+
+Every aggregation protocol message carries a self-declared `from` DID, and the state machines act
+on that claim rather than on any transport identity. A participant records the service DID an
+advert names and registers the communication key that advert declares
+(`participant/participant-runner.ts:274`). A service seats the DID an opt-in names and registers
+the key it declares (`service/service-runner.ts:675`). Meanwhile each transport authenticates a
+*key*: a nostr event carries a BIP-340 signature that `nostr-tools` verifies before delivery, and
+an HTTP request carries a detached envelope signature that `verifyEnvelope` checks. Nothing joined
+the two on most receive paths, so the party that authenticated and the party the protocol acted on
+could be different people.
+
+Five concrete gaps existed:
+
+1. **`NostrTransport` performed no inbound authentication at all.** Neither
+   `#makeActorEventHandler` (directed, kinds 1 and 1059) nor `#handleBroadcastEvent` (kind 1)
+   compared `message.from` to `event.pubkey`. Anyone who could reach a relay could publish an
+   event whose content claimed any DID.
+2. **`POST /v1/adverts` lacked the bind that `POST /v1/messages` had.** ADR 066 added
+   `401 sender_mismatch` to the messages route only.
+3. **`HttpClientTransport`'s broadcast and inbox dispatch loops** revived, flattened, and
+   dispatched the inner message without comparing its `from` to the authenticated `envelope.from`.
+4. **The advertised-versus-authenticated key cross-check lived only inside the `x1` bootstrap.**
+   ADR 066 decision B says a controller's communication key is a property of its DID; outside the
+   bootstrap nothing enforced that the key a sender advertised was the key it signed with.
+5. **`AggregationParticipant` accepted service-originated messages from any DID.** Handlers
+   looked up the cohort by `cohortId` and proceeded, so a stranger who knew (or guessed, or
+   observed) a cohort id could drive a member's state machine directly.
+
+The sharpest consequence is a confidentiality break, not merely a nuisance. On nostr, a forged
+`COHORT_ADVERT` naming a reputable service DID and carrying the attacker's `communicationPk`
+causes the participant runner to register `serviceDid -> attackerKey`, after which every NIP-44
+message that member sends to "the service" is encrypted to the attacker. The mirror image on the
+service side is slot squatting: a forged opt-in seats a victim DID in a cohort under an
+attacker-held key.
+
+## Decision
+
+### 1. Every receive path binds the claimed sender to the key that authenticated it
+
+**Nostr.** Both receive paths route through `#flattenAndAuthenticate` before dispatch
+(`core/transport/nostr.ts:475` for directed events, `:503` for broadcasts). Flattening happens
+first, because the fields the check consults (`communicationPk`, `genesisDocument`) ride in
+`body` and the handlers downstream read the flat shape; `#dispatchMessage` no longer flattens.
+`#authenticateSender` then requires, in order:
+
+- a non-empty string `from`;
+- that `from` resolves to a key. Resolution consults the peer registry first, then the injected
+  `NostrTransportConfig.resolveSenderPk`, exactly the order the HTTP transports use;
+- that `bytesToHex(senderPk.x) === event.pubkey` (case-normalized), which is the bind itself;
+- that a declared `communicationPk`, when present, is a `Uint8Array` equal to the authenticated
+  key's compressed form. This is ADR 066's step-3 cross-check lifted out of the `x1` bootstrap and
+  applied to every message that advertises a key (adverts and opt-ins). Without it a sender
+  authenticates as itself and still tells the cohort to encrypt to, and attribute keys to,
+  somebody else.
+
+A failure at any step drops the event with a debug log. In particular, **an unresolvable sender is
+dropped, not dispatched**: the transport fails closed. That matches the posture
+`HttpClientTransport.#dispatchBroadcast` has always had for a broadcast from an unresolvable DID,
+so the three transports now agree rather than one of them inventing a policy. The alternative,
+dispatching when the DID cannot be resolved, would leave the whole class open in the default
+configuration, since an attacker only ever needs to claim a DID the victim trusts.
+
+**HTTP client.** Both dispatch loops drop a message whose inner `from` is not `envelope.from`
+(`participant/http-client.ts:337-356` on broadcast, `:386-396` on inbox), and the broadcast loop
+additionally applies the `communicationPk` cross-check.
+
+**HTTP server.** `POST /v1/adverts` gains the `401 sender_mismatch` answer
+(`service/http-server.ts:472-480`), placed after envelope verification, replay, rate limiting, and
+the registered-actor check, and before the advert is cached or relayed. A mismatched advert
+therefore never becomes `#currentAdvert` and never reaches a broadcast subscriber, and an
+unregistered sender is still turned away by `403 not_an_actor` before the bind is even consulted.
+
+### 2. Why binding to `event.pubkey` is sufficient on nostr
+
+A nostr event id is a hash over `pubkey`, `created_at`, `kind`, `tags`, and `content`, and the
+event's BIP-340 signature is over that id. The relay pool verifies it before `onevent` fires, so by
+the time a handler sees an event, `event.pubkey` is an authenticated identity *and* it is
+authenticated over the very content that carries the message's `from` claim. Comparing the two is
+therefore a complete bind: there is no unsigned region an attacker could vary.
+
+This is why nostr needs no second, detached envelope signature of the kind HTTP uses. HTTP has no
+transport-level signature to borrow, so ADR 028 introduced a signed envelope and ADR 066 bound the
+inner message to it. On nostr the transport already supplies the signature, so the fix is a
+comparison rather than a new wire field. The wire format is unchanged, nothing is double-signed,
+and an old publisher's events remain byte-identical to a new one's.
+
+### 3. Why the advert route in particular
+
+An advert is the one message a server relays **verbatim to every broadcast subscriber**, and it is
+the message that bootstraps trust rather than consuming it. It names two things a recipient will
+act on before it has any other source of truth: the service DID a participant will join (which the
+participant's join filter matches against, and which every subsequent `#serviceCohortState` check
+is measured against) and the communication key the participant will encrypt to. An unbound advert
+therefore lets any actor the server relays for advertise a cohort in another DID's name and receive
+the traffic encrypted to itself. Every later authorization decision in that cohort is downstream of
+a lie told once, at the point where nothing yet exists to contradict it. The same reasoning is why
+the nostr broadcast path is authenticated with the same rigor as the directed path.
+
+### 4. The participant state machine holds messages to its cohort's service
+
+Transport authentication is the first line; the state machine refuses to act on a stranger's
+say-so regardless of transport, including the deliberately unauthenticated `InMemoryTransport` and
+any caller driving the machine by hand. `#serviceCohortState` (`participant/participant.ts:289-296`)
+resolves the named cohort and requires `message.from === state.serviceDid`; `COHORT_READY`,
+`DISTRIBUTE_AGGREGATED_DATA`, `AUTHORIZATION_REQUEST`, `AGGREGATED_NONCE`, and
+`FALLBACK_AUTHORIZATION_REQUEST` all route through it. `AGGREGATED_NONCE` additionally requires
+the message to name the signing session the member is actually in
+(`participant/participant.ts:829`), and the fallback request requires the optimistic round's id;
+the service already applied the identical session check to everything it receives, so this makes
+the two sides symmetric.
+
+`COHORT_ADVERT` is deliberately exempt: the advert is what *establishes* the service DID, so there
+is nothing yet to compare it against. Its authenticity is purely a transport property, which is
+precisely why decision 3 above matters.
+
+## Consequences
+
+- The claim a message makes about who sent it is now backed by a key on every receive path of
+  every transport that has one. Forged adverts, slot squatting, service impersonation, and
+  advertised-key substitution are refused at the transport boundary, and service impersonation is
+  refused a second time inside the participant.
+- **Observable behavior changes.** `NostrTransport` drops any event whose message `from` is
+  unresolvable, was not signed by that DID's key, or advertises a `communicationPk` other than the
+  authenticating one. `POST /v1/adverts` answers `401 sender_mismatch`. `HttpClientTransport`
+  silently drops mismatched broadcast and inbox messages. `AggregationParticipant` ignores
+  service-originated messages from any DID other than its cohort's service, and nonce or fallback
+  messages for any session other than the active one.
+- `TransportFactory` forwards `resolveSenderPk`, and `NostrTransportConfigOption` now extends
+  `NostrTransportConfig` rather than restating its fields, so future transport config additions
+  reach the factory automatically.
+- `@did-btcr2/aggregation` takes a minor bump under 0.x semantics: the config field is additive,
+  but the transport refuses traffic it previously dispatched.
+
+### The migration requirement for nostr consumers
+
+`NostrTransportConfig.resolveSenderPk` is **optional and has no default**, and both receive paths
+now authenticate through it. A transport constructed without it can only answer from the peer
+registry, and that registry is bootstrapped by exactly the two messages the new check drops: a
+participant registers the service only after handling an advert
+(`participant/participant-runner.ts:274`), and a service registers a participant only after
+receiving an opt-in (`service/service-runner.ts:675`). The result is a closed loop. An existing
+consumer that upgrades and keeps
+
+```ts
+new NostrTransport({ relays });
+```
+
+finds that its cohorts never form: adverts and opt-ins are dropped, the registry stays empty, and
+the only signal is a debug log. There is no error and no thrown exception.
+
+This is a migration requirement, not a tuning knob. Callers driving did:btcr2 identities must pass
+method's resolver:
+
+```ts
+new NostrTransport({
+  relays,
+  resolveSenderPk : resolveBtcr2SenderPk,
+});
+```
+
+The aggregation package cannot ship that as a default. `resolveBtcr2SenderPk` lives in
+`@did-btcr2/method`, and per ADR 046 and ADR 066 aggregation does not depend on method (it is a
+dev-only dependency for tests). Injecting the resolver is what keeps the transport
+DID-method-agnostic. The in-repo demo scripts under `packages/aggregation/lib/operations/` were
+updated to inject it, and `packages/method/docs/aggregation.md` documents the requirement.
+
+**Follow-up:** emit a one-time warning from the `NostrTransport` constructor when no
+`resolveSenderPk` is supplied, naming the consequence ("only registered peers will be accepted").
+A silent misconfiguration whose only symptom is "nothing ever happens" is the worst failure mode
+this change introduces, and a constructor-time warning costs nothing.
+
+## Residuals
+
+Stated plainly, because each is a live limitation rather than a hypothetical.
+
+### An EXTERNAL (`x1`) service cannot advertise over nostr
+
+`CohortAdvertMessage` carries no `genesisDocument` field
+(`core/messages/factories.ts:25-30`), unlike `CohortOptInMessage`, which does (`:31-38`). An `x1`
+DID commits to a document hash, not a key, so with no genesis in hand `resolveSenderPk` returns
+undefined and the advert is dropped. `x1` *participants* are unaffected: their opt-ins already
+carry the genesis, so they authenticate exactly as ADR 066 intended, on nostr and over HTTP alike.
+The same barrier already existed on the HTTP advert route, where an unresolvable sender has always
+drawn `401 unknown_sender`; this change extends it to nostr.
+
+The out-of-band workaround is `registerPeer(serviceDid, communicationPk)` on the participant side
+before subscribing, which seeds the registry from a channel the operator already trusts. The fix
+direction is to let adverts carry an optional `genesisDocument` the way opt-ins do, at which point
+the existing self-verifying hash check authenticates an `x1` service with zero trust. ADR 066's
+D8 deferred exactly this direction ("client-side bootstrap: a participant authenticating an `x1`
+service"); it is now the blocking item for `x1` service operators rather than a theoretical gap.
+
+### `participantPk` is self-declared and not tied to the sender's DID
+
+The MuSig2 cohort key a member declares in its opt-in is never cross-checked against a key in that
+member's DID document, so a member can seat a key it controls but has not published. Two things
+bound the damage:
+
+- An update signed by a key outside the DID's `capabilityInvocation` relationship fails at
+  resolution (see [ADR 088](088-read-path-update-authorization.md)), and
+  `#verifySubmittedUpdate` pins `proof.verificationMethod.split('#')[0] === sender`
+  (`service/service.ts:667`), so the proof must at least name the sender's own DID. The residue is
+  therefore pollution of the sender's own DID, not impersonation of another controller's.
+- **This is not a rogue-key risk.** The question a reader will ask is whether an unvetted member
+  key lets an attacker cancel the honest members' keys and control the aggregate alone. It does
+  not: cohort keys are combined with BIP-327 key aggregation
+  (`keyAggregate` from `@scure/btc-signer/musig2`, called at `core/cohort.ts:236`), which derives
+  `L = taggedHash('KeyAgg list', ...publicKeys)` and gives each key the coefficient
+  `taggedInt('KeyAgg coefficient', L, pk_i)`. Every coefficient commits to a hash of the full,
+  sorted key list, so an attacker cannot solve for a key that cancels the others: doing so would
+  require choosing a key whose own coefficient is known before the list containing it is fixed.
+  `AggregationCohort.isValidCohortKey` additionally refuses anything that is not a 33-byte
+  compressed curve point before it reaches aggregation.
+
+### The `to` field is not checked against the receiving actor on nostr
+
+On HTTP, `verifyEnvelope(..., { expectedTo })` pins the recipient
+(`core/transport/http/envelope.ts:100`). On nostr, routing relies on NIP-44 encryption (only the
+intended recipient can decrypt a kind 1059 event) and the relay's `#p` tag filter, and the message
+body's `to` is never compared to the actor that received it. In practice the encryption is the
+stronger control, but the asymmetry is real and worth closing for defence in depth.
+
+### There is no replay protection or freshness window on nostr
+
+The nostr path has no event-id cache, no `created_at` bound, and the directed subscription
+deliberately carries no `since` filter so that messages survive a reconnect or crash recovery
+(`core/transport/nostr.ts:424`). An authenticated peer can therefore re-publish, and a relay can
+re-deliver, any event it has seen. Two things make that acceptable today:
+
+- `cohortId` and `sessionId` are random UUIDs (`core/cohort.ts:142`,
+  `core/signing-session.ts:72`) carried inside the event-signed body, so a captured message cannot
+  be retargeted at a different cohort or a different signing session without breaking the event
+  signature. Replay is confined to the exact context the message was minted for.
+- Within that context, the phase guards and duplicate guards in both state machines absorb it: a
+  message arriving out of phase is dropped, and a second response from the same member in the same
+  round is rejected as a duplicate.
+
+The follow-up is an explicit staleness window: reject events older than a configurable bound and
+keep a bounded seen-event-id cache, the nostr analogue of the HTTP transport's nonce cache and
+clock-skew check. That is a behavior change for reconnect semantics, which is why it is a
+follow-up rather than part of this change.
+
+### The HTTP server does not cross-check `communicationPk` on the non-bootstrap opt-in path
+
+Only `#bootstrapSenderPk` applies the check. A `k1` controller can therefore still advertise a
+communication key other than its DID key over HTTP, which ADR 066 decision B says it should not.
+The declared key is still bound to the authenticated sender's DID by `sender_mismatch`, so nobody
+else's traffic is affected. Closing it is a small addition to `#handleMessagesPost`, deliberately
+left out here because it changes a path that currently succeeds.
+
+### `InMemoryTransport` still performs no inbound authentication
+
+It is an in-process harness whose entire purpose is delivering hand-built messages, and every
+existing spec depends on that. The participant-side state-machine checks (decision 4) are what
+make it acceptable to leave alone.
+
+## Rejected alternatives
+
+- **Dispatch when the sender is unresolvable, and only log.** Backwards-compatible for nostr
+  consumers, and it would have avoided the migration requirement entirely. Rejected: an attacker
+  only ever needs to claim a DID the victim trusts, so a transport that dispatches unresolvable
+  senders leaves the entire class open in the default configuration. Fail-closed with a documented
+  migration is the honest trade.
+- **Ship a default did:btcr2 resolver inside `@did-btcr2/aggregation`.** Would make the upgrade
+  seamless. Rejected: it inverts the package boundary set by ADR 046 and reaffirmed by ADR 066, by
+  making the aggregation package depend on `@did-btcr2/method`. The transport is meant to know
+  nothing about did:btcr2 beyond "the caller injects a resolver."
+- **Add a detached envelope signature to nostr messages, mirroring HTTP.** Uniform across
+  transports and would let one verification routine serve both. Rejected: the nostr event
+  signature already covers the full content, so a second signature authenticates nothing new,
+  changes the wire format, and forces every publisher to double-sign.
+- **Trust the peer registry alone and skip the injected resolver.** Simplest possible transport
+  change. Rejected: the registry is bootstrapped by precisely the two message types that need
+  authenticating (advert and opt-in), so registry-only authentication can never accept a first
+  contact and the protocol cannot start.
+- **Enforce the bind only in the state machines, leaving the transports as they were.** Attractive
+  because it is one place instead of four. Rejected: the confidentiality break happens in the
+  runner, before the state machine sees anything, when it registers the advert's declared key for
+  encryption. A check downstream of that registration is already too late.
+- **Reject a message whose `communicationPk` differs, only for adverts.** Rejected as arbitrary:
+  the opt-in declares a key the service will encrypt to and attribute cohort membership by, so the
+  same reasoning applies with the same force. The rule is stated once, for any message that
+  advertises a key.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -69,6 +69,7 @@ children:
   - ./066-x1-transport-authentication.md
   - ./067-resolver-duplicate-confirmation.md
   - ./068-resolver-versiontime-duplicate-order.md
+  - ./086-beacon-signal-recognition.md
 ---
 
 # Architecture Decision Records
@@ -162,3 +163,8 @@ Each ADR captures one significant architectural decision: the context, the alter
 | 083 | 2026-07-14 | [A btcr2 quickstart Command that Composes Onboarding into One Step](083-cli-quickstart.md) |
 | 084 | 2026-07-16 | [Publish the Coverage Badge from CI to a Dedicated Branch](084-ci-published-coverage-badge.md) |
 | 085 | 2026-07-17 | [Typed Errors Across Core Packages, Enforced by Lint](085-typed-error-policy.md) |
+| 086 | 2026-08-19 | [Beacon Signal Recognition - Decode the Serialized Script and Require a Beacon Spend](086-beacon-signal-recognition.md) |
+| 087 | 2026-08-19 | [The Bitcoin RPC Password Has No Command-Line Flag](087-bitcoin-rpc-password-channels.md) |
+| 088 | 2026-08-19 | [Enforce capabilityInvocation Membership When Resolution Applies an Update](088-read-path-update-authorization.md) |
+| 089 | 2026-08-19 | [Aggregation Signing Preconditions for Cohort Members](089-aggregation-signing-preconditions.md) |
+| 090 | 2026-08-19 | [Bind a Message's Claimed Sender to Its Authenticated Key on Every Aggregation Receive Path](090-aggregation-transport-sender-authentication.md) |

--- a/packages/aggregation/CHANGELOG.md
+++ b/packages/aggregation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @did-btcr2/aggregation
 
+## 0.6.0
+
+### Minor Changes
+
+- Bind every member signature to the data it validated, authenticate a message's claimed sender, and keep one bad message from failing the cohort (ADRs 089, 090).
+
+  - **BREAKING:** `AggregateBeaconStrategy` requires a `deriveSignal(result)` member, which recomputes the 32-byte signal from the data just validated (SHA-256 of the canonicalized CAS map, or the SMT root the member's proof was checked against). A participant approves only when the announced `signalBytesHex` equals it, so a coordinator can no longer distribute data that validates while anchoring a signal derived from different data, for instance a CAS map that omits the member. A strategy with nothing to derive from fails closed. Custom strategies must implement it.
+  - **BREAKING:** a participant refuses to sign a beacon transaction unless the cohort data validated and the transaction spends exactly one input, carries exactly one OP_RETURN, places `OP_RETURN OP_PUSHBYTES_32 <validated signal>` in its last output (the only output resolution reads), burns nothing in that output, and spends no more than the input holds. A fallback request must additionally carry the optimistic round's session id and its exact transaction, or the member hands the coordinator two competing spends of one UTXO. New typed failures: `UNVALIDATED_DATA`, `INVALID_TX_STRUCTURE`, `INVALID_PREVOUT_VALUE`, `TX_MISMATCH`.
+  - **BREAKING:** `NostrTransport` binds a message's self-declared `from` DID to the key that signed the event carrying it, and drops the event when they disagree or when the DID resolves to no key at all. Fail-closed: a transport built without the new `NostrTransportConfig.resolveSenderPk` receives only messages from peers registered through `registerPeer()`, and because that registry is bootstrapped by the advert and opt-in messages that are now dropped, a cohort will not form. Pass `resolveBtcr2SenderPk` from `@did-btcr2/method`; `TransportFactory` forwards it.
+  - **BREAKING:** both HTTP transports bind the inner message's `from` to the authenticated envelope sender, and the server answers a mismatched advert with `401 sender_mismatch`. An advert is relayed verbatim to every subscriber and names the service DID a participant will join and the key it will encrypt to, so an unbound one lets any actor advertise a cohort in another DID's name.
+  - **BREAKING:** a participant acts on a service-originated message (`COHORT_READY`, `DISTRIBUTE_AGGREGATED_DATA`, `AGGREGATED_NONCE`, `AUTHORIZATION_REQUEST`, `FALLBACK_AUTHORIZATION_REQUEST`) only when `from` is that cohort's service DID, and on an aggregated nonce only when it names the session the member is in. `COHORT_ADVERT` is exempt: it is what establishes the service DID.
+  - **BREAKING:** `RejectionReason` gains `NOT_A_MEMBER`, `DUPLICATE_RESPONSE`, `INVALID_NONCE`, `INVALID_PARTIAL_SIG`, and `INVALID_PARTICIPANT_KEY`, and the double-submit and double-decline drops are recoded from `UPDATE_MALFORMED` to `DUPLICATE_RESPONSE`. Consumers switching exhaustively on the union, or matching the old codes, need updating.
+  - Added `AggregationCohort.isValidCohortKey`, plus `BeaconSigningSession.isValidNonceContribution` and `verifyPartialSignature`: the checks that previously ran at cohort formation or round completion, hoisted so a receive path can apply them on arrival and blame the sender instead of the cohort.
+  - Added `MAX_RETAINED_REJECTIONS` (256). The rejection log is written by anyone able to reach the service, so it is bounded for callers driving the state machine without draining it. Only diagnostics are dropped, never protocol traffic.
+  - `AggregationService.receive()` no longer throws for any inbound message. Non-members, duplicate responses, unserializable update bodies, a non-string `proof.verificationMethod`, malformed nonces, invalid partial signatures, and opt-in keys that are not well-formed compressed secp256k1 points are recorded as rejections. Each of those was previously one message, from anyone able to reach the service, that failed the whole cohort.
+  - `acceptParticipant` validates the opt-in key before it mutates cohort state, so a refusal can no longer leave a DID in `participants` with no key in the aggregate, which made the signing round permanently uncompletable.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.10.0
+  - @did-btcr2/common@9.3.0
+  - @did-btcr2/cryptosuite@10.0.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/aggregation/lib/operations/aggregation/aggregation-participant.ts
+++ b/packages/aggregation/lib/operations/aggregation/aggregation-participant.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * Aggregation Participant - Standalone Process (Runner API)
  *
@@ -36,7 +36,7 @@ if(!SECRET_KEY) {
 const myKeys = SchnorrKeyPair.fromSecret(SECRET_KEY);
 const myDid = DidBtcr2.create(myKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
-const transport = new NostrTransport({ relays: [RELAY] });
+const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 transport.registerActor(myDid, myKeys);
 transport.start();
 

--- a/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
+++ b/packages/aggregation/lib/operations/aggregation/aggregation-service.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2 } from '@did-btcr2/method';
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * Aggregation Service - Standalone Process (Runner API)
  *
@@ -29,7 +29,7 @@ const MIN_PARTICIPANTS = Number(process.env.MIN_PARTICIPANTS ?? '2');
 const serviceKeys = SchnorrKeyPair.fromSecret('cbd42da155c70d5a8806a1f68bfb802097e152f28230990d8e3c979e78e52d1d');
 const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
-const transport = new NostrTransport({ relays: [RELAY] });
+const transport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 transport.registerActor(serviceDid, serviceKeys);
 transport.start();
 

--- a/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-nostr-transport.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, Identifier, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * E2E Demo: Per-Actor Nostr Transports (Runner API)
  *
@@ -58,9 +58,9 @@ const bobGenesis: Record<string, unknown> = {
 };
 const bobDid = DidBtcr2.create(GenesisDocument.toGenesisBytes(bobGenesis), { idType: 'EXTERNAL', network: 'mutinynet' });
 
-const serviceTransport = new NostrTransport({ relays: [RELAY] });
-const aliceTransport = new NostrTransport({ relays: [RELAY] });
-const bobTransport = new NostrTransport({ relays: [RELAY] });
+const serviceTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
+const aliceTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
+const bobTransport = new NostrTransport({ relays: [RELAY], resolveSenderPk: resolveBtcr2SenderPk });
 
 serviceTransport.registerActor(serviceDid, serviceKeys);
 aliceTransport.registerActor(aliceDid, aliceKeys);

--- a/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
+++ b/packages/aggregation/lib/operations/aggregation/e2e-verify-signing.ts
@@ -1,4 +1,4 @@
-import { DidBtcr2, Resolver, Updater } from '@did-btcr2/method';
+import { DidBtcr2, Resolver, Updater, resolveBtcr2SenderPk } from '@did-btcr2/method';
 /**
  * E2E Check: End-to-end MuSig2 signing over a real Nostr relay, with
  * cryptographic verification of the aggregated signature against the
@@ -50,9 +50,9 @@ const bobKeys = SchnorrKeyPair.generate();
 const bobDid = DidBtcr2.create(bobKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
 
 // ── Transports (one per actor, same relay) ──
-const serviceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
-const aliceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
-const bobTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER });
+const serviceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
+const aliceTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
+const bobTransport = new NostrTransport({ relays: [RELAY], logger: SILENT_LOGGER, resolveSenderPk: resolveBtcr2SenderPk });
 
 serviceTransport.registerActor(serviceDid, serviceKeys);
 aliceTransport.registerActor(aliceDid, aliceKeys);

--- a/packages/aggregation/package.json
+++ b/packages/aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/aggregation",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Multi-party coordination for did:btcr2 aggregate beacons: sans-I/O AggregationService and AggregationParticipant state machines, MuSig2 (BIP-327) signing sessions, cohort conditions, and pluggable transports (Nostr, HTTP, in-memory).",
   "main": "./dist/cjs/index.js",

--- a/packages/aggregation/src/core/beacon-strategy.ts
+++ b/packages/aggregation/src/core/beacon-strategy.ts
@@ -1,4 +1,4 @@
-import { canonicalize } from '@did-btcr2/common';
+import { canonicalize, hash } from '@did-btcr2/common';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof } from '@did-btcr2/smt';
 import { base64UrlToHash, blockHash, didToIndex, hashToBase64Url, verifySerializedProof } from '@did-btcr2/smt';
@@ -56,6 +56,20 @@ export interface AggregateBeaconStrategy {
     expectedHash?: string;
     body: BaseBody;
   }): BeaconValidationResult;
+
+  /**
+   * Participant: recompute the 32-byte beacon signal from the data just
+   * validated, exactly as the service derives it on the cohort. The caller
+   * requires the announced `signalBytesHex` to equal this value before the
+   * member approves, so a coordinator cannot distribute data that validates
+   * while anchoring a signal derived from different data (for instance a CAS
+   * map that omits the member, or another SMT root).
+   *
+   * Returns undefined when the validated result carries nothing to derive from;
+   * the caller treats that as a validation failure, so a strategy that cannot
+   * bind its signal fails closed rather than signing unbound.
+   */
+  deriveSignal(result: BeaconValidationResult): Uint8Array | undefined;
 }
 
 const CAS_STRATEGY: AggregateBeaconStrategy = {
@@ -80,6 +94,13 @@ const CAS_STRATEGY: AggregateBeaconStrategy = {
       matches : casAnnouncement[participantDid] === expectedHash,
       casAnnouncement,
     };
+  },
+
+  // Same derivation the cohort uses to set signalBytes (see
+  // AggregationCohort.buildCASAnnouncement): SHA-256 of the canonicalized map.
+  deriveSignal({ casAnnouncement }) {
+    if(!casAnnouncement) return undefined;
+    return hash(canonicalize(casAnnouncement));
   },
 };
 
@@ -122,6 +143,18 @@ const SMT_STRATEGY: AggregateBeaconStrategy = {
       matches : verifySerializedProof(smtProof, index, candidateHash),
       smtProof,
     };
+  },
+
+  // The signal is the SMT root, which is the very root `verifySerializedProof`
+  // checked the member's leaf against (the proof's `id`). Binding to it makes
+  // "my proof is valid" and "my root is what gets anchored" one statement.
+  deriveSignal({ smtProof }) {
+    if(!smtProof?.id) return undefined;
+    try {
+      return base64UrlToHash(smtProof.id);
+    } catch {
+      return undefined;
+    }
   },
 };
 

--- a/packages/aggregation/src/core/cohort.ts
+++ b/packages/aggregation/src/core/cohort.ts
@@ -3,7 +3,7 @@ import { canonicalHash, canonicalize, hash } from '@did-btcr2/common';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof, TreeEntry } from '@did-btcr2/smt';
 import { BTCR2MerkleTree } from '@did-btcr2/smt';
-import { schnorr } from '@noble/curves/secp256k1.js';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { concatBytes, hexToBytes, randomBytes } from '@noble/hashes/utils';
 import { p2tr } from '@scure/btc-signer';
 import { keyAggExport, keyAggregate, sortKeys } from '@scure/btc-signer/musig2';
@@ -152,12 +152,48 @@ export class AggregationCohort {
     this.fallbackThreshold = fallbackThreshold;
   }
 
+  /**
+   * True when `key` is a member key this cohort can carry: exactly 33 bytes and
+   * an actual secp256k1 curve point in compressed form.
+   *
+   * The MuSig2 primitives are strict but late. `sortKeys` insists on 33 bytes
+   * and raises a bare length error; a 33-byte value that is not a point clears
+   * sorting and is only caught by `keyAggregate` when the beacon address is
+   * computed, further still from the message that introduced the key. Callers
+   * taking a key from an untrusted sender check here when it arrives and drop
+   * the message instead.
+   */
+  public static isValidCohortKey(key: unknown): key is Uint8Array {
+    return key instanceof Uint8Array
+      && key.length === 33
+      && secp256k1.utils.isValidPublicKey(key);
+  }
+
   /** Sorted cohort keys (sorted on assignment per BIP-327). */
   get cohortKeys(): Array<Uint8Array> {
     return this.#cohortKeys;
   }
 
+  /**
+   * Sorts and stores the cohort keys, refusing any that is not a compressed
+   * secp256k1 point. This is the single choke point every key reaches before
+   * key aggregation, so validating here keeps a malformed key from turning into
+   * a library error deep inside address computation or signing. The assignment
+   * is all-or-nothing: a refused array leaves the previous keys in place.
+   *
+   * Cost is one point decode per key per assignment, so building a cohort one
+   * member at a time is quadratic in cohort size; bound the cohort with the
+   * `maxParticipants` condition when opt-ins are unmetered.
+   */
   set cohortKeys(keys: Array<Uint8Array>) {
+    keys.forEach((key, index) => {
+      if(!AggregationCohort.isValidCohortKey(key)) {
+        throw new AggregationCohortError(
+          `Cohort key at index ${index} is not a 33-byte compressed secp256k1 public key.`,
+          'INVALID_COHORT_KEY', { cohortId: this.id, index }
+        );
+      }
+    });
     this.#cohortKeys = sortKeys(keys);
   }
 

--- a/packages/aggregation/src/core/messages/bodies.ts
+++ b/packages/aggregation/src/core/messages/bodies.ts
@@ -244,6 +244,18 @@ export function isCohortAdvertMessage(m: BaseMessage): m is CohortAdvertMessage 
     && hasBytes(m.body, 'communicationPk');
 }
 
+/**
+ * Wire shape only: the keys are checked for being bytes, not for being
+ * secp256k1 points. Curve validity is deliberately not a guard's business, in
+ * line with {@link isNonceContributionMessage} (a nonce's points are checked by
+ * `BeaconSigningSession.isValidNonceContribution` at the receive path). A guard
+ * that folded the two together would leave a caller unable to tell "not an
+ * opt-in" from "an opt-in carrying an unusable key", which is exactly the
+ * distinction the handler needs to blame the sender; it would also put curve
+ * arithmetic behind a narrowing check callers reasonably assume is cheap.
+ * `AggregationService` validates the keys on arrival, and
+ * `AggregationCohort.isValidCohortKey` is the shared check.
+ */
 export function isCohortOptInMessage(m: BaseMessage): m is CohortOptInMessage {
   return m.type === COHORT_OPT_IN
     && hasStr(m.body, 'cohortId')

--- a/packages/aggregation/src/core/signing-session.ts
+++ b/packages/aggregation/src/core/signing-session.ts
@@ -127,6 +127,28 @@ export class BeaconSigningSession {
     }
   }
 
+  /**
+   * True when `nonceContribution` is a well-formed MuSig2 public nonce: 66 bytes
+   * carrying two valid, non-infinity secp256k1 points.
+   *
+   * {@link generateAggregatedNonce} throws on anything else, and it runs long
+   * after the contribution arrived, so a receive path that stores an unchecked
+   * nonce turns one inbound message into a cohort-wide failure. Callers driving
+   * the session from untrusted input validate here first and drop the message
+   * instead.
+   */
+  public static isValidNonceContribution(nonceContribution: Uint8Array): boolean {
+    try {
+      // Aggregating the single contribution is the validity check itself: it
+      // decodes both points and rejects infinity, exactly as the real
+      // aggregation will.
+      musig2.nonceAggregate([nonceContribution]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   public generateAggregatedNonce(): Uint8Array {
     if(this.phase !== SigningSessionPhase.NonceContributionsReceived) {
       throw new SigningSessionError(
@@ -175,33 +197,14 @@ export class BeaconSigningSession {
     if(!this.aggregatedNonce) {
       throw new SigningSessionError('Aggregated nonce missing.', 'MISSING_AGGREGATED_NONCE');
     }
-    const session = new musig2.Session(
-      this.aggregatedNonce,
-      this.cohort.cohortKeys,
-      this.sigHash,
-      [this.cohort.tapTweak],
-      [true]
-    );
+    const session = this.#musig2Session(this.aggregatedNonce);
 
     // Pre-verify each partial signature against the signer's public key before
     // aggregating (BIP-327 §2.3.5). Delegating verification to partialSigAgg
     // alone makes it impossible to attribute a bad contribution; pinpointing
     // the offending participant lets the service blame and retry without the
     // whole cohort.
-    //
-    // partialSigVerify(partialSig, pubNonces, i) needs pubNonces ordered to
-    // match cohort.cohortKeys, and `i` is the signer's position in that array.
-    const pubNoncesByIndex: Uint8Array[] = new Array(this.cohort.cohortKeys.length);
-    for(const [did, nonce] of this.nonceContributions) {
-      const idx = this.cohort.indexOfParticipant(did);
-      if(idx < 0) {
-        throw new SigningSessionError(
-          `Cannot verify nonce from ${did}: participant key missing from cohort.`,
-          'UNKNOWN_PARTICIPANT_KEY', { participantDid: did }
-        );
-      }
-      pubNoncesByIndex[idx] = nonce;
-    }
+    const pubNoncesByIndex = this.#pubNoncesByIndex();
 
     for(const [did, partialSig] of this.partialSignatures) {
       const idx = this.cohort.indexOfParticipant(did);
@@ -223,6 +226,68 @@ export class BeaconSigningSession {
     this.signature = session.partialSigAgg([...this.partialSignatures.values()]);
     this.phase = SigningSessionPhase.Complete;
     return this.signature;
+  }
+
+  /**
+   * True when `partialSig` is a valid MuSig2 partial signature from
+   * `participantDid` for this session's aggregated nonce and sighash.
+   *
+   * The same check {@link generateFinalSignature} runs before aggregating, hoisted
+   * so a caller can apply it when the contribution arrives rather than when the
+   * round completes: a bad partial signature stored now is a `BAD_PARTIAL_SIG`
+   * throw later, by which point one member's message has failed the whole cohort.
+   * Never throws - an unknown signer, a missing nonce, or malformed bytes are all
+   * `false`.
+   *
+   * Cost is one key aggregation over the cohort keys plus one verification, so it
+   * is linear in cohort size per call; cap the cohort with the `maxParticipants`
+   * condition if inbound signature messages are unmetered.
+   */
+  public verifyPartialSignature(participantDid: string, partialSig: Uint8Array): boolean {
+    try {
+      if(!this.aggregatedNonce) return false;
+      const index = this.cohort.indexOfParticipant(participantDid);
+      if(index < 0) return false;
+      return this.#musig2Session(this.aggregatedNonce)
+        .partialSigVerify(partialSig, this.#pubNoncesByIndex(), index);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Build the MuSig2 session for this round. Deliberately rebuilt per call: the
+   * sighash is recomputed from the live transaction every time, so a session is
+   * never verified or aggregated against a stale message.
+   */
+  #musig2Session(aggregatedNonce: Uint8Array): musig2.Session {
+    return new musig2.Session(
+      aggregatedNonce,
+      this.cohort.cohortKeys,
+      this.sigHash,
+      [this.cohort.tapTweak],
+      [true]
+    );
+  }
+
+  /**
+   * Public nonces ordered to match `cohort.cohortKeys`, the layout
+   * `partialSigVerify(partialSig, pubNonces, i)` indexes with the signer's
+   * position `i`.
+   */
+  #pubNoncesByIndex(): Uint8Array[] {
+    const pubNoncesByIndex: Uint8Array[] = new Array(this.cohort.cohortKeys.length);
+    for(const [did, nonce] of this.nonceContributions) {
+      const idx = this.cohort.indexOfParticipant(did);
+      if(idx < 0) {
+        throw new SigningSessionError(
+          `Cannot verify nonce from ${did}: participant key missing from cohort.`,
+          'UNKNOWN_PARTICIPANT_KEY', { participantDid: did }
+        );
+      }
+      pubNoncesByIndex[idx] = nonce;
+    }
+    return pubNoncesByIndex;
   }
 
   /**
@@ -253,13 +318,7 @@ export class BeaconSigningSession {
     if(!this.#secretNonce) {
       throw new SigningSessionError('Secret nonce not available - generateNonceContribution() must be called first.', 'MISSING_SECRET_NONCE');
     }
-    const session = new musig2.Session(
-      this.aggregatedNonce,
-      this.cohort.cohortKeys,
-      this.sigHash,
-      [this.cohort.tapTweak],
-      [true]
-    );
+    const session = this.#musig2Session(this.aggregatedNonce);
     try {
       return session.sign(this.#secretNonce, participantSecretKey);
     } finally {

--- a/packages/aggregation/src/core/transport/nostr.ts
+++ b/packages/aggregation/src/core/transport/nostr.ts
@@ -1,6 +1,7 @@
 import type { Did } from '@did-btcr2/common';
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { equalBytes } from '@noble/curves/utils.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import type { SubCloser } from 'nostr-tools/abstract-pool';
 import type { Event, EventTemplate} from 'nostr-tools';
@@ -42,6 +43,22 @@ export interface NostrTransportConfig {
    * {@link DEFAULT_BROADCAST_LOOKBACK_MS} (5 minutes).
    */
   broadcastLookbackMs?: number;
+  /**
+   * Resolve a sender's communication public key from its DID when the sender is not a
+   * registered peer. Lets the transport stay DID-method-agnostic: the caller supplies
+   * the decode (for example, a did:btcr2 KEY identifier yields its genesis key). The
+   * optional `genesisDocument` lets an EXTERNAL (`x1`) sender be authenticated from the
+   * self-verifying genesis it carries on a bootstrap opt-in, and is the same signature
+   * the HTTP transports take, so one injected resolver serves all three.
+   *
+   * Inbound authentication depends on it: a message whose `from` resolves to no key is
+   * dropped (see {@link NostrTransport}), so a transport constructed without it receives
+   * only messages from already-registered peers.
+   */
+  resolveSenderPk?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 }
 
 /** Default `since` lookback for broadcast (COHORT_ADVERT) subscriptions: 5 minutes. */
@@ -68,6 +85,13 @@ interface ActorEntry {
  * - Update messages (SUBMIT_UPDATE, DISTRIBUTE_AGGREGATED_DATA, VALIDATION_ACK) to kind 1059 (NIP-44 encrypted)
  * - Sign messages to kind 1059 (NIP-44 encrypted)
  *
+ * Inbound authentication: every event delivered by the relay pool carries a BIP-340
+ * signature over its content, verified by `nostr-tools` before it reaches a handler here,
+ * so `event.pubkey` is an authenticated identity. The aggregation message inside it
+ * declares its own `from` DID, which the protocol acts on. The transport binds the two
+ * ({@link #authenticateSender}) and drops any event where they disagree or where the
+ * claimed DID cannot be resolved to a key at all.
+ *
  * @class NostrTransport
  * @implements {Transport}
  */
@@ -81,11 +105,16 @@ export class NostrTransport implements Transport {
   #started = false;
   #logger: Logger;
   #broadcastLookbackMs: number;
+  readonly #resolveSenderPkFn?: (
+    did: string,
+    opts?: { genesisDocument?: object },
+  ) => CompressedSecp256k1PublicKey | undefined;
 
   constructor(config?: NostrTransportConfig) {
     this.#relays = config?.relays ?? DEFAULT_NOSTR_RELAYS;
     this.#logger = config?.logger ?? CONSOLE_LOGGER;
     this.#broadcastLookbackMs = config?.broadcastLookbackMs ?? DEFAULT_BROADCAST_LOOKBACK_MS;
+    this.#resolveSenderPkFn = config?.resolveSenderPk;
   }
 
   /**
@@ -443,7 +472,10 @@ export class NostrTransport implements Transport {
         return;
       }
 
-      this.#dispatchMessage(message, actor);
+      const flat = this.#flattenAndAuthenticate(message, event);
+      if(!flat) return;
+
+      this.#dispatchMessage(flat, actor);
     };
   }
 
@@ -460,17 +492,16 @@ export class NostrTransport implements Transport {
   async #handleBroadcastEvent(event: Event): Promise<void> {
     if(event.kind !== 1) return;
 
-    let message: Record<string, unknown>;
+    let parsed: Record<string, unknown>;
     try {
-      message = JSON.parse(event.content, NostrTransport.#jsonReviver);
+      parsed = JSON.parse(event.content, NostrTransport.#jsonReviver);
     } catch(err) {
       this.#logger.debug(`Failed to parse broadcast event ${event.id}:`, err);
       return;
     }
 
-    if(message.body && typeof message.body === 'object') {
-      message = { ...message, ...(message.body as Record<string, unknown>) };
-    }
+    const message = this.#flattenAndAuthenticate(parsed, event);
+    if(!message) return;
 
     const messageType = message.type as string;
     if(!messageType || !isAggregationMessageType(messageType)) return;
@@ -483,22 +514,112 @@ export class NostrTransport implements Transport {
   }
 
   /**
-   * Dispatches a parsed message to the appropriate handler of a registered actor based on message type.
-   * The message is expected to have already been parsed from the Nostr event content and validated as
-   * an aggregation message. If the message has a body, its properties are merged into the top-level
-   * message object for easier handler access. The message is then dispatched to the handler registered
-   * for its type, if one exists.
-   * @param {Record<string, unknown>} message - The message object parsed from a Nostr event, expected to
+   * Flatten a parsed event payload and bind its self-declared sender to the event's
+   * signing key. Returns the flattened message when it authenticates, `undefined` when
+   * the caller must drop it.
+   *
+   * Flattening happens first because the fields the binding consults (`communicationPk`,
+   * `genesisDocument`) ride in `body`, and the handlers downstream read the flat shape.
+   * @param {Record<string, unknown>} message The parsed (unflattened) event payload.
+   * @param {Event} event The Nostr event that carried it.
+   * @returns {Record<string, unknown> | undefined} The authenticated flat message, or undefined.
+   */
+  #flattenAndAuthenticate(message: Record<string, unknown>, event: Event): Record<string, unknown> | undefined {
+    const flat = (message.body && typeof message.body === 'object')
+      ? { ...message, ...(message.body as Record<string, unknown>) }
+      : message;
+    return this.#authenticateSender(flat, event) ? flat : undefined;
+  }
+
+  /**
+   * Bind a message's self-declared `from` DID to the key that signed the Nostr event
+   * carrying it.
+   *
+   * `nostr-tools` verifies the event signature before delivery, so `event.pubkey` is an
+   * authenticated key; `message.from` is an unauthenticated claim that the protocol acts
+   * on (the participant records the service DID an advert names and encrypts to the key
+   * it declares; the service seats the DID an opt-in names). Without this bind anyone can
+   * publish an event claiming to be any DID.
+   *
+   * Fails closed: a DID this transport cannot resolve to a key is dropped rather than
+   * dispatched, matching {@link HttpClientTransport}'s existing posture for a broadcast
+   * from an unresolvable DID. Registered peers resolve from the peer registry; everyone
+   * else needs the injected {@link NostrTransportConfig.resolveSenderPk}.
+   *
+   * When the message advertises a `communicationPk` (a cohort advert or an opt-in), it
+   * must be the key that just authenticated. Otherwise a sender could authenticate as
+   * itself and have the cohort encrypt to, and attribute keys to, a different key
+   * (the same cross-check the HTTP server applies when bootstrapping an `x1` opt-in).
+   * @param {Record<string, unknown>} message The flattened message claiming a sender.
+   * @param {Event} event The Nostr event that carried it.
+   * @returns {boolean} True when the claim is bound to the event's signing key.
+   */
+  #authenticateSender(message: Record<string, unknown>, event: Event): boolean {
+    const from = message.from;
+    if(typeof from !== 'string' || from.length === 0) {
+      this.#logger.debug(`Dropping event ${event.id}: message declares no sender DID`);
+      return false;
+    }
+
+    const genesisDocument = message.genesisDocument;
+    const senderPk = this.#resolveSenderPk(
+      from,
+      genesisDocument && typeof genesisDocument === 'object'
+        ? { genesisDocument: genesisDocument as object }
+        : undefined,
+    );
+    if(!senderPk) {
+      this.#logger.debug(`Dropping event ${event.id}: cannot resolve a key for sender ${from}`);
+      return false;
+    }
+
+    if(bytesToHex(senderPk.x) !== event.pubkey.toLowerCase()) {
+      this.#logger.debug(`Dropping event ${event.id}: ${from} did not sign it`);
+      return false;
+    }
+
+    const communicationPk = message.communicationPk;
+    if(communicationPk !== undefined) {
+      if(!(communicationPk instanceof Uint8Array) || !equalBytes(communicationPk, senderPk.compressed)) {
+        this.#logger.debug(`Dropping event ${event.id}: ${from} advertises a key it did not authenticate with`);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Resolve a sender's communication public key: a registered peer's key first, then the
+   * injected DID resolver. Mirrors the HTTP transports' resolution order.
+   * @param {string} did The sender's DID.
+   * @param {object} [opts] Optional resolution inputs (an `x1` sender's genesis document).
+   * @returns {CompressedSecp256k1PublicKey | undefined} The key, or undefined if unresolvable.
+   */
+  #resolveSenderPk(
+    did: string,
+    opts?: { genesisDocument?: object },
+  ): CompressedSecp256k1PublicKey | undefined {
+    const peerBytes = this.#peerRegistry.get(did);
+    if(peerBytes) {
+      try { return new CompressedSecp256k1PublicKey(peerBytes); }
+      catch { /* fall through to the injected resolver */ }
+    }
+    return this.#resolveSenderPkFn?.(did, opts);
+  }
+
+  /**
+   * Dispatches a message to the appropriate handler of a registered actor based on message type.
+   * The message is expected to have already been parsed from the Nostr event content, flattened,
+   * and authenticated against the event's signing key by {@link #flattenAndAuthenticate}. The
+   * message is then dispatched to the handler registered for its type, if one exists.
+   * @param {Record<string, unknown>} message - The flattened, authenticated message.
    * @param {ActorEntry} actor - The registered actor entry containing keys and handlers to dispatch the message to.
    * @returns {void}
    * @throws {TransportAdapterError} If the message type is unsupported or if no handler is registered
    * for the message type.
    */
   #dispatchMessage(message: Record<string, unknown>, actor: ActorEntry): void {
-    if(message.body && typeof message.body === 'object') {
-      message = { ...message, ...(message.body as Record<string, unknown>) };
-    }
-
     const messageType = message.type as string;
     if(!messageType || !isAggregationMessageType(messageType)) return;
 

--- a/packages/aggregation/src/participant/http-client.ts
+++ b/packages/aggregation/src/participant/http-client.ts
@@ -1,5 +1,6 @@
 import type { SchnorrKeyPair } from '@did-btcr2/keypair';
 import { CompressedSecp256k1PublicKey } from '@did-btcr2/keypair';
+import { equalBytes } from '@noble/curves/utils.js';
 
 import type { Logger } from '../core/logger.js';
 import { CONSOLE_LOGGER } from '../core/logger.js';
@@ -333,6 +334,26 @@ export class HttpClientTransport implements Transport {
 
     const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
     const flat = flattenMessage(revived);
+
+    // Bind the inner message to the authenticated envelope. The envelope signature
+    // authenticates envelope.from; the advert inside it names the service DID the
+    // participant will join and the key it will encrypt to. Unbound, any sender the
+    // server relays for can advertise a cohort in a reputable service's name, and a
+    // participant whose join filter trusts that DID encrypts its updates to the sender.
+    if(flat.from !== envelope.from) {
+      this.#logger.debug(`Broadcast inner sender ${String(flat.from)} does not match envelope sender ${envelope.from}`);
+      return;
+    }
+
+    // The key a sender advertises to the cohort must be the key it authenticated with,
+    // the same cross-check the server applies to a bootstrap opt-in (ADR 066).
+    const communicationPk = flat.communicationPk;
+    if(communicationPk !== undefined
+      && (!(communicationPk instanceof Uint8Array) || !equalBytes(communicationPk, senderPk.compressed))) {
+      this.#logger.debug(`Broadcast from ${envelope.from} advertises a key it did not authenticate with`);
+      return;
+    }
+
     const messageType = typeof flat.type === 'string' ? flat.type : undefined;
     if(!messageType) return;
 
@@ -363,6 +384,16 @@ export class HttpClientTransport implements Transport {
 
     const revived = reviveFromWire(envelope.message) as Record<string, unknown>;
     const flat = flattenMessage(revived);
+
+    // Bind the inner message to the authenticated envelope: the participant state machine
+    // acts on the inner `from` (it holds every service-originated message to the cohort's
+    // service DID), so a sender authenticated as itself must not be able to speak as the
+    // service by relabelling the message it carries.
+    if(flat.from !== envelope.from) {
+      this.#logger.debug(`Inbox inner sender ${String(flat.from)} does not match envelope sender ${envelope.from}`);
+      return;
+    }
+
     const messageType = typeof flat.type === 'string' ? flat.type : undefined;
     if(!messageType) return;
 

--- a/packages/aggregation/src/participant/participant.ts
+++ b/packages/aggregation/src/participant/participant.ts
@@ -2,7 +2,7 @@ import { canonicalHash } from '@did-btcr2/common';
 import type { SecuredDocument } from '@did-btcr2/cryptosuite';
 import type { SerializedSMTProof} from '@did-btcr2/smt';
 import { schnorr } from '@noble/curves/secp256k1.js';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { bytesToHex, concatBytes, hexToBytes } from '@noble/hashes/utils';
 import { Script, Transaction } from '@scure/btc-signer';
 import { getBeaconStrategy } from '../core/beacon-strategy.js';
 import { AggregationCohort } from '../core/cohort.js';
@@ -36,28 +36,45 @@ import { ParticipantCohortPhase } from '../core/phases.js';
 import type { AggregationSigner } from '../core/signer.js';
 import { BeaconSigningSession } from '../core/signing-session.js';
 
+/** Length of a beacon signal: SHA-256 of the CAS announcement, or the SMT root. */
+const SIGNAL_BYTE_LENGTH = 32;
+
 /**
- * True if `tx` has an OP_RETURN output whose payload equals the 32-byte signal
- * `signalHex`. A member binds its fallback signature to the exact signal it
- * validated, so a coordinator that drives the fallback output selection cannot
- * anchor a different announcement (a stale signal, or one whose CAS/SMT root
- * omits the member's update) under the member's signature.
+ * The exact scriptPubKey a did:btcr2 resolver reads a signal out of:
+ * `OP_RETURN OP_PUSHBYTES_32 <signal>`, i.e. the bytes `6a20 || signal`.
+ * Resolution parses the serialized script of the transaction's LAST output
+ * against that shape, so this is the only encoding that announces anything.
  */
-function txEmbedsSignal(tx: Transaction, signalHex: string): boolean {
-  let expected: Uint8Array;
-  try { expected = hexToBytes(signalHex); } catch { return false; }
-  if(expected.length === 0) return false;
-  for(let i = 0; i < tx.outputsLength; i++) {
-    const script = tx.getOutput(i)?.script;
-    if(!script) continue;
-    let decoded: Array<string | Uint8Array>;
-    try { decoded = Script.decode(script) as Array<string | Uint8Array>; } catch { continue; }
-    if(decoded.length === 2 && decoded[0] === 'RETURN' && decoded[1] instanceof Uint8Array) {
-      const payload = decoded[1];
-      if(payload.length === expected.length && payload.every((b, j) => b === expected[j])) return true;
-    }
+function signalScript(signal: Uint8Array): Uint8Array {
+  return concatBytes(new Uint8Array([ 0x6a, 0x20 ]), signal);
+}
+
+/** True if `script` is any OP_RETURN (data) output, whatever it carries. */
+function isOpReturn(script: Uint8Array | undefined): boolean {
+  if(!script) return false;
+  try {
+    return Script.decode(script)[0] === 'RETURN';
+  } catch {
+    return script.length > 0 && script[0] === 0x6a;
   }
-  return false;
+}
+
+/** Number of OP_RETURN outputs in `tx`. */
+function opReturnOutputCount(tx: Transaction): number {
+  let count = 0;
+  for(let i = 0; i < tx.outputsLength; i++) {
+    if(isOpReturn(tx.getOutput(i)?.script)) count++;
+  }
+  return count;
+}
+
+/** Sum of every output amount in `tx` (absent amounts count as zero). */
+function totalOutputValue(tx: Transaction): bigint {
+  let total = 0n;
+  for(let i = 0; i < tx.outputsLength; i++) {
+    total += tx.getOutput(i)?.amount ?? 0n;
+  }
+  return total;
 }
 
 /**
@@ -89,6 +106,12 @@ export interface PendingValidation {
   smtProof?: SerializedSMTProof;
   /** Canonical hash of this participant's update; empty for a decliner. */
   expectedHash: string;
+  /**
+   * True when the member's own slot is correct in the distributed data AND
+   * `signalBytesHex` is the signal that data derives to. Both halves are
+   * required: a slot that validates against data the coordinator does not
+   * intend to anchor authorizes nothing the member wanted.
+   */
   matches: boolean;
   /** True if this participant submitted an update; false if it declined (non-inclusion). */
   included: boolean;
@@ -244,6 +267,34 @@ export class AggregationParticipant {
     return map;
   }
 
+  /**
+   * Resolve the cohort a service-originated message names, and require the message to
+   * come from that cohort's service.
+   *
+   * Every message below the advert is sent by the coordinator, and each one steers this
+   * member: COHORT_READY pins the cohort keys and beacon address, DISTRIBUTE_AGGREGATED_DATA
+   * decides what the member validates, AUTHORIZATION_REQUEST and FALLBACK_AUTHORIZATION_REQUEST
+   * decide what it signs. `from` is a self-declared field, so a transport that does not bind
+   * it to the sender's key (or a caller driving this state machine by hand) would otherwise
+   * let any party drive a member's cohort from the outside. Transport authentication is the
+   * first line; this is the state machine refusing to act on a stranger's say-so regardless.
+   *
+   * COHORT_ADVERT is deliberately not routed through here: the advert is what *establishes*
+   * the service DID, so there is nothing yet to compare it against. Its authenticity is a
+   * transport property (the signed Nostr event / the signed HTTP envelope).
+   * @param {BaseMessage} message The inbound message.
+   * @returns {ParticipantCohortState | undefined} The cohort state, or undefined when the
+   * cohort is unknown or the sender is not its service.
+   */
+  #serviceCohortState(message: BaseMessage): ParticipantCohortState | undefined {
+    const cohortId = message.body?.cohortId;
+    if(!cohortId) return undefined;
+    const state = this.#cohortStates.get(cohortId);
+    if(!state) return undefined;
+    if(message.from !== state.serviceDid) return undefined;
+    return state;
+  }
+
   #handleCohortAdvert(message: BaseMessage): void {
     // Validate the wire shape (incl. minParticipants range) before trusting it,
     // rather than reading fields with `?? 0` fallbacks (see ADR 039).
@@ -313,7 +364,9 @@ export class AggregationParticipant {
   }
 
   #handleOptInAccept(message: BaseMessage): void {
-    // Acknowledgment from service, no state change needed
+    // Acknowledgment from service, no state change needed. Nothing to bind to the
+    // cohort's service DID here for the same reason: this handler reads and writes no
+    // state. Route it through #serviceCohortState if it ever grows a body.
     void message;
   }
 
@@ -335,9 +388,7 @@ export class AggregationParticipant {
   }
 
   #handleCohortReady(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
-    const state = this.#cohortStates.get(cohortId);
+    const state = this.#serviceCohortState(message);
     if(!state || !state.cohort) return;
     if(state.phase !== ParticipantCohortPhase.OptedIn) return;
 
@@ -432,12 +483,11 @@ export class AggregationParticipant {
   }
 
   #handleDistributeAggregatedData(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
-    const state = this.#cohortStates.get(cohortId);
+    const state = this.#serviceCohortState(message);
     // A submitter is in UpdateSubmitted; a decliner (cooperative non-inclusion)
     // is in NonIncluded. Both validate their own slot in the distributed data.
     if(!state || (state.phase !== ParticipantCohortPhase.UpdateSubmitted && state.phase !== ParticipantCohortPhase.NonIncluded)) return;
+    const cohortId = state.cohortId;
 
     const declined = state.included === false;
     // A submitter must have its update stored; a decliner has none by design.
@@ -460,12 +510,22 @@ export class AggregationParticipant {
       body            : message.body!,
     });
 
+    // Bind the announced signal to the data just validated. Validating a slot
+    // says "this data is right"; it says nothing about the 32 bytes the
+    // coordinator intends to anchor. Recompute the signal from the validated
+    // data and require the announcement to be it, or the member would approve a
+    // CAS map/SMT proof containing its update while the chain records a
+    // different aggregation that omits it.
+    const derivedSignal = strategy.deriveSignal(result);
+    const signalBound = derivedSignal !== undefined
+      && bytesToHex(derivedSignal) === signalBytesHex.toLowerCase();
+
     state.validation = {
       cohortId,
       beaconType,
       signalBytesHex,
       expectedHash,
-      matches         : result.matches,
+      matches         : result.matches && signalBound,
       casAnnouncement : result.casAnnouncement,
       smtProof        : result.smtProof,
       included        : !declined,
@@ -526,11 +586,10 @@ export class AggregationParticipant {
   }
 
   #handleAuthorizationRequest(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
-    const state = this.#cohortStates.get(cohortId);
+    const state = this.#serviceCohortState(message);
     if(!state || !state.cohort) return;
     if(state.phase !== ParticipantCohortPhase.ValidationSent) return;
+    const cohortId = state.cohortId;
 
     const sessionId = message.body?.sessionId;
     const pendingTxHex = message.body?.pendingTx;
@@ -549,25 +608,151 @@ export class AggregationParticipant {
   }
 
   /**
-   * Bind a signing approval to the announcement the member validated: a beacon
-   * transaction MUST carry an OP_RETURN with the exact 32-byte signal stored when
-   * the aggregated data was distributed. Both the optimistic nonce approval and
-   * the fallback approval sign with SIGHASH_DEFAULT (committing to every output)
-   * while the coordinator drives output selection, so without this check a
-   * coordinator could anchor a different signal under the member's signature.
+   * Parse and range-check the spent output's value as supplied by the
+   * coordinator. It is the only figure the member has for the input side, so a
+   * malformed one must fail loudly rather than reach `BigInt` unguarded.
    */
-  #assertTxAnchorsValidatedSignal(cohortId: string, state: ParticipantCohortState, tx: Transaction): void {
-    const signalHex = state.validation?.signalBytesHex;
-    if(!signalHex) {
+  #prevOutValue(cohortId: string, raw: string): bigint {
+    let value: bigint;
+    try {
+      value = BigInt(raw);
+    } catch {
+      throw new AggregationParticipantError(
+        `Cohort ${cohortId} signing request carries a malformed prevOutValue.`,
+        'INVALID_PREVOUT_VALUE', { cohortId, prevOutValue: raw }
+      );
+    }
+    if(value < 0n) {
+      throw new AggregationParticipantError(
+        `Cohort ${cohortId} signing request carries a negative prevOutValue.`,
+        'INVALID_PREVOUT_VALUE', { cohortId, prevOutValue: raw }
+      );
+    }
+    return value;
+  }
+
+  /**
+   * Gate every signature the member produces on the transaction it was shown.
+   *
+   * Both the optimistic nonce approval and the fallback approval sign with
+   * SIGHASH_DEFAULT, which commits to the entire transaction, while the
+   * coordinator alone chooses its inputs and outputs. The member therefore
+   * checks the properties its announcement depends on before signing:
+   *
+   * - it validated the distributed data, and the announced signal is derived
+   *   from that data (see {@link PendingValidation.matches});
+   * - the LAST output is exactly `OP_RETURN OP_PUSHBYTES_32 <validated signal>`.
+   *   Resolution reads the signal from the last output only, so a transaction
+   *   carrying the member's signal anywhere else announces someone else's
+   *   aggregation, whatever else it contains;
+   * - that signal output burns nothing, and it is the transaction's only data
+   *   output (a second OP_RETURN is ambiguous and non-standard);
+   * - the transaction spends exactly one input. The protocol conveys a single
+   *   prevout script/value, which is all a BIP-341 sighash over more inputs
+   *   would need, so a multi-input transaction is one the member cannot check
+   *   or correctly sign;
+   * - the outputs do not spend more than the input holds, so the transaction is
+   *   at least capable of confirming and the fee it implies is a real number.
+   *
+   * Deliberately NOT checked: where the change goes and how large the fee is.
+   * The change destination is a caller-chosen privacy lever (ADR 044) and under
+   * the only implemented funding model (`operator-funded`) the value at stake is
+   * the coordinator's own, so a member cannot tell a legitimate change address
+   * from a "drain" and has nothing of its own to lose either way.
+   */
+  #assertSignableBeaconTx(
+    cohortId: string,
+    state: ParticipantCohortState,
+    tx: Transaction,
+    prevOutValue: bigint,
+  ): void {
+    const validation = state.validation;
+    if(!validation?.signalBytesHex) {
       throw new AggregationParticipantError(
         `Cohort ${cohortId} has no validated signal to bind the signature to.`,
         'MISSING_STATE', { cohortId }
       );
     }
-    if(!txEmbedsSignal(tx, signalHex)) {
+    if(!validation.matches) {
       throw new AggregationParticipantError(
-        `Transaction for cohort ${cohortId} does not anchor the validated signal.`,
+        `Cohort ${cohortId} aggregated data did not validate; refusing to sign.`,
+        'UNVALIDATED_DATA', { cohortId }
+      );
+    }
+
+    let signal: Uint8Array;
+    try {
+      signal = hexToBytes(validation.signalBytesHex);
+    } catch {
+      throw new AggregationParticipantError(
+        `Cohort ${cohortId} validated signal is not hex.`,
         'SIGNAL_MISMATCH', { cohortId }
+      );
+    }
+    if(signal.length !== SIGNAL_BYTE_LENGTH) {
+      throw new AggregationParticipantError(
+        `Cohort ${cohortId} validated signal is ${signal.length} bytes, expected ${SIGNAL_BYTE_LENGTH}.`,
+        'SIGNAL_MISMATCH', { cohortId }
+      );
+    }
+
+    if(tx.inputsLength !== 1) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} spends ${tx.inputsLength} inputs; exactly one is signable.`,
+        'INVALID_TX_STRUCTURE', { cohortId, inputs: tx.inputsLength }
+      );
+    }
+
+    const lastOutput = tx.outputsLength > 0 ? tx.getOutput(tx.outputsLength - 1) : undefined;
+    const expectedScript = signalScript(signal);
+    const lastScript = lastOutput?.script;
+    const anchored = !!lastScript
+      && lastScript.length === expectedScript.length
+      && lastScript.every((b, i) => b === expectedScript[i]);
+    if(!anchored) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} does not anchor the validated signal in its last output.`,
+        'SIGNAL_MISMATCH', { cohortId }
+      );
+    }
+    if((lastOutput?.amount ?? 0n) !== 0n) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} burns value in the signal output.`,
+        'INVALID_TX_STRUCTURE', { cohortId, amount: lastOutput?.amount?.toString() }
+      );
+    }
+    const dataOutputs = opReturnOutputCount(tx);
+    if(dataOutputs !== 1) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} carries ${dataOutputs} OP_RETURN outputs; exactly one is allowed.`,
+        'INVALID_TX_STRUCTURE', { cohortId, dataOutputs }
+      );
+    }
+
+    const outputValue = totalOutputValue(tx);
+    if(outputValue > prevOutValue) {
+      throw new AggregationParticipantError(
+        `Transaction for cohort ${cohortId} spends ${outputValue} from an input of ${prevOutValue}.`,
+        'INVALID_TX_STRUCTURE', { cohortId, outputValue: outputValue.toString(), prevOutValue: prevOutValue.toString() }
+      );
+    }
+  }
+
+  /**
+   * A fallback signature MUST cover the same transaction as the optimistic
+   * round. The two paths spend one UTXO through different witnesses, so signing
+   * a fallback over a different transaction hands the coordinator two competing
+   * spends (a key-path signature for one, a k-of-n script path for the other)
+   * and lets it choose which to broadcast. Members that never saw an
+   * authorization request have nothing to compare against and authorize one
+   * transaction only, so they are not held to this.
+   */
+  #assertMatchesOptimisticTx(cohortId: string, state: ParticipantCohortState, pendingTxHex: string): void {
+    const optimisticTxHex = state.signingRequest?.pendingTxHex;
+    if(optimisticTxHex && optimisticTxHex.toLowerCase() !== pendingTxHex.toLowerCase()) {
+      throw new AggregationParticipantError(
+        `Fallback transaction for cohort ${cohortId} differs from the transaction of the optimistic round.`,
+        'TX_MISMATCH', { cohortId }
       );
     }
   }
@@ -594,9 +779,11 @@ export class AggregationParticipant {
     // output, which scure does not classify as a known (spendable) output type;
     // re-parsing the raw tx would otherwise throw.
     const tx = Transaction.fromRaw(hexToBytes(state.signingRequest.pendingTxHex), { allowUnknownOutputs: true });
+    const prevOutValue = this.#prevOutValue(cohortId, state.signingRequest.prevOutValue);
 
-    // Refuse to sign unless the tx anchors the signal this member validated.
-    this.#assertTxAnchorsValidatedSignal(cohortId, state, tx);
+    // Refuse to sign unless the tx announces the signal this member validated
+    // and is otherwise a beacon transaction the member can account for.
+    this.#assertSignableBeaconTx(cohortId, state, tx, prevOutValue);
 
     // Derive UTXO metadata for Taproot sighash (BIP-341). Use the script
     // supplied by the service in AUTHORIZATION_REQUEST rather than reading
@@ -604,7 +791,7 @@ export class AggregationParticipant {
     // beacon designs, and the prevOutScript must be the UTXO script, not the
     // change script.
     const prevOutScripts = [hexToBytes(state.signingRequest.prevOutScriptHex)];
-    const prevOutValues = [BigInt(state.signingRequest.prevOutValue)];
+    const prevOutValues = [prevOutValue];
 
     const session = new BeaconSigningSession({
       id        : state.signingRequest.sessionId,
@@ -631,11 +818,15 @@ export class AggregationParticipant {
   }
 
   #handleAggregatedNonce(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
-    const state = this.#cohortStates.get(cohortId);
+    const state = this.#serviceCohortState(message);
     if(!state || !state.signingSession) return;
     if(state.phase !== ParticipantCohortPhase.NonceSent) return;
+
+    // The nonce must belong to the round this member is in. The service applies the
+    // same check to every contribution it receives; without the mirror image, a stale
+    // or replayed message from an earlier round installs its aggregated nonce here and
+    // the partial signature computed from it is worthless.
+    if(message.body?.sessionId !== state.signingSession.id) return;
 
     const aggregatedNonce = message.body?.aggregatedNonce;
     if(!aggregatedNonce) return;
@@ -692,10 +883,9 @@ export class AggregationParticipant {
   }
 
   #handleFallbackAuthorizationRequest(message: BaseMessage): void {
-    const cohortId = message.body?.cohortId;
-    if(!cohortId) return;
-    const state = this.#cohortStates.get(cohortId);
+    const state = this.#serviceCohortState(message);
     if(!state || !state.cohort) return;
+    const cohortId = state.cohortId;
     // The service can fall back at any point after the member validated. This
     // includes the local Complete phase a member reaches the moment it sends its
     // optimistic partial signature: the cohort has NOT finalized (the service
@@ -719,6 +909,17 @@ export class AggregationParticipant {
     const prevOutValue = message.body?.prevOutValue;
     const fallbackLeafScriptHex = message.body?.fallbackLeafScriptHex;
     if(!sessionId || !pendingTxHex || !prevOutScriptHex || !prevOutValue || !fallbackLeafScriptHex) return;
+
+    // Drop a request that does not carry the optimistic round's transaction or its
+    // session, BEFORE the secret-nonce wipe below: accepting one would both authorize a
+    // competing spend and, on its own, kill an in-flight optimistic round for
+    // the price of a single unsolicited message. The fallback runs on the service's
+    // existing signing session, so its id is the one already on record; a member still
+    // in ValidationSent has no session to compare against and is held to neither check.
+    const optimisticRequest = state.signingRequest;
+    if(optimisticRequest && optimisticRequest.sessionId !== sessionId) return;
+    const optimisticTxHex = optimisticRequest?.pendingTxHex;
+    if(optimisticTxHex && optimisticTxHex.toLowerCase() !== pendingTxHex.toLowerCase()) return;
 
     state.fallbackRequest = { cohortId, sessionId, pendingTxHex, prevOutScriptHex, prevOutValue, fallbackLeafScriptHex };
     // The optimistic path is abandoned; wipe any retained secret nonce for it.
@@ -751,11 +952,13 @@ export class AggregationParticipant {
     const req = state.fallbackRequest;
     const tx = Transaction.fromRaw(hexToBytes(req.pendingTxHex), { allowUnknownOutputs: true });
     const prevOutScript = hexToBytes(req.prevOutScriptHex);
-    const prevOutValue = BigInt(req.prevOutValue);
+    const prevOutValue = this.#prevOutValue(cohortId, req.prevOutValue);
 
-    // Refuse to sign unless the fallback tx anchors the signal this member
-    // validated (the coordinator drives output selection on the fallback path).
-    this.#assertTxAnchorsValidatedSignal(cohortId, state, tx);
+    // The coordinator drives output selection on the fallback path too, so the
+    // same transaction checks apply, plus: it must be the optimistic round's
+    // transaction, not a second one competing with it.
+    this.#assertSignableBeaconTx(cohortId, state, tx, prevOutValue);
+    this.#assertMatchesOptimisticTx(cohortId, state, req.pendingTxHex);
 
     // Recompute the fallback leaf from our own cohort keys so a malicious service
     // cannot induce a signature over a different leaf than the one the funded

--- a/packages/aggregation/src/service/http-server.ts
+++ b/packages/aggregation/src/service/http-server.ts
@@ -469,6 +469,15 @@ export class HttpServerTransport implements Transport {
       return this.#respondJson(403, { error: 'not_an_actor' }, req);
     }
 
+    // Bind the inner message to the authenticated envelope, exactly as POST /v1/messages
+    // does. The advert is relayed verbatim to every broadcast subscriber, and a
+    // participant reads the service DID it will join from the inner `from`, so an
+    // unbound advert lets one actor advertise a cohort in another DID's name.
+    const flat = flattenMessage(reviveFromWire(envelope.message) as Record<string, unknown>);
+    if(flat.from !== envelope.from) {
+      return this.#respondJson(401, { error: 'sender_mismatch' }, req);
+    }
+
     const id = String(++this.#advertSeq);
     this.#currentAdvert = {
       dataJson    : JSON.stringify(envelope),

--- a/packages/aggregation/src/service/service.ts
+++ b/packages/aggregation/src/service/service.ts
@@ -33,7 +33,7 @@ import {
   createFallbackAuthorizationRequestMessage,
 } from '../core/messages/factories.js';
 import type { ServiceCohortPhaseType } from '../core/phases.js';
-import { ServiceCohortPhase } from '../core/phases.js';
+import { ServiceCohortPhase, SigningSessionPhase } from '../core/phases.js';
 import { BeaconSigningSession } from '../core/signing-session.js';
 
 /**
@@ -92,7 +92,17 @@ export type RejectionReason =
   | 'WRONG_VERSION'
   | 'UPDATE_TOO_LARGE'
   | 'UPDATE_VERIFICATION_FAILED'
-  | 'UPDATE_MALFORMED';
+  | 'UPDATE_MALFORMED'
+  /** The sender is not a member of the cohort the message names. */
+  | 'NOT_A_MEMBER'
+  /** The sender already answered this round or signing step; the first answer stands. */
+  | 'DUPLICATE_RESPONSE'
+  /** The nonce contribution is not a well-formed MuSig2 public nonce. */
+  | 'INVALID_NONCE'
+  /** The partial signature does not verify against the sender's key. */
+  | 'INVALID_PARTIAL_SIG'
+  /** An opt-in key is not a 33-byte compressed secp256k1 public key. */
+  | 'INVALID_PARTICIPANT_KEY';
 
 /** Record of a silently-dropped inbound message. Drained by the runner to emit events. */
 export interface Rejection {
@@ -125,6 +135,19 @@ interface ServiceCohortState {
 
 /** Default maximum canonicalized byte-length of a submitted BTCR2 update. */
 export const DEFAULT_MAX_UPDATE_SIZE_BYTES = 256 * 1024;
+
+/**
+ * Maximum rejections retained per cohort between drains; the oldest is dropped
+ * once the log is full.
+ *
+ * The receive path records a rejection for every message it drops, including
+ * messages from senders who are not cohort members, so the log is written by
+ * anyone who can reach the service. A runner drains after each `receive()` and
+ * never accumulates; this bound is for callers driving the state machine
+ * directly, so an undrained log cannot grow without limit. It never refuses
+ * protocol traffic: only diagnostics are dropped.
+ */
+export const MAX_RETAINED_REJECTIONS = 256;
 
 export interface AggregationServiceParams {
   did: string;
@@ -169,6 +192,18 @@ export class AggregationService {
   }
 
 
+  /**
+   * Sans-I/O entry point for every inbound message.
+   *
+   * Contract: a message from an untrusted sender never throws out of here. Each
+   * handler validates what the message claims before touching cohort or signing
+   * state, and records a {@link Rejection} instead of letting the underlying
+   * `AggregationCohort` / {@link BeaconSigningSession} invariant throw. A runner
+   * turns any escaping error into a cohort failure, so a single throw on the
+   * receive path is a cohort-kill anyone able to reach the service could
+   * trigger. The action methods (`acceptParticipant`, `startSigning`, ...) still
+   * throw: those are operator calls, not attacker input.
+   */
   receive(message: BaseMessage): void {
     // Reject messages whose wire version doesn't match what this build speaks.
     // Missing version, treat as legacy and drop: bumping the protocol must be
@@ -178,11 +213,8 @@ export class AggregationService {
       const cohortId = message.body?.cohortId;
       const state = cohortId ? this.#cohortStates.get(cohortId) : undefined;
       if(state) {
-        state.rejections.push({
-          from   : message.from,
-          code   : 'WRONG_VERSION',
-          reason : `Expected wire version ${AGGREGATION_WIRE_VERSION}, got ${String(version)}`,
-        });
+        this.#reject(state, message.from, 'WRONG_VERSION',
+          `Expected wire version ${AGGREGATION_WIRE_VERSION}, got ${String(version)}`);
       }
       return;
     }
@@ -213,6 +245,18 @@ export class AggregationService {
       default:
         // Unknown message type - silently ignore
         break;
+    }
+  }
+
+  /**
+   * Record a dropped message. The log is bounded by
+   * {@link MAX_RETAINED_REJECTIONS}; the oldest entry is discarded once it is
+   * full.
+   */
+  #reject(state: ServiceCohortState, from: string, code: RejectionReason, reason: string): void {
+    state.rejections.push({ from, code, reason });
+    if(state.rejections.length > MAX_RETAINED_REJECTIONS) {
+      state.rejections.shift();
     }
   }
 
@@ -321,6 +365,27 @@ export class AggregationService {
     const communicationPk = message.body?.communicationPk;
     if(!participantPk || !communicationPk) return;
 
+    // Validate both keys on arrival. The wire guard only asks for bytes, so a
+    // three-byte or off-curve key reaches this handler intact, and a stored one
+    // is not refused until the operator accepts the sender, inside an operator
+    // action the runner is driving. The failure would then belong to the cohort
+    // rather than to the sender, and a runner turns it into removeCohort: one
+    // opt-in from any stranger destroys an in-flight cohort, and opting in is
+    // open to everyone while a cohort is advertised. Rejected here, nothing is
+    // stored and the sender can send a well-formed opt-in instead.
+    if(!AggregationCohort.isValidCohortKey(participantPk)) {
+      this.#reject(state, participantDid, 'INVALID_PARTICIPANT_KEY',
+        'Opt-in participantPk is not a 33-byte compressed secp256k1 public key');
+      return;
+    }
+    // communicationPk never joins the MuSig2 key set, but a runner hands it
+    // straight to transport.registerPeer, which refuses a key it cannot decode.
+    if(!AggregationCohort.isValidCohortKey(communicationPk)) {
+      this.#reject(state, participantDid, 'INVALID_PARTICIPANT_KEY',
+        'Opt-in communicationPk is not a 33-byte compressed secp256k1 public key');
+      return;
+    }
+
     // Reject re-opt-in from already-accepted participants. Without this guard a
     // participant could send a second opt-in with a different key, overwriting
     // pendingOptIns[did] while cohortKeys still holds the original key - opening
@@ -368,10 +433,26 @@ export class AggregationService {
       );
     }
 
+    // Refuse a key the cohort cannot carry before touching any state. The
+    // receive path already refuses one at opt-in; a caller driving the state
+    // machine with its own opt-in record (a resumed or externally persisted
+    // cohort) still reaches here.
+    if(!AggregationCohort.isValidCohortKey(optIn.participantPk)) {
+      throw new AggregationServiceError(
+        `Cannot accept ${participantDid} into cohort ${cohortId}: participant key is not a 33-byte compressed secp256k1 public key.`,
+        'INVALID_PARTICIPANT_KEY', { cohortId, participantDid }
+      );
+    }
+
+    // Assign the cohort keys first: it is the only step that can refuse, and
+    // the membership bookkeeping below cannot. Growing `participants` ahead of
+    // it would leave a refused DID a member with no key in the aggregate, and a
+    // cohort with more members than keys can never finish a round - every round
+    // waits for one contribution per participant.
+    state.cohort.cohortKeys = [...state.cohort.cohortKeys, optIn.participantPk];
     state.acceptedParticipants.add(participantDid);
     state.cohort.participants.push(participantDid);
     state.cohort.participantKeys.set(participantDid, optIn.participantPk);
-    state.cohort.cohortKeys = [...state.cohort.cohortKeys, optIn.participantPk];
 
     return [createCohortOptInAcceptMessage({
       from : this.did,
@@ -451,24 +532,35 @@ export class AggregationService {
 
     const signedUpdate = message.body?.signedUpdate as SecuredDocument | undefined;
     if(!signedUpdate) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_MALFORMED',
-        reason : 'SUBMIT_UPDATE missing signedUpdate body',
-      });
+      this.#reject(state, message.from, 'UPDATE_MALFORMED', 'SUBMIT_UPDATE missing signedUpdate body');
+      return;
+    }
+
+    // Membership first, and before any canonicalization or signature work: a
+    // pending opt-in that was never accepted still has a pendingOptIns entry, so
+    // it passes #verifySubmittedUpdate and would reach addUpdate, which throws
+    // UNKNOWN_PARTICIPANT out of receive() and fails the whole cohort. Mirrors
+    // the guard in #handleSubmitNonInclusion.
+    if(!state.cohort.participants.includes(message.from)) {
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Sender is not a member of this cohort');
       return;
     }
 
     // Cap the canonicalized update size before doing any heavier verification
     // work. Without this guard, a participant could submit multi-MB payloads
     // that the service would canonicalize, hash, and aggregate - cheap DoS.
-    const canonicalSize = canonicalize(signedUpdate as unknown as Record<string, unknown>).length;
+    let canonicalSize: number;
+    try {
+      canonicalSize = canonicalize(signedUpdate as unknown as Record<string, unknown>).length;
+    } catch {
+      // Canonicalization is the first thing that touches the body, so anything
+      // JCS cannot serialize is dropped here rather than thrown at the caller.
+      this.#reject(state, message.from, 'UPDATE_MALFORMED', 'Update could not be canonicalized');
+      return;
+    }
     if(canonicalSize > this.maxUpdateSizeBytes) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_TOO_LARGE',
-        reason : `Canonicalized update is ${canonicalSize} bytes; max allowed is ${this.maxUpdateSizeBytes}`,
-      });
+      this.#reject(state, message.from, 'UPDATE_TOO_LARGE',
+        `Canonicalized update is ${canonicalSize} bytes; max allowed is ${this.maxUpdateSizeBytes}`);
       return;
     }
 
@@ -477,11 +569,8 @@ export class AggregationService {
     // service would aggregate into the CAS announcement / SMT root and ultimately
     // anchor on-chain with the cohort's MuSig2 signature.
     if(!this.#verifySubmittedUpdate(state, message.from, signedUpdate)) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_VERIFICATION_FAILED',
-        reason : 'BIP-340 Data Integrity proof verification failed',
-      });
+      this.#reject(state, message.from, 'UPDATE_VERIFICATION_FAILED',
+        'BIP-340 Data Integrity proof verification failed');
       return;
     }
 
@@ -490,19 +579,13 @@ export class AggregationService {
     // would corrupt the aggregated data the member already validated against).
     // Both are dropped as rejections, symmetric with #handleSubmitNonInclusion.
     if(state.cohort.nonIncluded.has(message.from)) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_MALFORMED',
-        reason : 'Participant already declined this round; cannot also submit an update',
-      });
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE',
+        'Participant already declined this round; cannot also submit an update');
       return;
     }
     if(state.cohort.pendingUpdates.has(message.from)) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_MALFORMED',
-        reason : 'Participant already submitted an update this round; cannot resubmit',
-      });
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE',
+        'Participant already submitted an update this round; cannot resubmit');
       return;
     }
 
@@ -535,22 +618,14 @@ export class AggregationService {
     // UNKNOWN_PARTICIPANT out of receive() and fail the whole cohort, a DoS any
     // non-member could trigger. Mirrors the SUBMIT_UPDATE verification path.
     if(!state.cohort.participants.includes(message.from)) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_MALFORMED',
-        reason : 'Sender is not a member of this cohort',
-      });
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Sender is not a member of this cohort');
       return;
     }
 
     // One response per round: already submitted or already declined. Surface the
     // conflict as a rejection, symmetric with the double-submit guard above.
     if(state.cohort.pendingUpdates.has(message.from) || state.cohort.nonIncluded.has(message.from)) {
-      state.rejections.push({
-        from   : message.from,
-        code   : 'UPDATE_MALFORMED',
-        reason : 'Participant already responded this round',
-      });
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE', 'Participant already responded this round');
       return;
     }
 
@@ -582,6 +657,10 @@ export class AggregationService {
   ): boolean {
     const proof = signedUpdate.proof;
     if(!proof?.verificationMethod || !proof.proofValue) return false;
+    // The body is attacker-shaped until proven otherwise: a non-string
+    // verificationMethod would make the split() below throw a raw TypeError out
+    // of receive() and fail the cohort.
+    if(typeof proof.verificationMethod !== 'string') return false;
 
     // The proof must be signed by the sender's own key. Reject if the
     // verificationMethod references a different DID.
@@ -677,6 +756,21 @@ export class AggregationService {
     const approved = message.body?.approved;
     if(approved === undefined) return;
 
+    // A non-member ack would throw UNKNOWN_PARTICIPANT out of addValidation and
+    // fail the cohort: one message, from anyone who can reach the service.
+    if(!state.cohort.participants.includes(message.from)) {
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Sender is not a member of this cohort');
+      return;
+    }
+
+    // One vote per member. A repeat (an innocent transport retry, or a member
+    // flipping its answer) would be counted twice by hasAllValidationResponses,
+    // which can settle the round while another member is still pending.
+    if(state.cohort.validationAcks.has(message.from) || state.cohort.validationRejections.has(message.from)) {
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE', 'Participant already validated this round');
+      return;
+    }
+
     state.cohort.addValidation(message.from, approved);
 
     // Transition to Validated only when all participants approved.
@@ -751,9 +845,34 @@ export class AggregationService {
     const nonceContribution = message.body?.nonceContribution;
     if(!nonceContribution) return;
 
-    state.signingSession.addNonceContribution(message.from, nonceContribution);
+    const session = state.signingSession;
+    // The cohort phase gate above tracks the session phase, but the session is
+    // the authority on what it will accept: read it rather than let it throw.
+    if(session.phase !== SigningSessionPhase.AwaitingNonceContributions) return;
+    if(!state.cohort.participants.includes(message.from)) {
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Sender is not a member of this cohort');
+      return;
+    }
+    // One contribution per member. Dropping the repeat (rather than throwing
+    // DUPLICATE_NONCE) keeps an innocent transport retry from failing the round;
+    // the first contribution stands, since the members' nonces are what the
+    // aggregated nonce they will sign against is built from.
+    if(session.nonceContributions.has(message.from)) {
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE', 'Participant already contributed a nonce to this session');
+      return;
+    }
+    // Validate before storing. A malformed contribution is accepted by
+    // addNonceContribution (it only checks the length) and detonates later
+    // inside sendAggregatedNonce, where the failure is the cohort's, not the
+    // sender's. Rejected here, the member can simply resend a valid one.
+    if(!BeaconSigningSession.isValidNonceContribution(nonceContribution)) {
+      this.#reject(state, message.from, 'INVALID_NONCE', 'Nonce contribution is not a valid MuSig2 public nonce');
+      return;
+    }
 
-    if(state.signingSession.nonceContributions.size === state.cohort.participants.length) {
+    session.addNonceContribution(message.from, nonceContribution);
+
+    if(session.nonceContributions.size === state.cohort.participants.length) {
       state.phase = ServiceCohortPhase.NoncesCollected;
     }
   }
@@ -803,19 +922,41 @@ export class AggregationService {
     const partialSignature = message.body?.partialSignature;
     if(!partialSignature) return;
 
-    state.signingSession.addPartialSignature(message.from, partialSignature);
+    const session = state.signingSession;
+    if(session.phase !== SigningSessionPhase.AwaitingPartialSignatures) return;
+    if(!state.cohort.participants.includes(message.from)) {
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Sender is not a member of this cohort');
+      return;
+    }
+    if(session.partialSignatures.has(message.from)) {
+      this.#reject(state, message.from, 'DUPLICATE_RESPONSE', 'Participant already contributed a partial signature to this session');
+      return;
+    }
+    // Verify on arrival, not at aggregation. A stored bad signature surfaces as
+    // BAD_PARTIAL_SIG inside generateFinalSignature, where the whole round dies
+    // for one member's contribution; rejecting it here blames the sender and
+    // leaves the round open for it to send a correct one (BIP-327 §2.3.5).
+    if(!session.verifyPartialSignature(message.from, partialSignature)) {
+      this.#reject(state, message.from, 'INVALID_PARTIAL_SIG', 'Partial signature failed verification');
+      return;
+    }
 
-    if(state.signingSession.partialSignatures.size === state.cohort.participants.length) {
-      // All partial sigs received - generate final signature
-      const signature = state.signingSession.generateFinalSignature();
+    session.addPartialSignature(message.from, partialSignature);
+
+    if(session.partialSignatures.size === state.cohort.participants.length) {
+      // All partial sigs received - generate final signature. Every stored
+      // contribution was verified on arrival, so this cannot fail on one
+      // member's input; an error here is the service's own state and belongs to
+      // the caller.
+      const signature = session.generateFinalSignature();
 
       // Set Taproot key-path witness (finalScriptWitness injects the aggregated MuSig2 sig)
-      state.signingSession.pendingTx.updateInput(0, { finalScriptWitness: [signature] });
+      session.pendingTx.updateInput(0, { finalScriptWitness: [signature] });
 
       state.result = {
         cohortId,
         signature,
-        signedTx : state.signingSession.pendingTx,
+        signedTx : session.pendingTx,
         path     : 'key-path',
       };
       state.phase = ServiceCohortPhase.Complete;
@@ -923,12 +1064,12 @@ export class AggregationService {
     // rejection, never thrown, so one bad contribution cannot stall the fallback.
     const memberKey = state.cohort.participantKeys.get(message.from);
     if(!memberKey) {
-      state.rejections.push({ from: message.from, code: 'UPDATE_MALFORMED', reason: 'Fallback signature from a non-member' });
+      this.#reject(state, message.from, 'NOT_A_MEMBER', 'Fallback signature from a non-member');
       return;
     }
     const memberXOnly = memberKey.slice(1);
     if(signerPk.length !== 32 || !memberXOnly.every((b, i) => b === signerPk[i])) {
-      state.rejections.push({ from: message.from, code: 'UPDATE_MALFORMED', reason: 'Fallback signerPk does not match the sender cohort key' });
+      this.#reject(state, message.from, 'UPDATE_MALFORMED', 'Fallback signerPk does not match the sender cohort key');
       return;
     }
 
@@ -940,7 +1081,7 @@ export class AggregationService {
     let valid = false;
     try { valid = fallbackSignature.length === 64 && schnorr.verify(fallbackSignature, sighash, signerPk); } catch { valid = false; }
     if(!valid) {
-      state.rejections.push({ from: message.from, code: 'UPDATE_VERIFICATION_FAILED', reason: 'Fallback signature failed verification' });
+      this.#reject(state, message.from, 'UPDATE_VERIFICATION_FAILED', 'Fallback signature failed verification');
       return;
     }
 

--- a/packages/aggregation/src/transport-factory.ts
+++ b/packages/aggregation/src/transport-factory.ts
@@ -1,10 +1,10 @@
 import { NotImplementedError } from '@did-btcr2/common';
-import type { Logger } from './core/logger.js';
 import { TransportError } from './core/transport/error.js';
 import type { HttpClientTransportConfig } from './participant/http-client.js';
 import { HttpClientTransport } from './participant/http-client.js';
 import type { HttpServerTransportConfig } from './service/http-server.js';
 import { HttpServerTransport } from './service/http-server.js';
+import type { NostrTransportConfig } from './core/transport/nostr.js';
 import { NostrTransport } from './core/transport/nostr.js';
 import type { Transport } from './core/transport/transport.js';
 
@@ -15,11 +15,8 @@ export type TransportConfig =
   | HttpClientTransportConfigOption
   | HttpServerTransportConfigOption;
 
-export interface NostrTransportConfigOption {
+export interface NostrTransportConfigOption extends NostrTransportConfig {
   type: 'nostr';
-  relays?: string[];
-  logger?: Logger;
-  broadcastLookbackMs?: number;
 }
 
 export interface DidCommTransportConfigOption {
@@ -45,6 +42,7 @@ export class TransportFactory {
           relays              : config.relays,
           logger              : config.logger,
           broadcastLookbackMs : config.broadcastLookbackMs,
+          resolveSenderPk     : config.resolveSenderPk,
         });
       case 'didcomm':
         throw new NotImplementedError('DIDComm transport not implemented yet.');

--- a/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
+++ b/packages/aggregation/tests/aggregation-fallback-protocol.spec.ts
@@ -244,7 +244,9 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
     const sessionId = service.getSigningSessionId(cohortId)!;
 
     // A coordinator hands the member a tx whose OP_RETURN carries a DIFFERENT
-    // signal than the one the member validated. The member must refuse to sign.
+    // signal than the one the member validated. It is not the transaction of
+    // the optimistic round this member is already in, so the request is dropped
+    // outright and the member never reaches a position to sign it.
     const tampered = beaconTx(script, cohort.internalKey, value, new Uint8Array(32).fill(0xbe));
     const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
     parts[0].receive(createFallbackAuthorizationRequestMessage({
@@ -257,8 +259,9 @@ describe('Aggregate beacon fallback protocol (ADR 042)', () => {
       prevOutValue          : value.toString(),
       fallbackLeafScriptHex : bytesToHex(leaf),
     }) as never);
-    expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
-    expect(() => parts[0].approveFallback(cohortId)).to.throw(/SIGNAL_MISMATCH|does not anchor/);
+    expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingSigning);
+    expect(parts[0].pendingFallbackRequests.get(cohortId)).to.be.undefined;
+    expect(() => parts[0].approveFallback(cohortId)).to.throw(/not in AwaitingFallbackSig phase/);
   });
 
   it('SMT: fallback completes and the witness verifies', async () => {

--- a/packages/aggregation/tests/aggregation-receive-path-dos.spec.ts
+++ b/packages/aggregation/tests/aggregation-receive-path-dos.spec.ts
@@ -1,0 +1,659 @@
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
+import { DidBtcr2 } from '@did-btcr2/method';
+import { p2tr, Transaction } from '@scure/btc-signer';
+import * as musig2 from '@scure/btc-signer/musig2';
+import { expect } from 'chai';
+import type { BaseMessage } from '../src/index.js';
+import {
+  AggregationCohort,
+  AggregationService,
+  AggregationServiceRunner,
+  BeaconSigningSession,
+  MAX_RETAINED_REJECTIONS,
+  ServiceCohortPhase,
+  createCohortOptInMessage,
+  createNonceContributionMessage,
+  createSignatureAuthorizationMessage,
+  createSubmitUpdateMessage,
+  createValidationAckMessage,
+} from '../src/index.js';
+import { MessageBus, MockTransport } from './helpers/mock-transport.js';
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+const VALUE = 100_000n;
+
+/** Three bytes: passes the `instanceof Uint8Array` wire guard, nothing else. */
+const SHORT_PK = Uint8Array.from([0x02, 0x03, 0x04]);
+/**
+ * 33 bytes with a legal compressed prefix whose x coordinate (2^256-1) exceeds
+ * the field modulus, so it is not a curve point. Passes a length check and only
+ * fails once something tries to decode it.
+ */
+const NON_POINT_PK = Uint8Array.from([0x02, ...new Array<number>(32).fill(0xff)]);
+
+function newDid(keys: SchnorrKeyPair): string {
+  return DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+}
+
+function createSignedUpdate(did: string, keys: SchnorrKeyPair): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const verificationMethodId = `${did}#initialKey`;
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [ { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } } ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : 2,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : verificationMethodId,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(verificationMethodId, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+/**
+ * A two-member cohort driven through the service state machine alone, with
+ * every message delivered by hand so a test can inject one from an outsider.
+ * `extraOptIns` are senders that opt in but are never accepted: a pending
+ * opt-in is the state an attacker reaches unaided, since opt-ins are open to
+ * anyone while a cohort is advertised.
+ */
+function formCohort(extraOptIns: Array<{ did: string; keys: SchnorrKeyPair }> = []) {
+  const serviceKeys = SchnorrKeyPair.generate();
+  const serviceDid = newDid(serviceKeys);
+  const keys = [ SchnorrKeyPair.generate(), SchnorrKeyPair.generate() ];
+  const dids = keys.map(newDid);
+  const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
+
+  const cohortId = service.createCohort({
+    minParticipants  : 2,
+    network          : 'mutinynet',
+    beaconType       : 'CASBeacon',
+    recoveryKey      : TEST_RECOVERY_KEY,
+    recoverySequence : TEST_RECOVERY_SEQUENCE,
+  });
+  service.advertise(cohortId);
+
+  const optIn = (did: string, k: SchnorrKeyPair) => service.receive(createCohortOptInMessage({
+    from            : did,
+    to              : serviceDid,
+    cohortId,
+    participantPk   : k.publicKey.compressed,
+    communicationPk : k.publicKey.compressed,
+  }));
+  dids.forEach((did, i) => optIn(did, keys[i]!));
+  extraOptIns.forEach(o => optIn(o.did, o.keys));
+  dids.forEach(did => service.acceptParticipant(cohortId, did));
+  service.finalizeKeygen(cohortId);
+
+  const submit = (did: string, k: SchnorrKeyPair) => service.receive(createSubmitUpdateMessage({
+    from         : did,
+    to           : serviceDid,
+    cohortId,
+    signedUpdate : createSignedUpdate(did, k) as unknown as Record<string, unknown>,
+  }));
+  const ack = (did: string, approved = true) => service.receive(createValidationAckMessage({
+    from : did, to : serviceDid, cohortId, approved,
+  }));
+
+  return { service, serviceDid, keys, dids, cohortId, submit, ack };
+}
+
+/**
+ * A cohort parked at Advertised, so a test can hand it an opt-in of its own
+ * making. Opt-ins are open while a cohort is advertised and cohort ids travel in
+ * a broadcast advert, so this is the state any stranger reaches unaided.
+ */
+function advertisedCohort() {
+  const serviceKeys = SchnorrKeyPair.generate();
+  const serviceDid = newDid(serviceKeys);
+  const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
+
+  const cohortId = service.createCohort({
+    minParticipants  : 2,
+    network          : 'mutinynet',
+    beaconType       : 'CASBeacon',
+    recoveryKey      : TEST_RECOVERY_KEY,
+    recoverySequence : TEST_RECOVERY_SEQUENCE,
+  });
+  service.advertise(cohortId);
+
+  const optIn = (from: string, participantPk: Uint8Array, communicationPk: Uint8Array = participantPk) =>
+    service.receive(createCohortOptInMessage({
+      from, to : serviceDid, cohortId, participantPk, communicationPk,
+    }));
+
+  /** Two honest members opting in and being accepted, for the survival checks. */
+  const members = [ SchnorrKeyPair.generate(), SchnorrKeyPair.generate() ];
+  const memberDids = members.map(newDid);
+  const formHonestly = () => {
+    memberDids.forEach((did, i) => optIn(did, members[i]!.publicKey.compressed));
+    memberDids.forEach(did => service.acceptParticipant(cohortId, did));
+    return service.finalizeKeygen(cohortId);
+  };
+
+  return { service, serviceDid, cohortId, optIn, members, memberDids, formHonestly };
+}
+
+/** The same cohort, carried through validation into an open MuSig2 signing round. */
+function toSigning() {
+  const ctx = formCohort();
+  const { service, cohortId, dids, keys, submit, ack } = ctx;
+  dids.forEach((did, i) => submit(did, keys[i]!));
+  service.buildAndDistribute(cohortId);
+  dids.forEach(did => ack(did));
+
+  const cohort = service.getCohort(cohortId)!;
+  const payment = p2tr(musig2.keyAggExport(musig2.keyAggregate(cohort.cohortKeys)));
+  const tx = new Transaction({ version: 2, allowUnknownOutputs: true });
+  tx.addInput({ txid: '00'.repeat(32), index: 0, witnessUtxo: { amount: VALUE, script: payment.script } });
+  tx.addOutput({ script: payment.script, amount: VALUE - 500n });
+  service.startSigning(cohortId, { tx, prevOutScripts: [payment.script], prevOutValues: [VALUE] });
+  const sessionId = service.getSigningSessionId(cohortId)!;
+
+  // Member-side sessions, so the test can produce real nonces and partial sigs.
+  const sessions = dids.map(() => new BeaconSigningSession({
+    cohort, pendingTx : tx, prevOutScripts : [payment.script], prevOutValues : [VALUE],
+  }));
+  const nonces = sessions.map((s, i) => s.generateNonceContribution(
+    keys[i]!.publicKey.compressed, keys[i]!.secretKey.bytes,
+  ));
+
+  const sendNonce = (i: number, nonceContribution: Uint8Array = nonces[i]!, from = dids[i]!) =>
+    service.receive(createNonceContributionMessage({
+      from, to : ctx.serviceDid, cohortId, sessionId, nonceContribution,
+    }));
+  const sendPartialSig = (partialSignature: Uint8Array, from: string) =>
+    service.receive(createSignatureAuthorizationMessage({
+      from, to : ctx.serviceDid, cohortId, sessionId, partialSignature,
+    }));
+  /** Aggregate the nonces the service holds and hand them to the member sessions. */
+  const openPartialSigRound = () => {
+    service.sendAggregatedNonce(cohortId);
+    const aggregatedNonce = musig2.nonceAggregate(nonces);
+    sessions.forEach(s => { s.aggregatedNonce = aggregatedNonce; });
+    return sessions.map((s, i) => s.generatePartialSignature(keys[i]!.secretKey.bytes));
+  };
+
+  return { ...ctx, sessionId, nonces, sendNonce, sendPartialSig, openPartialSigRound };
+}
+
+/** Drain and return only the rejection codes recorded for a cohort. */
+function codes(service: AggregationService, cohortId: string): string[] {
+  return service.drainRejections(cohortId).map(r => r.code);
+}
+
+describe('H5: one inbound message cannot kill a cohort', () => {
+
+  describe('cohort formation and update collection', () => {
+    it('drops a non-member VALIDATION_ACK instead of throwing, and the round still validates', () => {
+      const { service, serviceDid, cohortId, dids, keys, submit, ack } = formCohort();
+      dids.forEach((did, i) => submit(did, keys[i]!));
+      service.buildAndDistribute(cohortId);
+      service.drainRejections(cohortId);
+
+      const outsider = newDid(SchnorrKeyPair.generate());
+      expect(() => service.receive(createValidationAckMessage({
+        from : outsider, to : serviceDid, cohortId, approved : true,
+      }))).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['NOT_A_MEMBER']);
+      expect(service.validationProgress(cohortId).approved.has(outsider)).to.be.false;
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      // The members' own acks still carry the cohort to Validated.
+      dids.forEach(did => ack(did));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
+    });
+
+    it('drops a SUBMIT_UPDATE from a pending opt-in that was never accepted', () => {
+      const attackerKeys = SchnorrKeyPair.generate();
+      const attackerDid = newDid(attackerKeys);
+      const { service, serviceDid, cohortId, dids, keys, submit } = formCohort([{ did: attackerDid, keys: attackerKeys }]);
+
+      // The update is genuinely signed by the sender's own opt-in key, so it
+      // passes proof verification: only membership rules it out.
+      expect(() => service.receive(createSubmitUpdateMessage({
+        from         : attackerDid,
+        to           : serviceDid,
+        cohortId,
+        signedUpdate : createSignedUpdate(attackerDid, attackerKeys) as unknown as Record<string, unknown>,
+      }))).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['NOT_A_MEMBER']);
+      expect(service.collectedUpdates(cohortId).has(attackerDid)).to.be.false;
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+
+      dids.forEach((did, i) => submit(did, keys[i]!));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.UpdatesCollected);
+    });
+
+    it('drops an update whose proof carries a non-string verificationMethod', () => {
+      const { service, serviceDid, cohortId, dids, keys } = formCohort();
+      const update = createSignedUpdate(dids[0]!, keys[0]!) as unknown as Record<string, unknown>;
+      (update.proof as Record<string, unknown>).verificationMethod = 42;
+
+      expect(() => service.receive(createSubmitUpdateMessage({
+        from : dids[0]!, to : serviceDid, cohortId, signedUpdate : update,
+      }))).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['UPDATE_VERIFICATION_FAILED']);
+      expect(service.collectedUpdates(cohortId).has(dids[0]!)).to.be.false;
+    });
+
+    it('counts a member VALIDATION_ACK once, so a retry cannot settle the round early', () => {
+      const { service, cohortId, dids, keys, submit, ack } = formCohort();
+      dids.forEach((did, i) => submit(did, keys[i]!));
+      service.buildAndDistribute(cohortId);
+      service.drainRejections(cohortId);
+
+      ack(dids[0]!);
+      // A retry with the opposite answer: counted twice it would satisfy
+      // hasAllValidationResponses and fail the cohort while member 1 is pending.
+      expect(() => ack(dids[0]!, false)).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['DUPLICATE_RESPONSE']);
+      const progress = service.validationProgress(cohortId);
+      expect(progress.approved.has(dids[0]!)).to.be.true;
+      expect(progress.rejected.size).to.equal(0);
+      expect([...progress.pending]).to.deep.equal([dids[1]!]);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+    });
+  });
+
+  describe('opt-in keys', () => {
+    it('rejects an opt-in whose participantPk is too short, and the cohort still forms', () => {
+      const { service, cohortId, optIn, formHonestly } = advertisedCohort();
+      const attackerDid = newDid(SchnorrKeyPair.generate());
+
+      expect(() => optIn(attackerDid, SHORT_PK)).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_PARTICIPANT_KEY']);
+      // Nothing stored, so the key never reaches the sorted cohort key list.
+      expect(service.pendingOptIns(cohortId).has(attackerDid)).to.be.false;
+      expect(() => service.acceptParticipant(cohortId, attackerDid)).to.throw(/No pending opt-in/);
+
+      expect(() => formHonestly()).to.not.throw();
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+    });
+
+    it('rejects an opt-in whose 33-byte participantPk is not a curve point', () => {
+      const { service, cohortId, optIn, formHonestly } = advertisedCohort();
+      const attackerDid = newDid(SchnorrKeyPair.generate());
+
+      expect(() => optIn(attackerDid, NON_POINT_PK)).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_PARTICIPANT_KEY']);
+      expect(service.pendingOptIns(cohortId).has(attackerDid)).to.be.false;
+      expect(() => service.acceptParticipant(cohortId, attackerDid)).to.throw(/No pending opt-in/);
+
+      // Key aggregation is where a 33-byte non-point detonates, so keygen is the
+      // proof that none was retained.
+      expect(() => formHonestly()).to.not.throw();
+      expect(service.getCohort(cohortId)!.beaconAddress).to.match(/^tb1p/);
+    });
+
+    it('rejects an opt-in whose communicationPk is malformed', () => {
+      const { service, cohortId, optIn, formHonestly } = advertisedCohort();
+      const attackerKeys = SchnorrKeyPair.generate();
+      const attackerDid = newDid(attackerKeys);
+
+      expect(() => optIn(attackerDid, attackerKeys.publicKey.compressed, SHORT_PK)).to.not.throw();
+
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_PARTICIPANT_KEY']);
+      expect(service.pendingOptIns(cohortId).has(attackerDid)).to.be.false;
+
+      // A stored communicationPk is handed to transport.registerPeer, which
+      // refuses anything that is not a compressed key.
+      expect(() => optIn(attackerDid, attackerKeys.publicKey.compressed, NON_POINT_PK)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_PARTICIPANT_KEY']);
+      expect(service.pendingOptIns(cohortId).has(attackerDid)).to.be.false;
+
+      expect(() => formHonestly()).to.not.throw();
+    });
+
+    it('keeps accepting honest opt-ins', () => {
+      const { service, cohortId, optIn, members, memberDids } = advertisedCohort();
+      memberDids.forEach((did, i) => optIn(did, members[i]!.publicKey.compressed));
+
+      expect(service.drainRejections(cohortId)).to.be.empty;
+      expect([...service.pendingOptIns(cohortId).keys()]).to.deep.equal(memberDids);
+
+      memberDids.forEach(did => service.acceptParticipant(cohortId, did));
+      const cohort = service.getCohort(cohortId)!;
+      expect(cohort.participants).to.deep.equal(memberDids);
+      expect(cohort.cohortKeys).to.have.length(2);
+
+      service.finalizeKeygen(cohortId);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+    });
+
+    it('leaves participants and cohort keys in step when acceptParticipant refuses', () => {
+      const { service, cohortId, optIn, members, memberDids } = advertisedCohort();
+      memberDids.forEach((did, i) => optIn(did, members[i]!.publicKey.compressed));
+
+      // pendingOptIns hands back the live records the operator holds. The
+      // receive path now refuses a malformed key on arrival, so this stands in
+      // for a driver that supplies its own opt-in record (a resumed or
+      // externally persisted cohort) and calls the operator action directly.
+      const record = service.pendingOptIns(cohortId).get(memberDids[0]!)!;
+      record.participantPk = SHORT_PK;
+
+      expect(() => service.acceptParticipant(cohortId, memberDids[0]!)).to.throw(/compressed secp256k1/);
+
+      // A cohort carrying more members than keys can never finish a signing
+      // round: every round waits for one contribution per participant.
+      const cohort = service.getCohort(cohortId)!;
+      expect(cohort.participants).to.not.include(memberDids[0]!);
+      expect(cohort.participants.length).to.equal(cohort.cohortKeys.length);
+      expect(cohort.participantKeys.has(memberDids[0]!)).to.be.false;
+
+      // The refusal is not sticky: with a real key the same DID still joins.
+      record.participantPk = members[0]!.publicKey.compressed;
+      expect(() => service.acceptParticipant(cohortId, memberDids[0]!)).to.not.throw();
+      expect(() => service.acceptParticipant(cohortId, memberDids[1]!)).to.not.throw();
+      expect(() => service.finalizeKeygen(cohortId)).to.not.throw();
+    });
+
+    it('refuses a 33-byte non-point at acceptParticipant rather than at keygen', () => {
+      const { service, cohortId, optIn, members, memberDids } = advertisedCohort();
+      memberDids.forEach((did, i) => optIn(did, members[i]!.publicKey.compressed));
+
+      const record = service.pendingOptIns(cohortId).get(memberDids[0]!)!;
+      record.participantPk = NON_POINT_PK;
+
+      expect(() => service.acceptParticipant(cohortId, memberDids[0]!)).to.throw(/compressed secp256k1/);
+
+      const cohort = service.getCohort(cohortId)!;
+      expect(cohort.participants).to.not.include(memberDids[0]!);
+      expect(cohort.participants.length).to.equal(cohort.cohortKeys.length);
+    });
+
+    it('a cohort refuses a key that is not a compressed secp256k1 point', () => {
+      const cohort = new AggregationCohort({ network: 'mutinynet' });
+      const good = SchnorrKeyPair.generate().publicKey.compressed;
+      cohort.cohortKeys = [good];
+
+      expect(() => { cohort.cohortKeys = [good, SHORT_PK]; }).to.throw(/compressed secp256k1/);
+      expect(() => { cohort.cohortKeys = [good, NON_POINT_PK]; }).to.throw(/compressed secp256k1/);
+      expect(cohort.cohortKeys).to.deep.equal([good]);
+    });
+  });
+
+  describe('signing round', () => {
+    it('drops a duplicate nonce contribution and keeps the first', () => {
+      const { service, cohortId, dids, sendNonce, sendPartialSig, openPartialSigRound } = toSigning();
+      sendNonce(0);
+      // An innocent transport retry, indistinguishable from a hostile replay.
+      expect(() => sendNonce(0)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['DUPLICATE_RESPONSE']);
+
+      // The round is untouched, and the retained nonce is the one the member
+      // holds: it signs against the aggregate and the round completes.
+      sendNonce(1);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.NoncesCollected);
+      const sigs = openPartialSigRound();
+      sigs.forEach((sig, i) => sendPartialSig(sig, dids[i]!));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+    });
+
+    it('rejects a malformed 66-byte nonce on arrival, and the sender can retry', () => {
+      const { service, cohortId, sendNonce } = toSigning();
+      sendNonce(0);
+
+      // 66 bytes of filler: the length check passes, the points do not decode.
+      expect(() => sendNonce(1, new Uint8Array(66).fill(7))).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_NONCE']);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.SigningStarted);
+
+      // Nothing was stored for the sender, so a valid contribution still lands.
+      sendNonce(1);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.NoncesCollected);
+      expect(() => service.sendAggregatedNonce(cohortId)).to.not.throw();
+    });
+
+    it('rejects a wrong-length nonce contribution', () => {
+      const { service, cohortId, sendNonce } = toSigning();
+      expect(() => sendNonce(0, new Uint8Array(65))).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_NONCE']);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.SigningStarted);
+    });
+
+    it('drops a nonce contribution from a non-member', () => {
+      const { service, cohortId, sendNonce, nonces } = toSigning();
+      const outsider = newDid(SchnorrKeyPair.generate());
+      expect(() => sendNonce(0, nonces[0]!, outsider)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['NOT_A_MEMBER']);
+    });
+
+    it('blames a bad partial signature instead of failing the round, and accepts the retry', () => {
+      const { service, cohortId, dids, sendNonce, sendPartialSig, openPartialSigRound } = toSigning();
+      sendNonce(0);
+      sendNonce(1);
+      const sigs = openPartialSigRound();
+      service.drainRejections(cohortId);
+
+      const corrupted = Uint8Array.from(sigs[0]!);
+      corrupted[0] ^= 0xff;
+      expect(() => sendPartialSig(corrupted, dids[0]!)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['INVALID_PARTIAL_SIG']);
+
+      // The honest member's contribution is unaffected, and the blamed member's
+      // corrected signature still completes the round (BIP-327 §2.3.5).
+      sendPartialSig(sigs[1]!, dids[1]!);
+      expect(service.getResult(cohortId)).to.be.undefined;
+      expect(() => sendPartialSig(sigs[0]!, dids[0]!)).to.not.throw();
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+      expect(service.getResult(cohortId)!.signature).to.have.length(64);
+    });
+
+    it('drops a duplicate partial signature and keeps the first', () => {
+      const { service, cohortId, dids, sendNonce, sendPartialSig, openPartialSigRound } = toSigning();
+      sendNonce(0);
+      sendNonce(1);
+      const sigs = openPartialSigRound();
+      service.drainRejections(cohortId);
+
+      sendPartialSig(sigs[0]!, dids[0]!);
+      expect(() => sendPartialSig(sigs[0]!, dids[0]!)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['DUPLICATE_RESPONSE']);
+
+      sendPartialSig(sigs[1]!, dids[1]!);
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+    });
+
+    it('drops a partial signature from a non-member', () => {
+      const { service, cohortId, sendNonce, sendPartialSig, openPartialSigRound } = toSigning();
+      sendNonce(0);
+      sendNonce(1);
+      const sigs = openPartialSigRound();
+      service.drainRejections(cohortId);
+
+      const outsider = newDid(SchnorrKeyPair.generate());
+      expect(() => sendPartialSig(sigs[0]!, outsider)).to.not.throw();
+      expect(codes(service, cohortId)).to.deep.equal(['NOT_A_MEMBER']);
+    });
+  });
+
+  describe('runner', () => {
+    it('a non-member VALIDATION_ACK is surfaced as an event, not a cohort failure', async () => {
+      const serviceKeys = SchnorrKeyPair.generate();
+      const serviceDid = newDid(serviceKeys);
+      const members = [ SchnorrKeyPair.generate(), SchnorrKeyPair.generate() ];
+      const memberDids = members.map(newDid);
+      const attackerKeys = SchnorrKeyPair.generate();
+      const attackerDid = newDid(attackerKeys);
+
+      const bus = new MessageBus();
+      const serviceTransport = new MockTransport(bus);
+      serviceTransport.registerActor(serviceDid, serviceKeys);
+      const senderTransport = new MockTransport(bus);
+      senderTransport.registerActor(memberDids[0]!, members[0]!);
+      senderTransport.registerActor(memberDids[1]!, members[1]!);
+      senderTransport.registerActor(attackerDid, attackerKeys);
+
+      const runner = new AggregationServiceRunner({
+        transport              : serviceTransport,
+        did                    : serviceDid,
+        keys                   : serviceKeys,
+        onProvideTxData        : async () => { throw new Error('signing is not reached in this test'); },
+        advertRepeatIntervalMs : 0,
+      });
+      const rejections: string[] = [];
+      runner.on('message-rejected', r => rejections.push(r.code));
+      runner.on('error', () => { /* a failed cohort would land here */ });
+
+      const { cohortId, completion } = runner.advertiseCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      let settled: string | undefined;
+      void completion.then(() => { settled = 'resolved'; }, () => { settled = 'rejected'; });
+
+      const send = async (message: BaseMessage, from: string) =>
+        senderTransport.sendMessage(message, from, serviceDid);
+
+      for(const [i, did] of memberDids.entries()) {
+        await send(createCohortOptInMessage({
+          from            : did,
+          to              : serviceDid,
+          cohortId,
+          participantPk   : members[i]!.publicKey.compressed,
+          communicationPk : members[i]!.publicKey.compressed,
+        }), did);
+      }
+      for(const [i, did] of memberDids.entries()) {
+        await send(createSubmitUpdateMessage({
+          from         : did,
+          to           : serviceDid,
+          cohortId,
+          signedUpdate : createSignedUpdate(did, members[i]!) as unknown as Record<string, unknown>,
+        }), did);
+      }
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      await send(createValidationAckMessage({
+        from : attackerDid, to : serviceDid, cohortId, approved : true,
+      }), attackerDid);
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(rejections).to.deep.equal(['NOT_A_MEMBER']);
+      // The cohort is still live: its state survived and nothing settled it.
+      expect(settled, 'cohort completion settled').to.be.undefined;
+      expect(runner.session.getCohort(cohortId)).to.exist;
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.DataDistributed);
+
+      runner.stop();
+      await completion.catch(() => { /* rejected by stop() */ });
+    });
+
+    it('a malformed opt-in key is surfaced as an event, not a cohort failure', async () => {
+      const serviceKeys = SchnorrKeyPair.generate();
+      const serviceDid = newDid(serviceKeys);
+      const members = [ SchnorrKeyPair.generate(), SchnorrKeyPair.generate() ];
+      const memberDids = members.map(newDid);
+      const attackerKeys = SchnorrKeyPair.generate();
+      const attackerDid = newDid(attackerKeys);
+
+      const bus = new MessageBus();
+      const serviceTransport = new MockTransport(bus);
+      serviceTransport.registerActor(serviceDid, serviceKeys);
+      const senderTransport = new MockTransport(bus);
+      senderTransport.registerActor(memberDids[0]!, members[0]!);
+      senderTransport.registerActor(memberDids[1]!, members[1]!);
+      senderTransport.registerActor(attackerDid, attackerKeys);
+
+      const runner = new AggregationServiceRunner({
+        transport              : serviceTransport,
+        did                    : serviceDid,
+        keys                   : serviceKeys,
+        onProvideTxData        : async () => { throw new Error('signing is not reached in this test'); },
+        advertRepeatIntervalMs : 0,
+      });
+      const rejections: string[] = [];
+      runner.on('message-rejected', r => rejections.push(r.code));
+      runner.on('error', () => { /* a failed cohort would land here */ });
+
+      const { cohortId, completion } = runner.advertiseCohort({
+        minParticipants  : 2,
+        network          : 'mutinynet',
+        beaconType       : 'CASBeacon',
+        recoveryKey      : TEST_RECOVERY_KEY,
+        recoverySequence : TEST_RECOVERY_SEQUENCE,
+      });
+      let settled: string | undefined;
+      void completion.then(() => { settled = 'resolved'; }, () => { settled = 'rejected'; });
+
+      const send = async (message: BaseMessage, from: string) =>
+        senderTransport.sendMessage(message, from, serviceDid);
+
+      // The default accept policy takes everyone, so one opt-in is all it takes
+      // to reach the sorted cohort key list.
+      await send(createCohortOptInMessage({
+        from            : attackerDid,
+        to              : serviceDid,
+        cohortId,
+        participantPk   : SHORT_PK,
+        communicationPk : attackerKeys.publicKey.compressed,
+      }), attackerDid);
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(rejections).to.deep.equal(['INVALID_PARTICIPANT_KEY']);
+      expect(settled, 'cohort completion settled').to.be.undefined;
+      expect(runner.session.getCohort(cohortId)).to.exist;
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Advertised);
+
+      // The cohort is not merely alive, it still works: the honest members join
+      // and keygen completes.
+      for(const [i, did] of memberDids.entries()) {
+        await send(createCohortOptInMessage({
+          from            : did,
+          to              : serviceDid,
+          cohortId,
+          participantPk   : members[i]!.publicKey.compressed,
+          communicationPk : members[i]!.publicKey.compressed,
+        }), did);
+      }
+      expect(runner.session.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.CohortSet);
+      expect(runner.session.getCohort(cohortId)!.participants).to.deep.equal(memberDids);
+
+      runner.stop();
+      await completion.catch(() => { /* rejected by stop() */ });
+    });
+  });
+
+  describe('rejection bookkeeping', () => {
+    it('bounds the retained rejection log', () => {
+      const { service, serviceDid, cohortId } = formCohort();
+      const outsider = newDid(SchnorrKeyPair.generate());
+      const flood = MAX_RETAINED_REJECTIONS + 50;
+      for(let i = 0; i < flood; i++) {
+        service.receive(createSubmitUpdateMessage({
+          from         : outsider,
+          to           : serviceDid,
+          cohortId,
+          signedUpdate : { spam: i } as unknown as Record<string, unknown>,
+        }));
+      }
+      expect(service.drainRejections(cohortId)).to.have.length(MAX_RETAINED_REJECTIONS);
+    });
+  });
+});

--- a/packages/aggregation/tests/aggregation-signal-binding.spec.ts
+++ b/packages/aggregation/tests/aggregation-signal-binding.spec.ts
@@ -1,0 +1,469 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { canonicalize, hash } from '@did-btcr2/common';
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import type { Btcr2DataIntegrityConfig, SignedBTCR2Update, UnsignedBTCR2Update } from '@did-btcr2/method';
+import { DidBtcr2 } from '@did-btcr2/method';
+import { bytesToHex } from '@noble/hashes/utils';
+import { Script, Transaction, p2tr } from '@scure/btc-signer';
+import { expect } from 'chai';
+import type { AggregationParticipantError, BaseMessage } from '../src/index.js';
+import {
+  AggregationParticipant,
+  AggregationService,
+  KeyPairAggregationSigner,
+  ParticipantCohortPhase,
+  ServiceCohortPhase,
+  buildFallbackLeaf,
+  buildRecoveryLeaves,
+  createAuthorizationRequestMessage,
+  createFallbackAuthorizationRequestMessage,
+  getBeaconStrategy,
+} from '../src/index.js';
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+const NET = getNetwork('mutinynet');
+const VALUE = 100_000n;
+
+function createSignedUpdate(did: string, keys: SchnorrKeyPair): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const verificationMethodId = `${did}#initialKey`;
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [ { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } } ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : 2,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : verificationMethodId,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(verificationMethodId, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+/**
+ * A two-member cohort driven directly through both state machines (no
+ * transport), formed and with every member's round response in. Messages are
+ * delivered by hand so a test can tamper with one on the way. Members listed in
+ * `decliners` take the cooperative non-inclusion path instead of submitting.
+ */
+function formCohort(beaconType: string, decliners: number[] = []) {
+  const serviceKeys = SchnorrKeyPair.generate();
+  const serviceDid = DidBtcr2.create(serviceKeys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+  const keys = [ SchnorrKeyPair.generate(), SchnorrKeyPair.generate() ];
+  const dids = keys.map(k => DidBtcr2.create(k.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' }));
+  const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
+  const parts = keys.map((k, i) => new AggregationParticipant({ did: dids[i], signer: new KeyPairAggregationSigner(k) }));
+
+  const toParts = (msgs: BaseMessage[]) => msgs.forEach(m => parts.forEach(p => {
+    if(!m.to || m.to === p.did) p.receive(m);
+  }));
+  const toService = (msgs: BaseMessage[]) => msgs.forEach(m => service.receive(m));
+
+  const cohortId = service.createCohort({
+    minParticipants  : 2,
+    network          : 'mutinynet',
+    beaconType,
+    recoveryKey      : TEST_RECOVERY_KEY,
+    recoverySequence : TEST_RECOVERY_SEQUENCE,
+  });
+  toParts(service.advertise(cohortId));
+  parts.forEach(p => toService(p.joinCohort(cohortId)));
+  dids.forEach(did => toParts(service.acceptParticipant(cohortId, did)));
+  toParts(service.finalizeKeygen(cohortId));
+  parts.forEach((p, i) => toService(decliners.includes(i)
+    ? p.declineUpdate(cohortId)
+    : p.submitUpdate(cohortId, createSignedUpdate(dids[i], keys[i]))));
+
+  return { service, parts, serviceDid, dids, keys, cohortId, toParts, toService };
+}
+
+/** The real script-tree beacon output script the cohort's address commits to. */
+function beaconScript(service: AggregationService, cohortId: string): Uint8Array {
+  const cohort = service.getCohort(cohortId)!;
+  const leaves = buildRecoveryLeaves('operator-funded', {
+    recoveryKey       : cohort.recoveryKey!,
+    recoverySequence  : cohort.recoverySequence!,
+    cohortKeys        : cohort.cohortKeys,
+    fallbackThreshold : cohort.effectiveFallbackThreshold,
+  });
+  return p2tr(cohort.internalKey, leaves, NET, true).script;
+}
+
+interface BeaconTxOptions {
+  /** OP_RETURN payloads, appended in order after the change output. */
+  signals: Uint8Array[];
+  /** Change destination script; defaults to the beacon script (roll forward). */
+  changeScript?: Uint8Array;
+  /** Change amount; defaults to the input value less a 500 sat fee. */
+  changeAmount?: bigint;
+  /** Value assigned to the LAST OP_RETURN output; defaults to 0. */
+  signalAmount?: bigint;
+  /** Number of inputs spending the beacon UTXO; defaults to 1. */
+  inputs?: number;
+}
+
+/** A beacon announcement tx: change output first, signal OP_RETURN(s) after. */
+function beaconTx(script: Uint8Array, options: BeaconTxOptions): Transaction {
+  const { signals, changeScript, changeAmount, signalAmount, inputs = 1 } = options;
+  const tx = new Transaction({ version: 2, allowUnknownInputs: true, allowUnknownOutputs: true });
+  for(let i = 0; i < inputs; i++) {
+    tx.addInput({ txid: `${(i + 0x22).toString(16)}`.repeat(32).slice(0, 64), index: 0, witnessUtxo: { script, amount: VALUE } });
+  }
+  tx.addOutput({ script: changeScript ?? script, amount: changeAmount ?? VALUE - 500n });
+  signals.forEach((signal, i) => tx.addOutput({
+    script : Script.encode([ 'RETURN', signal ]),
+    amount : i === signals.length - 1 ? signalAmount ?? 0n : 0n,
+  }));
+  return tx;
+}
+
+/** An outsider-controlled P2TR script (a coordinator's own drain destination). */
+function outsiderScript(): Uint8Array {
+  return p2tr(SchnorrKeyPair.generate().publicKey.x, undefined, NET).script;
+}
+
+/** Assert `fn` throws a participant error with the given type and message. */
+function expectRefusal(fn: () => unknown, type: string, message: RegExp): void {
+  try {
+    fn();
+  } catch (error) {
+    expect((error as AggregationParticipantError).type, 'error type').to.equal(type);
+    expect((error as Error).message, 'error message').to.match(message);
+    return;
+  }
+  expect.fail(`expected a refusal of type ${type}`);
+}
+
+describe('Aggregate beacon announcement binding', () => {
+
+  describe('validated data binds the announced signal (audit H2)', () => {
+
+    it('CAS: rejects a map that includes the member when the signal excludes it', () => {
+      const { service, parts, dids, cohortId, toParts } = formCohort('CASBeacon');
+      const messages = service.buildAndDistribute(cohortId);
+      const honestMap = { ...service.getCohort(cohortId)!.casAnnouncement! };
+
+      // The coordinator distributes the honest map (the member's update IS in it)
+      // but announces the hash of a map that omits the member.
+      const excludingMap = { ...honestMap };
+      delete excludingMap[dids[0]];
+      messages[0].body!.signalBytesHex = bytesToHex(hash(canonicalize(excludingMap)));
+      toParts(messages);
+
+      const validation = parts[0].getValidation(cohortId)!;
+      expect(validation.casAnnouncement![dids[0]]).to.be.a('string');
+      expect(validation.matches).to.be.false;
+    });
+
+    it('CAS: accepts the announcement the distributed map derives to', () => {
+      const { service, parts, cohortId, toParts } = formCohort('CASBeacon');
+      toParts(service.buildAndDistribute(cohortId));
+
+      const validation = parts[0].getValidation(cohortId)!;
+      expect(validation.matches).to.be.true;
+      expect(validation.signalBytesHex).to.equal(bytesToHex(service.getCohort(cohortId)!.signalBytes!));
+    });
+
+    it('SMT: rejects a valid inclusion proof announced under a different root', () => {
+      const { service, parts, cohortId, toParts } = formCohort('SMTBeacon');
+      const messages = service.buildAndDistribute(cohortId);
+      messages[0].body!.signalBytesHex = bytesToHex(new Uint8Array(32).fill(0xbe));
+      toParts(messages);
+
+      const validation = parts[0].getValidation(cohortId)!;
+      // The proof itself still verifies: only the announced root is foreign.
+      expect(validation.smtProof!.id).to.be.a('string');
+      expect(validation.matches).to.be.false;
+    });
+
+    it('SMT: accepts the announcement equal to the proof root', () => {
+      const { service, parts, cohortId, toParts } = formCohort('SMTBeacon');
+      toParts(service.buildAndDistribute(cohortId));
+
+      const validation = parts[0].getValidation(cohortId)!;
+      expect(validation.matches).to.be.true;
+      expect(validation.signalBytesHex).to.equal(bytesToHex(service.getCohort(cohortId)!.signalBytes!));
+    });
+
+    it('fails closed when no signal is announced at all', () => {
+      const { service, parts, cohortId, toParts } = formCohort('CASBeacon');
+      const messages = service.buildAndDistribute(cohortId);
+      delete messages[0].body!.signalBytesHex;
+      toParts(messages);
+
+      expect(parts[0].getValidation(cohortId)!.matches).to.be.false;
+    });
+
+    it('CAS: a decliner binds its non-inclusion to the announced signal', () => {
+      // A decliner validates absence from the map, which every map it is absent
+      // from satisfies; without the binding its signature is the easiest to
+      // redirect onto an unrelated announcement.
+      const tampered = formCohort('CASBeacon', [ 1 ]);
+      const tamperedMessages = tampered.service.buildAndDistribute(tampered.cohortId);
+      tamperedMessages.find(m => m.to === tampered.dids[1])!.body!.signalBytesHex =
+        bytesToHex(new Uint8Array(32).fill(0x11));
+      tampered.toParts(tamperedMessages);
+      expect(tampered.parts[1].getValidation(tampered.cohortId)!.matches, 'foreign signal').to.be.false;
+
+      const honest = formCohort('CASBeacon', [ 1 ]);
+      honest.toParts(honest.service.buildAndDistribute(honest.cohortId));
+      const validation = honest.parts[1].getValidation(honest.cohortId)!;
+      expect(validation.included, 'decliner').to.be.false;
+      expect(validation.matches, 'honest signal').to.be.true;
+    });
+
+    it('the strategies derive the signal the cohort anchors', () => {
+      const cas = formCohort('CASBeacon');
+      cas.service.buildAndDistribute(cas.cohortId);
+      const casCohort = cas.service.getCohort(cas.cohortId)!;
+      const casDerived = getBeaconStrategy('CASBeacon')!.deriveSignal({ matches: true, casAnnouncement: casCohort.casAnnouncement });
+      expect(bytesToHex(casDerived!)).to.equal(bytesToHex(casCohort.signalBytes!));
+
+      const smt = formCohort('SMTBeacon');
+      smt.service.buildAndDistribute(smt.cohortId);
+      const smtCohort = smt.service.getCohort(smt.cohortId)!;
+      const smtDerived = getBeaconStrategy('SMTBeacon')!.deriveSignal({
+        matches  : true,
+        smtProof : smtCohort.smtProofs!.get(smt.dids[0]),
+      });
+      expect(bytesToHex(smtDerived!)).to.equal(bytesToHex(smtCohort.signalBytes!));
+
+      // Nothing to derive from: fail closed rather than bind to nothing.
+      expect(getBeaconStrategy('CASBeacon')!.deriveSignal({ matches: true })).to.be.undefined;
+      expect(getBeaconStrategy('SMTBeacon')!.deriveSignal({ matches: true })).to.be.undefined;
+    });
+
+    it('refuses to sign after an unbound announcement, even if the member approved it', () => {
+      const { service, parts, dids, cohortId, toParts, toService } = formCohort('CASBeacon');
+      const messages = service.buildAndDistribute(cohortId);
+      const honestMap = { ...service.getCohort(cohortId)!.casAnnouncement! };
+      const excludingMap = { ...honestMap };
+      delete excludingMap[dids[0]];
+      const excludingSignal = hash(canonicalize(excludingMap));
+      messages[0].body!.signalBytesHex = bytesToHex(excludingSignal);
+      toParts(messages);
+
+      // The member (or its UI) approves anyway; the signature boundary still holds.
+      parts.forEach(p => toService(p.approveValidation(cohortId)));
+      const script = beaconScript(service, cohortId);
+      const tx = beaconTx(script, { signals: [ excludingSignal ] });
+      toParts(service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] }));
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'UNVALIDATED_DATA', /did not validate/);
+    });
+  });
+
+  describe('beacon transaction structure (audit H3)', () => {
+
+    /** Form, validate and hand the cohort a transaction, ready for approveNonce. */
+    function readyToSign(options: Omit<BeaconTxOptions, 'signals'> & { signals?: (signal: Uint8Array) => Uint8Array[] }) {
+      const harness = formCohort('CASBeacon');
+      const { service, parts, cohortId, toParts, toService } = harness;
+      toParts(service.buildAndDistribute(cohortId));
+      parts.forEach(p => toService(p.approveValidation(cohortId)));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Validated);
+
+      const signal = service.getCohort(cohortId)!.signalBytes!;
+      const script = beaconScript(service, cohortId);
+      const { signals, ...rest } = options;
+      const tx = beaconTx(script, { ...rest, signals: signals ? signals(signal) : [ signal ] });
+      toParts(service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] }));
+      return { ...harness, signal, script, tx };
+    }
+
+    it('refuses a tx whose LAST output announces a foreign signal', () => {
+      // The member's own signal is present, just not where resolution reads it:
+      // every resolver takes the signal from the last output.
+      const foreign = new Uint8Array(32).fill(0xbe);
+      const { parts, cohortId } = readyToSign({ signals: signal => [ signal, foreign ] });
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'SIGNAL_MISMATCH', /last output/);
+    });
+
+    it('signs a well-formed beacon tx (change, then the signal last)', () => {
+      const { parts, cohortId } = readyToSign({});
+      const messages = parts[0].approveNonce(cohortId);
+
+      expect(messages).to.have.lengthOf(1);
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+    });
+
+    it('refuses a tx that burns value in the signal output', () => {
+      const { parts, cohortId } = readyToSign({ signalAmount: 1_000n });
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'INVALID_TX_STRUCTURE', /burns value/);
+    });
+
+    it('refuses a tx carrying a second OP_RETURN output', () => {
+      const { parts, cohortId } = readyToSign({ signals: signal => [ new Uint8Array(32).fill(0x77), signal ] });
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'INVALID_TX_STRUCTURE', /2 OP_RETURN outputs/);
+    });
+
+    it('refuses a tx that spends more than one input', () => {
+      // The protocol conveys a single prevout, so the member cannot see, check
+      // or correctly sign a second input.
+      const { parts, cohortId } = readyToSign({ inputs: 2 });
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'INVALID_TX_STRUCTURE', /spends 2 inputs/);
+    });
+
+    it('refuses a tx whose outputs exceed the value of the input', () => {
+      const { parts, cohortId } = readyToSign({ changeAmount: VALUE + 1n });
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'INVALID_TX_STRUCTURE', /from an input of/);
+    });
+
+    it('refuses a malformed prevOutValue', () => {
+      const { service, parts, serviceDid, dids, cohortId, toParts, toService } = formCohort('CASBeacon');
+      toParts(service.buildAndDistribute(cohortId));
+      parts.forEach(p => toService(p.approveValidation(cohortId)));
+      const script = beaconScript(service, cohortId);
+      const tx = beaconTx(script, { signals: [ service.getCohort(cohortId)!.signalBytes! ] });
+      // Start the session but deliver a hand-built request instead, so the
+      // member's stored prevOutValue is the junk one.
+      service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] });
+
+      parts[0].receive(createAuthorizationRequestMessage({
+        from             : serviceDid,
+        to               : dids[0],
+        cohortId,
+        sessionId        : service.getSigningSessionId(cohortId)!,
+        pendingTx        : tx.hex,
+        prevOutScriptHex : bytesToHex(script),
+        prevOutValue     : 'not-a-number',
+      }) as never);
+
+      expectRefusal(() => parts[0].approveNonce(cohortId), 'INVALID_PREVOUT_VALUE', /malformed prevOutValue/);
+    });
+
+    it('applies the same checks on the fallback path', () => {
+      // A member still in ValidationSent has no optimistic tx to compare
+      // against, so only the structural checks stand between it and a signature.
+      const { service, parts, serviceDid, dids, cohortId, toParts, toService } = formCohort('CASBeacon');
+      toParts(service.buildAndDistribute(cohortId));
+      parts.forEach(p => toService(p.approveValidation(cohortId)));
+      const cohort = service.getCohort(cohortId)!;
+      const script = beaconScript(service, cohortId);
+      const tx = beaconTx(script, { signals: [ cohort.signalBytes! ] });
+      service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] });
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+
+      const foreign = beaconTx(script, { signals: [ new Uint8Array(32).fill(0xbe) ] });
+      const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+      parts[0].receive(createFallbackAuthorizationRequestMessage({
+        from                  : serviceDid,
+        to                    : dids[0],
+        cohortId,
+        sessionId             : service.getSigningSessionId(cohortId)!,
+        pendingTx             : foreign.hex,
+        prevOutScriptHex      : bytesToHex(script),
+        prevOutValue          : VALUE.toString(),
+        fallbackLeafScriptHex : bytesToHex(leaf),
+      }) as never);
+
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+      expectRefusal(() => parts[0].approveFallback(cohortId), 'SIGNAL_MISMATCH', /last output/);
+    });
+  });
+
+  describe('fallback binds to the optimistic transaction (audit H4)', () => {
+
+    /** Form, validate, start signing and contribute a nonce for both members. */
+    function noncesContributed() {
+      const harness = formCohort('CASBeacon');
+      const { service, parts, cohortId, toParts, toService } = harness;
+      toParts(service.buildAndDistribute(cohortId));
+      parts.forEach(p => toService(p.approveValidation(cohortId)));
+      const cohort = service.getCohort(cohortId)!;
+      const script = beaconScript(service, cohortId);
+      const optimisticTx = beaconTx(script, { signals: [ cohort.signalBytes! ] });
+      toParts(service.startSigning(cohortId, { tx: optimisticTx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] }));
+      parts.forEach(p => toService(p.approveNonce(cohortId)));
+      return { ...harness, cohort, script, optimisticTx };
+    }
+
+    function fallbackRequest(
+      harness: ReturnType<typeof noncesContributed>,
+      pendingTx: Transaction,
+      sessionId?: string,
+    ): BaseMessage {
+      const { service, serviceDid, dids, cohortId, cohort, script } = harness;
+      const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+      return createFallbackAuthorizationRequestMessage({
+        from                  : serviceDid,
+        to                    : dids[0],
+        cohortId,
+        sessionId             : sessionId ?? service.getSigningSessionId(cohortId)!,
+        pendingTx             : pendingTx.hex,
+        prevOutScriptHex      : bytesToHex(script),
+        prevOutValue          : VALUE.toString(),
+        fallbackLeafScriptHex : bytesToHex(leaf),
+      });
+    }
+
+    it('ignores a fallback request carrying a different transaction', () => {
+      const harness = noncesContributed();
+      const { parts, cohortId, cohort, script } = harness;
+
+      // Same validated signal, different outputs: signing it would give the
+      // coordinator a script-path witness for a spend competing with the
+      // key-path signature this member is midway through producing.
+      const competing = beaconTx(script, { signals: [ cohort.signalBytes! ], changeScript: outsiderScript() });
+      parts[0].receive(fallbackRequest(harness, competing) as never);
+
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+      expect(parts[0].pendingFallbackRequests.get(cohortId)).to.be.undefined;
+    });
+
+    it('leaves the optimistic round intact after a rejected fallback request', () => {
+      const harness = noncesContributed();
+      const { service, parts, cohortId, cohort, script, toParts, toService } = harness;
+
+      const competing = beaconTx(script, { signals: [ cohort.signalBytes! ], changeScript: outsiderScript() });
+      parts[0].receive(fallbackRequest(harness, competing, 'not-the-session') as never);
+
+      // The secret nonce survived: the honest key-path round still completes.
+      toParts(service.sendAggregatedNonce(cohortId));
+      parts.forEach(p => toService(p.generatePartialSignature(cohortId)));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+      expect(service.getResult(cohortId)!.path).to.equal('key-path');
+    });
+
+    it('accepts and signs the fallback for the optimistic transaction', () => {
+      const harness = noncesContributed();
+      const { parts, cohortId, optimisticTx } = harness;
+
+      parts[0].receive(fallbackRequest(harness, optimisticTx) as never);
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+
+      const messages = parts[0].approveFallback(cohortId);
+      expect(messages).to.have.lengthOf(1);
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.Complete);
+    });
+
+    it('ignores a fallback request that differs only in its change amount', () => {
+      const harness = noncesContributed();
+      const { parts, cohortId, cohort, script } = harness;
+
+      const higherFee = beaconTx(script, { signals: [ cohort.signalBytes! ], changeAmount: VALUE - 50_000n });
+      parts[0].receive(fallbackRequest(harness, higherFee) as never);
+
+      expect(parts[0].getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+    });
+  });
+});

--- a/packages/aggregation/tests/aggregation-transport-sender-auth.spec.ts
+++ b/packages/aggregation/tests/aggregation-transport-sender-auth.spec.ts
@@ -1,0 +1,805 @@
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { SchnorrMultikey } from '@did-btcr2/cryptosuite';
+import { SchnorrKeyPair } from '@did-btcr2/keypair';
+import type {
+  Btcr2DataIntegrityConfig,
+  GenesisDocumentLike,
+  SignedBTCR2Update,
+  UnsignedBTCR2Update,
+} from '@did-btcr2/method';
+import { DidBtcr2, GenesisDocument, resolveBtcr2SenderPk } from '@did-btcr2/method';
+import { bytesToHex } from '@noble/hashes/utils';
+import { Script, Transaction, p2tr } from '@scure/btc-signer';
+import { expect } from 'chai';
+import type { Event, EventTemplate } from 'nostr-tools';
+import { finalizeEvent, nip44 } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+
+import type { BaseBody, HttpRequestLike } from '../src/index.js';
+import {
+  AGGREGATED_NONCE,
+  AggregationParticipant,
+  AggregationParticipantRunner,
+  AggregationService,
+  BaseMessage,
+  COHORT_ADVERT,
+  COHORT_OPT_IN,
+  FALLBACK_AUTHORIZATION_REQUEST,
+  HTTP_ROUTE,
+  HttpClientTransport,
+  HttpServerTransport,
+  KeyPairAggregationSigner,
+  NostrTransport,
+  ParticipantCohortPhase,
+  SILENT_LOGGER,
+  SSE_EVENT,
+  ServiceCohortPhase,
+  buildFallbackLeaf,
+  buildRecoveryLeaves,
+  createFallbackAuthorizationRequestMessage,
+  signEnvelope,
+} from '../src/index.js';
+
+/**
+ * Transport sender authentication and inner/outer `from` binding (audit H6).
+ *
+ * Every message in the protocol declares its own sender DID, and the protocol acts on
+ * that claim. Each transport authenticates a *key* (a signed Nostr event, a signed HTTP
+ * envelope); these tests pin that the claim is bound to that key on every receive path,
+ * and that the participant state machine refuses service-originated messages that do not
+ * come from its cohort's service.
+ */
+
+const TEST_RECOVERY_KEY = 'a'.repeat(64);
+const TEST_RECOVERY_SEQUENCE = 144;
+const NET = getNetwork('mutinynet');
+const VALUE = 100_000n;
+
+const k1Did = (keys: SchnorrKeyPair): string =>
+  DidBtcr2.create(keys.publicKey.compressed, { idType: 'KEY', network: 'mutinynet' });
+
+/** An x1 identity: keys, a genesis whose capabilityInvocation[0] is those keys, and the
+ *  x1 DID minted from that genesis (ADR 066). */
+function externalIdentity(): { keys: SchnorrKeyPair; did: string; genesisDocument: Record<string, unknown> } {
+  const keys = SchnorrKeyPair.generate();
+  const genesisDocument: Record<string, unknown> = {
+    'id'                 : 'did:btcr2:_',
+    '@context'           : ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+    'verificationMethod' : [{
+      'id'                 : 'did:btcr2:_#key-0',
+      'type'               : 'Multikey',
+      'controller'         : 'did:btcr2:_',
+      'publicKeyMultibase' : keys.publicKey.multibase.encoded,
+    }],
+    'authentication'       : ['did:btcr2:_#key-0'],
+    'assertionMethod'      : ['did:btcr2:_#key-0'],
+    'capabilityInvocation' : ['did:btcr2:_#key-0'],
+    'capabilityDelegation' : ['did:btcr2:_#key-0'],
+    'service'              : [{
+      'id'              : 'did:btcr2:_#service-0',
+      'type'            : 'SingletonBeacon',
+      'serviceEndpoint' : 'bitcoin:mhME7XiWpho6Ft4pvT3U3h6X8hHtE58ZDJ',
+    }],
+  };
+  const genesisBytes = GenesisDocument.toGenesisBytes(genesisDocument as GenesisDocumentLike);
+  return { keys, did: DidBtcr2.create(genesisBytes, { idType: 'EXTERNAL', network: 'mutinynet' }), genesisDocument };
+}
+
+function createSignedUpdate(did: string, keys: SchnorrKeyPair): SignedBTCR2Update {
+  const context = [
+    'https://w3id.org/security/v2',
+    'https://w3id.org/zcap/v1',
+    'https://w3id.org/json-ld-patch/v1',
+    'https://btcr2.dev/context/v1',
+  ];
+  const verificationMethodId = `${did}#initialKey`;
+  const unsigned: UnsignedBTCR2Update = {
+    '@context'      : context,
+    patch           : [ { op: 'add', path: '/service/-', value: { id: `${did}#svc`, type: 'Test', serviceEndpoint: 'https://example.com' } } ],
+    sourceHash      : `zQmSourceHash${did.slice(-6)}`,
+    targetHash      : `zQmTargetHash${did.slice(-6)}`,
+    targetVersionId : 2,
+  };
+  const config: Btcr2DataIntegrityConfig = {
+    '@context'         : context,
+    cryptosuite        : 'bip340-jcs-2025',
+    type               : 'DataIntegrityProof',
+    verificationMethod : verificationMethodId,
+    proofPurpose       : 'capabilityInvocation',
+    capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+    capabilityAction   : 'Write',
+  };
+  const multikey = SchnorrMultikey.fromSecretKey(verificationMethodId, did, keys.secretKey.bytes);
+  return multikey.toCryptosuite().toDataIntegrityProof().addProof(unsigned, config);
+}
+
+// ------------------------------------------------------------------ nostr harness
+
+interface Subscription { filter: Record<string, unknown>; onevent: (event: Event) => unknown }
+
+/**
+ * Stand in for the relay pool. `nostr-tools` verifies each event's BIP-340 signature
+ * before `onevent` fires (SimplePool passes the real `verifyEvent`), so events reaching
+ * the transport always carry an authentic `pubkey`; these tests build them with
+ * `finalizeEvent` for the same reason and feed them straight to the subscription the
+ * relay filter would have matched.
+ */
+class RelayHarness {
+  readonly subscriptions: Subscription[] = [];
+  #subscribeMany?: unknown;
+  #publish?: unknown;
+
+  install(): void {
+    const proto = SimplePool.prototype as unknown as Record<string, unknown>;
+    this.#subscribeMany = proto.subscribeMany;
+    this.#publish = proto.publish;
+    const subscriptions = this.subscriptions;
+    proto.subscribeMany = function(_relays: string[], filter: Record<string, unknown>, handlers: { onevent: (event: Event) => unknown }) {
+      subscriptions.push({ filter, onevent: handlers.onevent });
+      return { close: (): void => { /* nothing to close */ } };
+    };
+    proto.publish = function(): Promise<string>[] { return []; };
+  }
+
+  restore(): void {
+    const proto = SimplePool.prototype as unknown as Record<string, unknown>;
+    if(this.#subscribeMany) proto.subscribeMany = this.#subscribeMany;
+    if(this.#publish) proto.publish = this.#publish;
+    this.subscriptions.length = 0;
+  }
+
+  /** Deliver to the broadcast subscription (the one filtering on a `t` tag). */
+  broadcast(event: Event): void {
+    for(const sub of this.subscriptions) {
+      if(sub.filter['#t']) void sub.onevent(event);
+    }
+  }
+
+  /** Deliver to the directed subscription of the actor whose x-only key is `pkHex`. */
+  directed(event: Event, pkHex: string): void {
+    for(const sub of this.subscriptions) {
+      const p = sub.filter['#p'] as string[] | undefined;
+      if(p?.includes(pkHex)) void sub.onevent(event);
+    }
+  }
+}
+
+const wireReplacer = (_key: string, value: unknown): unknown =>
+  value instanceof Uint8Array ? { __bytes: bytesToHex(value) } : value;
+
+/** A plaintext (kind 1) aggregation event: `from` is claimed, `signWith` is authentic. */
+function plainEvent(type: string, from: string, body: Record<string, unknown>, signWith: SchnorrKeyPair): Event {
+  const message = new BaseMessage({ type, from, body: body as BaseBody });
+  return finalizeEvent({
+    kind       : 1,
+    created_at : Math.floor(Date.now() / 1000),
+    tags       : [ [ 'p', bytesToHex(signWith.publicKey.x) ], [ 't', type ] ],
+    content    : JSON.stringify(message, wireReplacer),
+  } as EventTemplate, signWith.secretKey.bytes);
+}
+
+/** A NIP-44 encrypted (kind 1059) aggregation event addressed to `recipient`. */
+function sealedEvent(
+  type: string,
+  from: string,
+  body: Record<string, unknown>,
+  signWith: SchnorrKeyPair,
+  recipient: SchnorrKeyPair,
+): Event {
+  const message = new BaseMessage({ type, from, to: k1Did(recipient), body: body as BaseBody });
+  const conversationKey = nip44.v2.utils.getConversationKey(
+    signWith.secretKey.bytes,
+    bytesToHex(recipient.publicKey.x),
+  );
+  return finalizeEvent({
+    kind       : 1059,
+    created_at : Math.floor(Date.now() / 1000),
+    tags       : [ [ 'p', bytesToHex(signWith.publicKey.x) ], [ 'p', bytesToHex(recipient.publicKey.x) ], [ 't', type ] ],
+    content    : nip44.v2.encrypt(JSON.stringify(message, wireReplacer), conversationKey),
+  } as EventTemplate, signWith.secretKey.bytes);
+}
+
+const advertBody = (cohortId: string, communicationPk: Uint8Array): Record<string, unknown> => ({
+  cohortId,
+  network          : 'mutinynet',
+  communicationPk,
+  beaconType       : 'SMTBeacon',
+  minParticipants  : 2,
+  recoveryKey      : TEST_RECOVERY_KEY,
+  recoverySequence : TEST_RECOVERY_SEQUENCE,
+  fundingModel     : 'operator-funded',
+});
+
+// ------------------------------------------------------------------- http harness
+
+interface MockSse {
+  fetch: typeof fetch;
+  push(pathname: string, event: string, data: string): void;
+}
+
+function mockSse(): MockSse {
+  const streams = new Map<string, ReadableStreamDefaultController<Uint8Array>>();
+  const encoder = new TextEncoder();
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = input instanceof URL ? input : new URL(String(input));
+    if((init?.method ?? 'GET').toUpperCase() === 'POST') return new Response('', { status: 202 });
+    let ctrl!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({ start(c) { ctrl = c; } });
+    streams.set(url.pathname, ctrl);
+    return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+  };
+  return {
+    fetch : fetchImpl,
+    push(pathname, event, data) {
+      const ctrl = streams.get(pathname);
+      if(!ctrl) throw new Error(`No SSE stream open at ${pathname}`);
+      ctrl.enqueue(encoder.encode(`event: ${event}\ndata: ${data}\n\n`));
+    },
+  };
+}
+
+const settle = (ms = 25): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const req = (method: string, url: string, body?: string): HttpRequestLike =>
+  ({ method, url, headers: { 'content-type': 'application/json' }, body });
+
+// ------------------------------------------------- participant state machine harness
+
+/** A one-member cohort driven through both state machines by hand, no transport. */
+function soloCohort() {
+  const serviceKeys = SchnorrKeyPair.generate();
+  const serviceDid = k1Did(serviceKeys);
+  const memberKeys = SchnorrKeyPair.generate();
+  const memberDid = k1Did(memberKeys);
+  const outsiderDid = k1Did(SchnorrKeyPair.generate());
+
+  const service = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
+  const member = new AggregationParticipant({ did: memberDid, signer: new KeyPairAggregationSigner(memberKeys) });
+
+  const toMember = (messages: BaseMessage[]): void => messages.forEach(m => member.receive(m));
+  const toService = (messages: BaseMessage[]): void => messages.forEach(m => service.receive(m));
+
+  const cohortId = service.createCohort({
+    minParticipants  : 1,
+    network          : 'mutinynet',
+    beaconType       : 'CASBeacon',
+    recoveryKey      : TEST_RECOVERY_KEY,
+    recoverySequence : TEST_RECOVERY_SEQUENCE,
+  });
+  toMember(service.advertise(cohortId));
+  toService(member.joinCohort(cohortId));
+  toMember(service.acceptParticipant(cohortId, memberDid));
+
+  return { service, member, serviceDid, memberDid, memberKeys, outsiderDid, cohortId, toMember, toService };
+}
+
+type SoloCohort = ReturnType<typeof soloCohort>;
+
+/** The real script-tree beacon output script the cohort's address commits to. */
+function beaconScript(service: AggregationService, cohortId: string): Uint8Array {
+  const cohort = service.getCohort(cohortId)!;
+  const leaves = buildRecoveryLeaves('operator-funded', {
+    recoveryKey       : cohort.recoveryKey!,
+    recoverySequence  : cohort.recoverySequence!,
+    cohortKeys        : cohort.cohortKeys,
+    fallbackThreshold : cohort.effectiveFallbackThreshold,
+  });
+  return p2tr(cohort.internalKey, leaves, NET, true).script;
+}
+
+/** A well-formed beacon announcement tx: change output, then the signal OP_RETURN. */
+function beaconTx(script: Uint8Array, signal: Uint8Array): Transaction {
+  const tx = new Transaction({ version: 2, allowUnknownInputs: true, allowUnknownOutputs: true });
+  tx.addInput({ txid: '22'.repeat(32), index: 0, witnessUtxo: { script, amount: VALUE } });
+  tx.addOutput({ script, amount: VALUE - 500n });
+  tx.addOutput({ script: Script.encode([ 'RETURN', signal ]), amount: 0n });
+  return tx;
+}
+
+/** Carry a solo cohort to CohortReady (keygen finalized). */
+function readyCohort(): SoloCohort {
+  const harness = soloCohort();
+  harness.toMember(harness.service.finalizeKeygen(harness.cohortId));
+  return harness;
+}
+
+/** Carry a solo cohort to NonceSent: the member has validated and contributed its nonce. */
+function noncesContributed(): SoloCohort & { script: Uint8Array; tx: Transaction } {
+  const harness = readyCohort();
+  const { service, member, cohortId, toMember, toService } = harness;
+  toService(member.submitUpdate(cohortId, createSignedUpdate(harness.memberDid, harness.memberKeys)));
+  toMember(service.buildAndDistribute(cohortId));
+  toService(member.approveValidation(cohortId));
+  const script = beaconScript(service, cohortId);
+  const tx = beaconTx(script, service.getCohort(cohortId)!.signalBytes!);
+  toMember(service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] }));
+  toService(member.approveNonce(cohortId));
+  return { ...harness, script, tx };
+}
+
+describe('Transport sender authentication (audit H6)', () => {
+
+  describe('NostrTransport binds message.from to the event signer', () => {
+    let relay: RelayHarness;
+    let serviceKeys: SchnorrKeyPair;
+    let serviceDid: string;
+    let attackerKeys: SchnorrKeyPair;
+    let aliceKeys: SchnorrKeyPair;
+    let aliceDid: string;
+    let transport: NostrTransport | undefined;
+
+    const makeTransport = (resolve = true): NostrTransport => {
+      transport = new NostrTransport({
+        relays          : [ 'wss://relay.invalid' ],
+        logger          : SILENT_LOGGER,
+        ...(resolve ? { resolveSenderPk: resolveBtcr2SenderPk } : {}),
+      });
+      return transport;
+    };
+
+    beforeEach(() => {
+      relay = new RelayHarness();
+      relay.install();
+      serviceKeys = SchnorrKeyPair.generate();
+      serviceDid = k1Did(serviceKeys);
+      attackerKeys = SchnorrKeyPair.generate();
+      aliceKeys = SchnorrKeyPair.generate();
+      aliceDid = k1Did(aliceKeys);
+    });
+
+    afterEach(() => {
+      transport?.unregisterActor(aliceDid);
+      transport = undefined;
+      relay.restore();
+    });
+
+    /** An actor with a recording handler for `type`, transport already started. */
+    const listen = (type: string, resolve = true): { received: Record<string, unknown>[] } => {
+      const t = makeTransport(resolve);
+      t.registerActor(aliceDid, aliceKeys);
+      const received: Record<string, unknown>[] = [];
+      t.registerMessageHandler(aliceDid, type, (message: Record<string, unknown>) => { received.push(message); });
+      t.start();
+      return { received };
+    };
+
+    it('drops a broadcast advert signed by a key the claimed service does not control', () => {
+      const { received } = listen(COHORT_ADVERT);
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c1', attackerKeys.publicKey.compressed), attackerKeys));
+      expect(received).to.be.empty;
+    });
+
+    it('accepts a broadcast advert signed by the service DID it names', () => {
+      const { received } = listen(COHORT_ADVERT);
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c1', serviceKeys.publicKey.compressed), serviceKeys));
+      expect(received).to.have.lengthOf(1);
+      expect(received[0].from).to.equal(serviceDid);
+    });
+
+    it('drops an advert that advertises a key the sender did not authenticate with', () => {
+      // The service DID signs the event, so the sender is authentic, but the key the
+      // cohort would encrypt to belongs to someone else.
+      const { received } = listen(COHORT_ADVERT);
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c1', attackerKeys.publicKey.compressed), serviceKeys));
+      expect(received).to.be.empty;
+    });
+
+    it('drops a directed message whose from names a DID that did not sign it', () => {
+      const { received } = listen(FALLBACK_AUTHORIZATION_REQUEST);
+      relay.directed(
+        sealedEvent(FALLBACK_AUTHORIZATION_REQUEST, serviceDid, { cohortId: 'c1', sessionId: 's', pendingTx: 'ff' }, attackerKeys, aliceKeys),
+        bytesToHex(aliceKeys.publicKey.x),
+      );
+      expect(received).to.be.empty;
+    });
+
+    it('accepts a directed message the named service actually signed', () => {
+      const { received } = listen(FALLBACK_AUTHORIZATION_REQUEST);
+      relay.directed(
+        sealedEvent(FALLBACK_AUTHORIZATION_REQUEST, serviceDid, { cohortId: 'c1', sessionId: 's', pendingTx: 'ff' }, serviceKeys, aliceKeys),
+        bytesToHex(aliceKeys.publicKey.x),
+      );
+      expect(received).to.have.lengthOf(1);
+    });
+
+    it('drops a message whose sender DID resolves to no key', () => {
+      // No resolver injected and the sender is not a registered peer: nothing to bind
+      // the claim to, so the message is dropped rather than trusted.
+      const { received } = listen(COHORT_ADVERT, false);
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c1', serviceKeys.publicKey.compressed), serviceKeys));
+      expect(received).to.be.empty;
+    });
+
+    it('authenticates a registered peer with no resolver injected', () => {
+      const { received } = listen(COHORT_ADVERT, false);
+      transport!.registerPeer(serviceDid, serviceKeys.publicKey.compressed);
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c1', serviceKeys.publicKey.compressed), serviceKeys));
+      expect(received).to.have.lengthOf(1);
+    });
+
+    it('drops a message that declares no sender DID', () => {
+      const { received } = listen(COHORT_ADVERT);
+      const message = { type: COHORT_ADVERT, version: 1, body: advertBody('c1', serviceKeys.publicKey.compressed) };
+      relay.broadcast(finalizeEvent({
+        kind       : 1,
+        created_at : Math.floor(Date.now() / 1000),
+        tags       : [ [ 't', COHORT_ADVERT ] ],
+        content    : JSON.stringify(message, wireReplacer),
+      } as EventTemplate, serviceKeys.secretKey.bytes));
+      expect(received).to.be.empty;
+    });
+
+    it('drops an opt-in that claims another participant DID (slot squatting)', () => {
+      // The service side of the same bind: an opt-in seats a DID into the cohort and
+      // registers the key its updates are verified against.
+      const victimKeys = SchnorrKeyPair.generate();
+      const victimDid = k1Did(victimKeys);
+      const t = makeTransport();
+      t.registerActor(aliceDid, aliceKeys);
+      const received: Record<string, unknown>[] = [];
+      t.registerMessageHandler(aliceDid, COHORT_OPT_IN, (message: Record<string, unknown>) => { received.push(message); });
+      t.start();
+
+      relay.directed(
+        plainEvent(COHORT_OPT_IN, victimDid, {
+          cohortId        : 'c1',
+          participantPk   : attackerKeys.publicKey.compressed,
+          communicationPk : attackerKeys.publicKey.compressed,
+        }, attackerKeys),
+        bytesToHex(aliceKeys.publicKey.x),
+      );
+      expect(received).to.be.empty;
+    });
+
+    it('authenticates an EXTERNAL (x1) sender from the genesis it carries in-band', () => {
+      const external = externalIdentity();
+      const t = makeTransport();
+      t.registerActor(aliceDid, aliceKeys);
+      const received: Record<string, unknown>[] = [];
+      t.registerMessageHandler(aliceDid, COHORT_OPT_IN, (message: Record<string, unknown>) => { received.push(message); });
+      t.start();
+
+      relay.directed(
+        plainEvent(COHORT_OPT_IN, external.did, {
+          cohortId        : 'c1',
+          participantPk   : external.keys.publicKey.compressed,
+          communicationPk : external.keys.publicKey.compressed,
+          genesisDocument : external.genesisDocument,
+        }, external.keys),
+        bytesToHex(aliceKeys.publicKey.x),
+      );
+      expect(received).to.have.lengthOf(1);
+      expect(received[0].from).to.equal(external.did);
+    });
+
+    it('drops an x1 opt-in whose genesis does not hash to the DID it claims', () => {
+      const victim = externalIdentity();
+      const impostor = externalIdentity();
+      const t = makeTransport();
+      t.registerActor(aliceDid, aliceKeys);
+      const received: Record<string, unknown>[] = [];
+      t.registerMessageHandler(aliceDid, COHORT_OPT_IN, (message: Record<string, unknown>) => { received.push(message); });
+      t.start();
+
+      relay.directed(
+        plainEvent(COHORT_OPT_IN, victim.did, {
+          cohortId        : 'c1',
+          participantPk   : impostor.keys.publicKey.compressed,
+          communicationPk : impostor.keys.publicKey.compressed,
+          genesisDocument : impostor.genesisDocument,
+        }, impostor.keys),
+        bytesToHex(aliceKeys.publicKey.x),
+      );
+      expect(received).to.be.empty;
+    });
+
+    it('keeps a forged advert out of the runner peer registry', async () => {
+      // End-to-end statement of the finding: the runner registers the advertised
+      // communication key under the advertised service DID, so an unbound advert
+      // redirects every later encrypted message to the attacker.
+      const t = makeTransport();
+      t.registerActor(aliceDid, aliceKeys);
+      const runner = new AggregationParticipantRunner({
+        transport       : t,
+        did             : aliceDid,
+        keys            : aliceKeys,
+        shouldJoin      : async () => false,
+        onProvideUpdate : async () => null,
+      });
+      await runner.start();
+      t.start();
+
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c-forged', attackerKeys.publicKey.compressed), attackerKeys));
+      expect(runner.session.discoveredCohorts.has('c-forged')).to.be.false;
+      expect(t.getPeerPk(serviceDid)).to.be.undefined;
+
+      // The honest advert from the same service still lands.
+      relay.broadcast(plainEvent(COHORT_ADVERT, serviceDid, advertBody('c-real', serviceKeys.publicKey.compressed), serviceKeys));
+      expect(runner.session.discoveredCohorts.has('c-real')).to.be.true;
+      expect(t.getPeerPk(serviceDid)).to.deep.equal(serviceKeys.publicKey.compressed);
+      runner.stop();
+    });
+  });
+
+  describe('HTTP server binds the advert to its envelope', () => {
+    let serverKeys: SchnorrKeyPair;
+    let serverDid: string;
+    let server: HttpServerTransport;
+
+    beforeEach(() => {
+      serverKeys = SchnorrKeyPair.generate();
+      serverDid = k1Did(serverKeys);
+      server = new HttpServerTransport({
+        logger              : SILENT_LOGGER,
+        heartbeatIntervalMs : 0,
+        resolveSenderPk     : resolveBtcr2SenderPk,
+      });
+      server.registerActor(serverDid, serverKeys);
+    });
+
+    afterEach(() => server.stop());
+
+    const advertPost = (innerFrom: string): HttpRequestLike => {
+      const message = new BaseMessage({
+        type : COHORT_ADVERT,
+        from : innerFrom,
+        body : advertBody('c1', serverKeys.publicKey.compressed) as BaseBody,
+      });
+      return req('POST', HTTP_ROUTE.ADVERTS, JSON.stringify(signEnvelope(message, { did: serverDid, keys: serverKeys })));
+    };
+
+    it('rejects an advert whose inner from is not the envelope sender', async () => {
+      const foreignDid = k1Did(SchnorrKeyPair.generate());
+      const res = await server.handleRequest(advertPost(foreignDid));
+      expect(res.status).to.equal(401);
+      expect(JSON.parse(res.body as string).error).to.equal('sender_mismatch');
+    });
+
+    it('accepts an advert whose inner from is the envelope sender', async () => {
+      const res = await server.handleRequest(advertPost(serverDid));
+      expect(res.status).to.equal(202);
+    });
+  });
+
+  describe('HTTP client binds inbound messages to their envelope', () => {
+    let sse: MockSse;
+    let client: HttpClientTransport;
+    let serviceKeys: SchnorrKeyPair;
+    let serviceDid: string;
+    let attackerKeys: SchnorrKeyPair;
+    let attackerDid: string;
+    let aliceKeys: SchnorrKeyPair;
+    let aliceDid: string;
+    let inboxPath: string;
+
+    beforeEach(async () => {
+      sse = mockSse();
+      serviceKeys = SchnorrKeyPair.generate();
+      serviceDid = k1Did(serviceKeys);
+      attackerKeys = SchnorrKeyPair.generate();
+      attackerDid = k1Did(attackerKeys);
+      aliceKeys = SchnorrKeyPair.generate();
+      aliceDid = k1Did(aliceKeys);
+      inboxPath = HTTP_ROUTE.ACTOR_INBOX.replace('{did}', encodeURIComponent(aliceDid));
+
+      client = new HttpClientTransport({
+        baseUrl         : 'http://aggregator.invalid/',
+        fetchImpl       : sse.fetch,
+        logger          : SILENT_LOGGER,
+        resolveSenderPk : resolveBtcr2SenderPk,
+      });
+      client.registerActor(aliceDid, aliceKeys);
+      client.start();
+      await settle();
+    });
+
+    afterEach(() => client.stop());
+
+    const record = (type: string): Record<string, unknown>[] => {
+      const received: Record<string, unknown>[] = [];
+      client.registerMessageHandler(aliceDid, type, (message: Record<string, unknown>) => { received.push(message); });
+      return received;
+    };
+
+    it('drops a broadcast whose inner from is not the envelope sender', async () => {
+      const received = record(COHORT_ADVERT);
+      const message = new BaseMessage({
+        type : COHORT_ADVERT,
+        from : serviceDid,
+        body : advertBody('c1', attackerKeys.publicKey.compressed) as BaseBody,
+      });
+      sse.push(HTTP_ROUTE.ADVERTS, SSE_EVENT.ADVERT,
+        JSON.stringify(signEnvelope(message, { did: attackerDid, keys: attackerKeys })));
+      await settle();
+      expect(received).to.be.empty;
+    });
+
+    it('dispatches a broadcast whose inner from is the envelope sender', async () => {
+      const received = record(COHORT_ADVERT);
+      const message = new BaseMessage({
+        type : COHORT_ADVERT,
+        from : serviceDid,
+        body : advertBody('c1', serviceKeys.publicKey.compressed) as BaseBody,
+      });
+      sse.push(HTTP_ROUTE.ADVERTS, SSE_EVENT.ADVERT,
+        JSON.stringify(signEnvelope(message, { did: serviceDid, keys: serviceKeys })));
+      await settle();
+      expect(received).to.have.lengthOf(1);
+    });
+
+    it('drops a broadcast advertising a key the sender did not authenticate with', async () => {
+      const received = record(COHORT_ADVERT);
+      const message = new BaseMessage({
+        type : COHORT_ADVERT,
+        from : serviceDid,
+        body : advertBody('c1', attackerKeys.publicKey.compressed) as BaseBody,
+      });
+      sse.push(HTTP_ROUTE.ADVERTS, SSE_EVENT.ADVERT,
+        JSON.stringify(signEnvelope(message, { did: serviceDid, keys: serviceKeys })));
+      await settle();
+      expect(received).to.be.empty;
+    });
+
+    it('drops an inbox message whose inner from is not the envelope sender', async () => {
+      const received = record(AGGREGATED_NONCE);
+      const message = new BaseMessage({
+        type : AGGREGATED_NONCE,
+        from : serviceDid,
+        to   : aliceDid,
+        body : { cohortId: 'c1', sessionId: 's', aggregatedNonce: new Uint8Array(66) } as BaseBody,
+      });
+      sse.push(inboxPath, SSE_EVENT.MESSAGE,
+        JSON.stringify(signEnvelope(message, { did: attackerDid, keys: attackerKeys }, { to: aliceDid })));
+      await settle();
+      expect(received).to.be.empty;
+    });
+
+    it('dispatches an inbox message whose inner from is the envelope sender', async () => {
+      const received = record(AGGREGATED_NONCE);
+      const message = new BaseMessage({
+        type : AGGREGATED_NONCE,
+        from : serviceDid,
+        to   : aliceDid,
+        body : { cohortId: 'c1', sessionId: 's', aggregatedNonce: new Uint8Array(66) } as BaseBody,
+      });
+      sse.push(inboxPath, SSE_EVENT.MESSAGE,
+        JSON.stringify(signEnvelope(message, { did: serviceDid, keys: serviceKeys }, { to: aliceDid })));
+      await settle();
+      expect(received).to.have.lengthOf(1);
+    });
+  });
+
+  describe('participant refuses service messages from anyone else', () => {
+
+    it('ignores a COHORT_READY that does not come from the cohort service', () => {
+      const { service, member, outsiderDid, cohortId } = soloCohort();
+      const ready = service.finalizeKeygen(cohortId);
+      ready[0].from = outsiderDid;
+      member.receive(ready[0]);
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.OptedIn);
+      expect(member.joinedCohorts.has(cohortId)).to.be.false;
+    });
+
+    it('applies a COHORT_READY from the cohort service', () => {
+      const { service, member, cohortId, toMember } = soloCohort();
+      toMember(service.finalizeKeygen(cohortId));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.CohortReady);
+    });
+
+    it('ignores aggregated data that does not come from the cohort service', () => {
+      const { service, member, memberDid, memberKeys, outsiderDid, cohortId, toService } = readyCohort();
+      toService(member.submitUpdate(cohortId, createSignedUpdate(memberDid, memberKeys)));
+      const distribute = service.buildAndDistribute(cohortId);
+      distribute[0].from = outsiderDid;
+      member.receive(distribute[0]);
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.UpdateSubmitted);
+      expect(member.getValidation(cohortId)).to.be.undefined;
+    });
+
+    it('ignores an authorization request that does not come from the cohort service', () => {
+      const { service, member, memberDid, memberKeys, outsiderDid, cohortId, toMember, toService } = readyCohort();
+      toService(member.submitUpdate(cohortId, createSignedUpdate(memberDid, memberKeys)));
+      toMember(service.buildAndDistribute(cohortId));
+      toService(member.approveValidation(cohortId));
+      const script = beaconScript(service, cohortId);
+      const tx = beaconTx(script, service.getCohort(cohortId)!.signalBytes!);
+      const auth = service.startSigning(cohortId, { tx, prevOutScripts: [ script ], prevOutValues: [ VALUE ] });
+      auth[0].from = outsiderDid;
+      member.receive(auth[0]);
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.ValidationSent);
+      expect(member.pendingSigningRequests.has(cohortId)).to.be.false;
+    });
+
+    it('ignores an aggregated nonce that does not come from the cohort service', () => {
+      const { service, member, outsiderDid, cohortId, toMember, toService } = noncesContributed();
+      const nonce = service.sendAggregatedNonce(cohortId);
+      member.receive(new BaseMessage({ ...nonce[0].toJSON(), from: outsiderDid }));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+
+      // The round is untouched: the real message still completes it.
+      toMember(nonce);
+      toService(member.generatePartialSignature(cohortId));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+    });
+
+    it('ignores an aggregated nonce for a different signing session', () => {
+      const { service, member, cohortId } = noncesContributed();
+      const nonce = service.sendAggregatedNonce(cohortId);
+      nonce[0].body!.sessionId = 'some-other-session';
+      member.receive(nonce[0]);
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+    });
+
+    it('applies an aggregated nonce for the active session', () => {
+      const { service, member, cohortId, toMember } = noncesContributed();
+      toMember(service.sendAggregatedNonce(cohortId));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingPartialSig);
+    });
+
+    it('ignores a fallback request that does not come from the cohort service', () => {
+      const { service, member, outsiderDid, cohortId, tx, script, toMember, toService } = noncesContributed();
+      const cohort = service.getCohort(cohortId)!;
+      const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+      member.receive(createFallbackAuthorizationRequestMessage({
+        from                  : outsiderDid,
+        to                    : member.did,
+        cohortId,
+        sessionId             : service.getSigningSessionId(cohortId)!,
+        pendingTx             : tx.hex,
+        prevOutScriptHex      : bytesToHex(script),
+        prevOutValue          : VALUE.toString(),
+        fallbackLeafScriptHex : bytesToHex(leaf),
+      }));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+      expect(member.pendingFallbackRequests.has(cohortId)).to.be.false;
+
+      // The secret nonce survived: the optimistic round still completes.
+      toMember(service.sendAggregatedNonce(cohortId));
+      toService(member.generatePartialSignature(cohortId));
+      expect(service.getCohortPhase(cohortId)).to.equal(ServiceCohortPhase.Complete);
+    });
+
+    it('ignores a fallback request for a different signing session', () => {
+      const { service, member, serviceDid, cohortId, tx, script } = noncesContributed();
+      const cohort = service.getCohort(cohortId)!;
+      const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+      member.receive(createFallbackAuthorizationRequestMessage({
+        from                  : serviceDid,
+        to                    : member.did,
+        cohortId,
+        sessionId             : 'some-other-session',
+        pendingTx             : tx.hex,
+        prevOutScriptHex      : bytesToHex(script),
+        prevOutValue          : VALUE.toString(),
+        fallbackLeafScriptHex : bytesToHex(leaf),
+      }));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.NonceSent);
+      expect(member.pendingFallbackRequests.has(cohortId)).to.be.false;
+    });
+
+    it('accepts the fallback request for the optimistic round', () => {
+      const { service, member, serviceDid, cohortId, tx, script } = noncesContributed();
+      const cohort = service.getCohort(cohortId)!;
+      const leaf = buildFallbackLeaf({ cohortKeys: cohort.cohortKeys, fallbackThreshold: cohort.effectiveFallbackThreshold });
+      member.receive(createFallbackAuthorizationRequestMessage({
+        from                  : serviceDid,
+        to                    : member.did,
+        cohortId,
+        sessionId             : service.getSigningSessionId(cohortId)!,
+        pendingTx             : tx.hex,
+        prevOutScriptHex      : bytesToHex(script),
+        prevOutValue          : VALUE.toString(),
+        fallbackLeafScriptHex : bytesToHex(leaf),
+      }));
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.AwaitingFallbackSig);
+    });
+
+    it('ignores a cohort message naming a cohort this member does not know', () => {
+      const { service, member, cohortId } = soloCohort();
+      const ready = service.finalizeKeygen(cohortId);
+      ready[0].body!.cohortId = 'not-a-cohort-we-joined';
+      member.receive(ready[0]);
+      expect(member.getCohortPhase(cohortId)).to.equal(ParticipantCohortPhase.OptedIn);
+    });
+  });
+});

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @did-btcr2/api
 
+## 0.19.0
+
+### Minor Changes
+
+- Choose where beacon signals are read from on the Bitcoin connection.
+
+  - Added `BitcoinApiConfig.signalDiscovery` (`'indexer' | 'fullnode'`, default `'indexer'`) and the `SignalDiscoveryMode` type, surfaced as the readonly `BitcoinApi.signalDiscovery`. `fullnode` scans every block from genesis over Bitcoin Core RPC instead of reading an Esplora index; it requires an `rpc` config (rejected at construction without one), a node with `-txindex=1`, and Bitcoin Core 25 or later for `getblock` verbosity 3, and the linear scan makes it practical only on regtest. Resolution reads the mode off the connection, not off the DID: which path reads the chain is a property of how this SDK talks to Bitcoin.
+  - **BREAKING:** resolution inherits the `capabilityInvocation` authorization check from `@did-btcr2/method`, so a DID whose updates were signed by a key outside that relationship now resolves as an error rather than a document (ADR 088).
+  - **BREAKING:** the re-exported `MultikeyObject` narrows with `@did-btcr2/cryptosuite`: its `keyPair` field carries public key material only.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.10.0
+  - @did-btcr2/common@9.3.0
+  - @did-btcr2/cryptosuite@10.0.0
+  - @did-btcr2/method@0.56.0
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/api/lib/test-fullnode.ts
+++ b/packages/api/lib/test-fullnode.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolves a regtest DID through the full node signal-discovery path.
+ *
+ * `signalDiscovery: 'fullnode'` scans every block over Bitcoin Core RPC instead of
+ * reading an Esplora index. Drop the field (or set 'indexer') to compare: both paths
+ * must resolve the same document and versionId from the same chain.
+ *
+ * Usage: bun lib/test-fullnode.ts
+ */
+
+import type { ResolutionOptions } from '@did-btcr2/method';
+import { DidBtcr2Api } from '../src/api.js';
+import type { ApiConfig } from '../src/types.js';
+
+const did = 'did:btcr2:k1qgppexmyqqlce9netky3h4ur2j9dur83j7m7vva497kfhdgsq2t9nxgqj3x0s';
+
+const apiConfig: ApiConfig = {
+  btc : {
+    network         : 'regtest',
+    rpc             : { host: 'http://localhost:18443', username: 'polaruser', password: 'polarpass' },
+    signalDiscovery : 'fullnode',
+  },
+};
+
+const context = [
+  'https://w3id.org/security/v2',
+  'https://w3id.org/zcap/v1',
+  'https://w3id.org/json-ld-patch/v1',
+  'https://btcr2.dev/context/v1'
+];
+
+// The signed update whose hash is anchored in the beacon signal on chain.
+const resolutionOptions: ResolutionOptions = {
+  sidecar : {
+    updates : [
+      {
+        '@context' : context,
+        patch      : [
+          {
+            op    : 'replace',
+            path  : '/service/0/serviceEndpoint',
+            value : 'bitcoin:mmBCLTLMZqUFhiG4vhhaM7EbLRN6h7sCfG'
+          }
+        ],
+        targetHash      : 'hduKs2Pj2VpUueLkvWLSR5MeSjTYgKPO02H9zrqjUKw',
+        targetVersionId : 2,
+        sourceHash      : 'AHcGbJ3OGSIrjVTIHFbIc2OEA25EDtMOM1uXBlw2qDQ',
+        proof           : {
+          '@context'         : context,
+          cryptosuite        : 'bip340-jcs-2025',
+          type               : 'DataIntegrityProof',
+          verificationMethod : `${did}#initialKey`,
+          proofPurpose       : 'capabilityInvocation',
+          capability         : `urn:zcap:root:${encodeURIComponent(did)}`,
+          capabilityAction   : 'Write',
+          proofValue         : 'z4uLUfMjfUufPGgeXa9ZgJ1DR7bnH7FAkHVf83ebT1C4iwFtiJPPNgStUrT9cpV2h8PKdN6RH4TFJgrRd7APPBqWA'
+        }
+      }
+    ]
+  }
+};
+
+const api = new DidBtcr2Api(apiConfig);
+
+const resolutionResult = await api.resolveDid(did, resolutionOptions);
+console.log('resolutionResult', JSON.stringify(resolutionResult, null, 2));

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/api",
-    "version": "0.18.0",
+    "version": "0.19.0",
     "type": "module",
     "description": "SDK for accessing the did:btcr2 method functionality.",
     "main": "./dist/cjs/index.js",

--- a/packages/api/src/bitcoin.ts
+++ b/packages/api/src/bitcoin.ts
@@ -9,7 +9,7 @@ import {
   type RawTransactionRest
 } from '@did-btcr2/bitcoin';
 import { assertString } from './helpers.js';
-import type { BitcoinApiConfig } from './types.js';
+import type { BitcoinApiConfig, SignalDiscoveryMode } from './types.js';
 
 /**
  * Default per-network service endpoints the SDK applies when the caller supplies
@@ -91,6 +91,13 @@ export class BitcoinApi {
   /** The underlying BitcoinConnection used for all operations. */
   readonly connection: BitcoinConnection;
 
+  /**
+   * Where beacon signals are read from during resolution. Set once at construction
+   * because it is a property of how this connection talks to Bitcoin, not of any
+   * individual DID being resolved.
+   */
+  readonly signalDiscovery: SignalDiscoveryMode;
+
   /** REST client for the active network. */
   get rest(): BitcoinRestClient {
     return this.connection.rest;
@@ -145,6 +152,16 @@ export class BitcoinApi {
       });
     }
     this.connection = new BitcoinConnection(resolveConnectionOptions(cfg, executor));
+
+    this.signalDiscovery = cfg.signalDiscovery ?? 'indexer';
+    if (this.signalDiscovery === 'fullnode' && !this.connection.rpc) {
+      throw new Error(
+        'signalDiscovery: \'fullnode\' scans blocks over Bitcoin Core RPC, but no rpc config was '
+        + `resolved for network '${cfg.network}'. Pass one, e.g.: `
+        + '{ network: \'regtest\', rpc: { host: \'http://localhost:18443\', username: \'u\', '
+        + 'password: \'p\' }, signalDiscovery: \'fullnode\' }'
+      );
+    }
   }
 
   /**

--- a/packages/api/src/method.ts
+++ b/packages/api/src/method.ts
@@ -126,12 +126,16 @@ export class DidMethodApi {
                 );
               }
               this.#log.debug(
-                'Fetching beacon signals for %d service(s)',
-                need.beaconServices.length
+                'Fetching beacon signals for %d service(s) via %s',
+                need.beaconServices.length,
+                this.#btc.signalDiscovery
               );
-              const signals = await BeaconSignalDiscovery.indexer(
-                [...need.beaconServices], this.#btc.connection
-              );
+              // Which path reads the chain is fixed by the connection, not by the DID:
+              // see BitcoinApiConfig.signalDiscovery.
+              const discover = this.#btc.signalDiscovery === 'fullnode'
+                ? BeaconSignalDiscovery.fullnode
+                : BeaconSignalDiscovery.indexer;
+              const signals = await discover([...need.beaconServices], this.#btc.connection);
               resolver.provide(need, signals);
               break;
             }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -64,6 +64,22 @@ export type ResolutionResult =
   | { ok: false; error: string; errorMessage?: string; raw: DidResolutionResult };
 
 /**
+ * How beacon signals are discovered when resolving a DID.
+ *
+ * - `indexer` reads the transaction listing for each beacon address from an
+ *   Esplora-compatible REST backend. This is the default: it is the only option that
+ *   scales past a local chain.
+ * - `fullnode` scans every block from genesis over Bitcoin Core RPC, requiring no
+ *   third-party index. It needs an `rpc` config, a node with `-txindex=1` (prevouts are
+ *   resolved with `getrawtransaction`), and Bitcoin Core >= 25 (`getblock` verbosity 3).
+ *   The scan is linear in chain length, so it is only practical on regtest.
+ *
+ * Both paths discover the same signals from the same chain; they differ only in where
+ * the data is read from.
+ */
+export type SignalDiscoveryMode = 'indexer' | 'fullnode';
+
+/**
  * Bitcoin API configuration options.
  * The `network` field is required and determines default REST/RPC endpoints.
  * Optional `rest` and `rpc` fields override individual endpoints on top of
@@ -79,6 +95,9 @@ export type ResolutionResult =
  *
  * // Use regtest with custom RPC credentials, default REST
  * { network: 'regtest', rpc: { host: 'http://mynode:18443', username: 'u', password: 'p' } }
+ *
+ * // Read beacon signals straight from a local node instead of an indexer
+ * { network: 'regtest', rpc: { ... }, signalDiscovery: 'fullnode' }
  * ```
  */
 export type BitcoinApiConfig = {
@@ -88,6 +107,12 @@ export type BitcoinApiConfig = {
   rest?: Partial<RestConfig>;
   /** Override RPC client settings on top of network defaults. */
   rpc?: RpcConfig;
+  /**
+   * Where beacon signals are read from. Defaults to `indexer`.
+   * `fullnode` requires an RPC-capable connection and is rejected at construction
+   * without one.
+   */
+  signalDiscovery?: SignalDiscoveryMode;
   /**
    * Optional HTTP executor for sans-I/O usage. Defaults to global `fetch`.
    * Inject a custom executor to intercept requests in tests or route through

--- a/packages/api/tests/bitcoin-api.spec.ts
+++ b/packages/api/tests/bitcoin-api.spec.ts
@@ -57,6 +57,34 @@ describe('BitcoinApi', () => {
     expect(btc.rpc).to.exist;
   });
 
+  // --- Signal discovery mode ---
+  //
+  // Which discovery path reads the chain is a property of the connection, not of an
+  // individual DID, so it is fixed at construction. `fullnode` scans blocks over
+  // Bitcoin Core RPC and is unusable without one, which is worth catching here rather
+  // than mid-resolution.
+
+  it('defaults signalDiscovery to indexer', () => {
+    const btc = new BitcoinApi({ network: 'regtest' });
+    expect(btc.signalDiscovery).to.equal('indexer');
+  });
+
+  it('accepts signalDiscovery: fullnode when RPC is configured', () => {
+    const btc = new BitcoinApi({
+      network         : 'regtest',
+      rpc             : { host: 'http://localhost:18443', username: 'u', password: 'p' },
+      signalDiscovery : 'fullnode'
+    });
+    expect(btc.signalDiscovery).to.equal('fullnode');
+  });
+
+  it('rejects signalDiscovery: fullnode on a network with no RPC config', () => {
+    // mempool.space-backed networks resolve no rpc by default, so this would otherwise
+    // fail only once a resolution reached the scan.
+    expect(() => new BitcoinApi({ network: 'bitcoin', signalDiscovery: 'fullnode' }))
+      .to.throw('no rpc config was resolved');
+  });
+
   it('btcToSats() converts correctly', () => {
     expect(BitcoinApi.btcToSats(1)).to.equal(100_000_000);
     expect(BitcoinApi.btcToSats(0.5)).to.equal(50_000_000);

--- a/packages/api/tests/did-method-api-cas-policy.spec.ts
+++ b/packages/api/tests/did-method-api-cas-policy.spec.ts
@@ -512,8 +512,21 @@ describe('DidMethodApi resolve() SMT proof handling', () => {
     const did = methodApi.createExternal(canonicalHashBytes(genesisDocument), { network: 'regtest' });
 
     const smtRootHex = 'ab'.repeat(32);
+    // A signal is a transaction that spends from the beacon address, so the input side
+    // has to look like one: discovery ignores transactions that merely pay the beacon.
     const signalTx = {
-      vout   : [{ scriptpubkey_asm: `OP_RETURN OP_PUSHBYTES_32 ${smtRootHex}` }],
+      vin    : [{
+        txid        : 'f'.repeat(64),
+        vout        : 0,
+        prevout     : { scriptpubkey_address: beaconAddress },
+        is_coinbase : false,
+      }],
+      // Discovery decodes the serialized script, which Esplora returns alongside the asm
+      // rendering; the asm is here only to document what those bytes mean.
+      vout   : [{
+        scriptpubkey     : `6a20${smtRootHex}`,
+        scriptpubkey_asm : `OP_RETURN OP_PUSHBYTES_32 ${smtRootHex}`,
+      }],
       status : { block_height: 100, block_time: 1700000000 },
     };
     const btcMock = {

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @did-btcr2/bitcoin
 
+## 0.10.0
+
+### Minor Changes
+
+- Bind JSON-RPC responses to the ids the request actually sent, and type `Vin.prevout` to the shape Esplora returns.
+
+  - **BREAKING:** `JsonRpcProtocol.parseBatchResponse` takes the batch's ids as a required third parameter. They cannot be recomputed at parse time from the protocol's id counter: it is shared and mutable, so any `buildRequest` or `buildBatchRequest` issued while a batch is in flight shifts the window and every response is matched to the wrong call, silently returning one transaction's data as another's. `buildBatchRequest` returns them on the descriptor as `JsonRpcBatchHttpRequest.ids`.
+  - **BREAKING:** `Vin.prevout` is typed `Vout | null`, the shape Esplora embeds in an address or transaction listing (`scriptpubkey*` fields, `null` for a coinbase input), replacing the incorrect `TxInPrevout`. Code reading `prevout.scriptPubKey` or `prevout.value` off a REST `Vin` was reading fields that never arrive.
+  - Added `JsonRpcHttpRequest` and `JsonRpcBatchHttpRequest`, the request descriptors returned by `buildRequest` and `buildBatchRequest`, carrying the assigned `id` and `ids`.
+  - `parseResponse` accepts an optional `expectedId` and throws `BitcoinRpcError` when a numeric response id does not match it. A payload with no id, or a null one (what Bitcoin Core sends when it could not parse the request), is still accepted: an endpoint able to fabricate ids can fabricate `result` just as easily, so the check guards against responses crossed in transit rather than against a dishonest node.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/common@9.3.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/bitcoin",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "type": "module",
     "description": "Bitcoin Core RPC and Rest Client Implementations in JS/TS. Used by @did-btcr2/method.",
     "main": "./dist/cjs/index.js",

--- a/packages/bitcoin/src/client/rpc/json-rpc.ts
+++ b/packages/bitcoin/src/client/rpc/json-rpc.ts
@@ -41,8 +41,8 @@ export class JsonRpcTransport {
       );
     }
 
-    const payload = await res.json() as { result?: unknown; error?: { code: number; message: string } };
-    return this.protocol.parseResponse(payload, method);
+    const payload = await res.json() as { id?: unknown; result?: unknown; error?: { code: number; message: string } };
+    return this.protocol.parseResponse(payload, method, request.id);
   }
 
   /**
@@ -70,6 +70,6 @@ export class JsonRpcTransport {
     }
 
     const payloads = await res.json() as Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>;
-    return this.protocol.parseBatchResponse(payloads, calls);
+    return this.protocol.parseBatchResponse(payloads, calls, request.ids);
   }
 }

--- a/packages/bitcoin/src/client/rpc/protocol.ts
+++ b/packages/bitcoin/src/client/rpc/protocol.ts
@@ -4,6 +4,29 @@ import type { HttpRequest } from '../http.js';
 import { toBase64 } from '../utils.js';
 
 /**
+ * An {@link HttpRequest} for a single JSON-RPC call, carrying the `id` that was
+ * assigned when the request was built.  Pass it back to
+ * {@link JsonRpcProtocol.parseResponse} so the response is bound to the request
+ * that asked for it.
+ */
+export interface JsonRpcHttpRequest extends HttpRequest {
+  /** The JSON-RPC id sent in the body of this request. */
+  readonly id: number;
+}
+
+/**
+ * An {@link HttpRequest} for a JSON-RPC batch, carrying the `id`s that were
+ * assigned when the request was built, in call order.  Pass them back to
+ * {@link JsonRpcProtocol.parseBatchResponse}: ids must never be recomputed from
+ * the protocol's counter, which any other call on the same instance advances
+ * while this request is in flight.
+ */
+export interface JsonRpcBatchHttpRequest extends HttpRequest {
+  /** The JSON-RPC ids sent in the body of this request, in call order. */
+  readonly ids: readonly number[];
+}
+
+/**
  * Sans-I/O JSON-RPC protocol for Bitcoin Core.
  *
  * Builds {@link HttpRequest} descriptors for JSON-RPC method calls and
@@ -29,7 +52,7 @@ import { toBase64 } from '../utils.js';
  * const json = await res.json();
  *
  * // Parse the JSON-RPC response (throws on errors)
- * const blockCount = protocol.parseResponse(json, 'getblockcount', []);
+ * const blockCount = protocol.parseResponse(json, 'getblockcount', req.id);
  * ```
  */
 export class JsonRpcProtocol {
@@ -80,10 +103,13 @@ export class JsonRpcProtocol {
 
   /**
    * Build an {@link HttpRequest} for a JSON-RPC method call.
+   * The assigned id is returned on the descriptor for {@link parseResponse}.
    */
-  buildRequest(method: string, params: unknown[]): HttpRequest {
-    const body = { jsonrpc: '2.0', id: ++this._id, method, params };
+  buildRequest(method: string, params: unknown[]): JsonRpcHttpRequest {
+    const id = ++this._id;
+    const body = { jsonrpc: '2.0', id, method, params };
     return {
+      id,
       url     : this.url,
       method  : 'POST',
       headers : { ...this._headers },
@@ -94,15 +120,19 @@ export class JsonRpcProtocol {
   /**
    * Build an {@link HttpRequest} for a JSON-RPC batch call.
    * Sends all calls in a single HTTP request per the JSON-RPC 2.0 spec.
+   * The assigned ids are returned on the descriptor for
+   * {@link parseBatchResponse}.
    */
-  buildBatchRequest(calls: Array<{ method: string; params: unknown[] }>): HttpRequest {
-    const body = calls.map(c => ({
+  buildBatchRequest(calls: Array<{ method: string; params: unknown[] }>): JsonRpcBatchHttpRequest {
+    const ids = calls.map(() => ++this._id);
+    const body = calls.map((c, i) => ({
       jsonrpc : '2.0',
-      id      : ++this._id,
+      id      : ids[i],
       method  : c.method,
       params  : c.params,
     }));
     return {
+      ids,
       url     : this.url,
       method  : 'POST',
       headers : { ...this._headers },
@@ -113,10 +143,18 @@ export class JsonRpcProtocol {
   /**
    * Parse a JSON-RPC response payload, throwing {@link BitcoinRpcError}
    * if the response contains an error.
+   *
+   * Pass `expectedId` (from {@link buildRequest}) to bind the response to the
+   * request that asked for it.  A payload carrying no `id`, or a null one
+   * (which Bitcoin Core sends when it could not parse the request), is
+   * accepted: an endpoint able to fabricate ids can fabricate `result` just as
+   * easily, so the check guards against responses crossed in transit rather
+   * than against a dishonest node.
    */
   parseResponse(
-    payload: { result?: unknown; error?: { code: number; message: string } },
+    payload: { id?: unknown; result?: unknown; error?: { code: number; message: string } },
     method: string,
+    expectedId?: number,
   ): unknown {
     if (payload.error) {
       throw new BitcoinRpcError(
@@ -126,33 +164,55 @@ export class JsonRpcProtocol {
         { method }
       );
     }
+    if (expectedId !== undefined && typeof payload.id === 'number' && payload.id !== expectedId) {
+      throw new BitcoinRpcError(
+        'RPC_ERROR',
+        -1,
+        `Response id ${payload.id} does not match request id ${expectedId} for ${method}`,
+        { method }
+      );
+    }
     return payload.result;
   }
 
   /**
    * Parse a JSON-RPC batch response payload.
    * Returns results in the same order as the original calls.
+   *
+   * `ids` must be the ids {@link buildBatchRequest} assigned to this batch.
+   * They cannot be derived from the protocol's counter at parse time: it is
+   * shared and mutable, so any call built while this batch is in flight shifts
+   * it and each response is then matched to the wrong call.
    */
   parseBatchResponse(
     payloads: Array<{ id: number; result?: unknown; error?: { code: number; message: string } }>,
     calls: Array<{ method: string; params: unknown[] }>,
+    ids: readonly number[],
   ): unknown[] {
+    if (ids.length !== calls.length) {
+      throw new BitcoinRpcError(
+        'RPC_ERROR',
+        -1,
+        `Batch id count (${ids.length}) does not match call count (${calls.length})`,
+        { methods: calls.map(c => c.method) }
+      );
+    }
+
+    // Batch responses may arrive out of order, so each call is matched to the
+    // response carrying the id assigned to that call at build time.
     const byId = new Map(payloads.map(p => [p.id, p]));
-    // Batch responses may arrive out of order; re-sort by sequential id.
-    // IDs were assigned as (_id - calls.length + 1) .. _id
-    const startId = this._id - calls.length + 1;
 
     return calls.map((call, i) => {
-      const payload = byId.get(startId + i);
+      const payload = byId.get(ids[i]);
       if (!payload) {
         throw new BitcoinRpcError(
           'RPC_ERROR',
           -1,
-          `Missing response for batch call ${call.method} (id ${startId + i})`,
+          `Missing response for batch call ${call.method} (id ${ids[i]})`,
           { method: call.method }
         );
       }
-      return this.parseResponse(payload, call.method);
+      return this.parseResponse(payload, call.method, ids[i]);
     });
   }
 

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -6,6 +6,7 @@ export type { HttpRequest, HttpExecutor } from './client/http.js';
 export { defaultHttpExecutor } from './client/http.js';
 export { EsploraProtocol } from './client/rest/protocol.js';
 export { JsonRpcProtocol } from './client/rpc/protocol.js';
+export type { JsonRpcHttpRequest, JsonRpcBatchHttpRequest } from './client/rpc/protocol.js';
 
 // Clients (convenience wrappers around the protocol layer)
 export { BitcoinRestClient } from './client/rest/index.js';

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -19,7 +19,12 @@ export type TransactionStatus = {
 export interface Vin {
   txid: string;
   vout: number;
-  prevout?: TxInPrevout;
+  /**
+   * The output being spent, as embedded by Esplora in an address/transaction
+   * listing. It carries the same shape as a {@link Vout} and is `null` for a
+   * coinbase input; a backend that does not embed it omits the field entirely.
+   */
+  prevout?: Vout | null;
   scriptsig: string;
   scriptsig_asm: string;
   witness: string[];

--- a/packages/bitcoin/tests/json-rpc.spec.ts
+++ b/packages/bitcoin/tests/json-rpc.spec.ts
@@ -196,15 +196,15 @@ describe('JsonRpcProtocol', () => {
         { method: 'getblockhash', params: [100] as unknown[] },
       ];
       // Build batch to assign IDs
-      protocol.buildBatchRequest(calls);
-      // IDs are now (id-1) and (id)
-      const id = (protocol as any)._id;
+      const req = protocol.buildBatchRequest(calls);
+      const [first, second] = req.ids;
       const results = protocol.parseBatchResponse(
         [
-          { id: id, result: 'hash100' },
-          { id: id - 1, result: 12345 },
+          { id: second, result: 'hash100' },
+          { id: first, result: 12345 },
         ],
         calls,
+        req.ids,
       );
       expect(results).to.deep.equal([12345, 'hash100']);
     });
@@ -212,13 +212,131 @@ describe('JsonRpcProtocol', () => {
     it('throws on missing response', () => {
       const protocol = new JsonRpcProtocol({});
       const calls = [{ method: 'getblockcount', params: [] as unknown[] }];
-      protocol.buildBatchRequest(calls);
+      const req = protocol.buildBatchRequest(calls);
       try {
-        protocol.parseBatchResponse([], calls);
+        protocol.parseBatchResponse([], calls, req.ids);
         expect.fail('Expected to throw');
       } catch (err: any) {
         expect(err).to.be.instanceOf(BitcoinRpcError);
         expect(err.message).to.include('Missing response');
+      }
+    });
+  });
+
+  describe('request id binding', () => {
+    /** A batch of `getrawtransaction` calls, one per txid. */
+    const txCalls = (...txids: string[]) =>
+      txids.map(txid => ({ method: 'getrawtransaction', params: [txid] as unknown[] }));
+
+    /** What a conformant node returns: the ids it was sent, results in call order. */
+    const echo = (ids: readonly number[], txids: string[]) =>
+      ids.map((id, i) => ({ id, result: `RESULT-FOR-${txids[i]}` }));
+
+    it('reports the id it assigned to a single request', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildRequest('getblockcount', []);
+      expect(req.id).to.equal(JSON.parse(req.body!).id);
+    });
+
+    it('reports the ids it assigned to a batch, in call order', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildBatchRequest(txCalls('txA', 'txB', 'txC'));
+      expect(req.ids).to.deep.equal(JSON.parse(req.body!).map((c: any) => c.id));
+      expect(new Set(req.ids).size, 'ids must be distinct').to.equal(3);
+    });
+
+    it('matches a batch response after a single call advanced the counter', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = txCalls('txA', 'txB');
+      const batch = protocol.buildBatchRequest(calls);
+      // A concurrent caller builds a request while the batch is in flight.
+      protocol.buildRequest('getblockcount', []);
+
+      const results = protocol.parseBatchResponse(echo(batch.ids, ['txA', 'txB']), calls, batch.ids);
+      expect(results).to.deep.equal(['RESULT-FOR-txA', 'RESULT-FOR-txB']);
+    });
+
+    it('does not read another in-flight batch\'s results out of a wide payload', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = txCalls('txA', 'txB');
+      const first = protocol.buildBatchRequest(calls);
+      const second = protocol.buildBatchRequest(txCalls('txC', 'txD'));
+
+      // A payload covering both id windows: matching by anything other than the
+      // ids this batch was built with can silently pick up the other batch's data.
+      const wire = [
+        ...echo(first.ids, ['txA', 'txB']),
+        ...echo(second.ids, ['txC', 'txD']),
+      ];
+      expect(protocol.parseBatchResponse(wire, calls, first.ids))
+        .to.deep.equal(['RESULT-FOR-txA', 'RESULT-FOR-txB']);
+      expect(protocol.parseBatchResponse(wire, calls, second.ids))
+        .to.deep.equal(['RESULT-FOR-txC', 'RESULT-FOR-txD']);
+    });
+
+    it('names the id it was actually sent when a response is missing', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = txCalls('txA', 'txB');
+      const batch = protocol.buildBatchRequest(calls);
+      protocol.buildRequest('getblockcount', []);
+      try {
+        protocol.parseBatchResponse([{ id: batch.ids[0], result: 'RESULT-FOR-txA' }], calls, batch.ids);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.message).to.include(`id ${batch.ids[1]}`);
+      }
+    });
+
+    it('throws when the id count does not match the call count', () => {
+      const protocol = new JsonRpcProtocol({});
+      const calls = txCalls('txA', 'txB');
+      try {
+        protocol.parseBatchResponse([], calls, [1]);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.message).to.include('does not match call count');
+      }
+    });
+
+    it('rejects a single response carrying a different id', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildRequest('getrawtransaction', ['txA']);
+      try {
+        protocol.parseResponse({ id: req.id + 1, result: 'RESULT-FOR-txB' }, 'getrawtransaction', req.id);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BitcoinRpcError);
+        expect(err.message).to.include('does not match request id');
+        expect(err.data.method).to.equal('getrawtransaction');
+      }
+    });
+
+    it('accepts a single response carrying the id it was sent', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildRequest('getrawtransaction', ['txA']);
+      expect(protocol.parseResponse({ id: req.id, result: 'RESULT-FOR-txA' }, 'getrawtransaction', req.id))
+        .to.equal('RESULT-FOR-txA');
+    });
+
+    it('accepts a response with no id, or a null id, when one is expected', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildRequest('getblockcount', []);
+      expect(protocol.parseResponse({ result: 42 }, 'getblockcount', req.id)).to.equal(42);
+      expect(protocol.parseResponse({ id: null, result: 42 }, 'getblockcount', req.id)).to.equal(42);
+    });
+
+    it('surfaces an RPC error ahead of any id mismatch', () => {
+      const protocol = new JsonRpcProtocol({});
+      const req = protocol.buildRequest('getblock', ['nope']);
+      try {
+        // Bitcoin Core answers a request it could not parse with id: null.
+        protocol.parseResponse({ id: null, error: { code: -5, message: 'Block not found' } }, 'getblock', req.id);
+        expect.fail('Expected to throw');
+      } catch (err: any) {
+        expect(err.code).to.equal(-5);
+        expect(err.message).to.equal('Block not found');
       }
     });
   });
@@ -408,6 +526,85 @@ describe('JsonRpcTransport', () => {
       // Single call sends a plain object, not an array
       const body = JSON.parse(seen[0].body!);
       expect(body).to.not.be.an('array');
+    });
+  });
+
+  describe('concurrent requests on one transport', () => {
+    /**
+     * A conformant node: echoes the ids it was sent and answers each
+     * `getrawtransaction` with the txid it was asked for.  `delays` holds the
+     * response delay per txid, so responses can be made to arrive out of the
+     * order the requests were built in.
+     */
+    function createConcurrentTransport(delays: Record<string, number> = {}) {
+      const executor: HttpExecutor = async (req) => {
+        const body = JSON.parse(req.body!);
+        const calls = Array.isArray(body) ? body : [body];
+        const wait = Math.max(...calls.map((c: any) => delays[c.params?.[0]] ?? 0));
+        await new Promise(resolve => setTimeout(resolve, wait));
+        const responses = calls.map((c: any) => ({
+          jsonrpc : '2.0',
+          id      : c.id,
+          result  : `RESULT-FOR-${c.params?.[0] ?? c.method}`,
+        }));
+        return new Response(JSON.stringify(Array.isArray(body) ? responses : responses[0]), {
+          status  : 200,
+          headers : { 'Content-Type': 'application/json' },
+        });
+      };
+      return new JsonRpcTransport({ host: 'http://node:8332' }, executor);
+    }
+
+    it('gives each of two overlapping batches its own results', async () => {
+      const transport = createConcurrentTransport({ txA: 40, txB: 40 });
+      const first = transport.batch([
+        { method: 'getrawtransaction', params: ['txA'] },
+        { method: 'getrawtransaction', params: ['txB'] },
+      ]);
+      // Built while the first batch is still in flight, so it advances the
+      // protocol's id counter before the first response is parsed.
+      const second = transport.batch([
+        { method: 'getrawtransaction', params: ['txC'] },
+        { method: 'getrawtransaction', params: ['txD'] },
+      ]);
+
+      expect(await first).to.deep.equal(['RESULT-FOR-txA', 'RESULT-FOR-txB']);
+      expect(await second).to.deep.equal(['RESULT-FOR-txC', 'RESULT-FOR-txD']);
+    });
+
+    it('gives a batch its own results when a single call overlaps it', async () => {
+      const transport = createConcurrentTransport({ txA: 40, txB: 40 });
+      const batch = transport.batch([
+        { method: 'getrawtransaction', params: ['txA'] },
+        { method: 'getrawtransaction', params: ['txB'] },
+      ]);
+      const single = transport.call('getblockcount', []);
+
+      expect(await batch).to.deep.equal(['RESULT-FOR-txA', 'RESULT-FOR-txB']);
+      expect(await single).to.equal('RESULT-FOR-getblockcount');
+    });
+
+    it('gives each of many overlapping batches its own results', async () => {
+      const transport = createConcurrentTransport({ txA0: 30, txB0: 20, txC0: 10 });
+      const batches = ['A', 'B', 'C'].map(tag => transport.batch([
+        { method: 'getrawtransaction', params: [`tx${tag}0`] },
+        { method: 'getrawtransaction', params: [`tx${tag}1`] },
+      ]));
+
+      expect(await Promise.all(batches)).to.deep.equal([
+        ['RESULT-FOR-txA0', 'RESULT-FOR-txA1'],
+        ['RESULT-FOR-txB0', 'RESULT-FOR-txB1'],
+        ['RESULT-FOR-txC0', 'RESULT-FOR-txC1'],
+      ]);
+    });
+
+    it('gives each of two overlapping single calls its own result', async () => {
+      const transport = createConcurrentTransport({ txA: 40 });
+      const first = transport.call('getrawtransaction', ['txA']);
+      const second = transport.call('getrawtransaction', ['txB']);
+
+      expect(await first).to.equal('RESULT-FOR-txA');
+      expect(await second).to.equal('RESULT-FOR-txB');
     });
   });
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @did-btcr2/cli
 
+## 0.19.0
+
+### Minor Changes
+
+- Keep the Bitcoin RPC password off argv, and expose the beacon signal-discovery mode (ADR 087).
+
+  - **BREAKING:** the `--btc-rpc-pass` flag and `GlobalOptions.btcRpcPass` are removed; passing the flag now fails parsing with `commander.unknownOption` and the command never runs. A password on argv is readable by any local user through `ps` and `/proc/<pid>/cmdline` while the process runs, and outlives it in shell history and CI logs. Supply it through `BTCR2_BTC_RPC_PASS`, a file named by `BTCR2_BTC_RPC_PASS_FILE`, or a profile `btc.rpcPass` holding a literal value or an `env:<VAR>` or `file:<path>` secret reference, matching the keystore passphrase, which is likewise never taken from a flag (ADR 077). Because the atomic credential unit binds url, user, and pass to one layer (ADR 074), a command-line `--btc-rpc-url` now takes its password from `BTCR2_BTC_RPC_PASS_FILE` and not from `BTCR2_BTC_RPC_PASS`.
+  - **BREAKING:** `resolve` fails for a DID whose update proofs name a key outside the document's `capabilityInvocation`, following the read-path authorization check in `@did-btcr2/method` (ADR 088).
+  - Added `--btc-signal-discovery <indexer|fullnode>`, `BTCR2_BTC_SIGNAL_DISCOVERY`, and `profiles.<name>.btc.signalDiscovery`: where beacon signals are read from. `fullnode` scans blocks over Bitcoin Core RPC and requires an RPC-capable connection. A bad value is rejected at the CLI with the same named-flag message from any precedence layer, rather than passed to the SDK.
+  - `btcr2 config effective` reports the resolved `signalDiscovery` value, so a setting that changes resolution behaviour is visible to config introspection (ADRs 075, 078).
+  - The command reference no longer suggests passing an `Authorization` header value on the command line: `--btc-rpc-header` and `--btc-rest-header` place whatever they carry on argv, with the same exposure as the removed password flag.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/api@0.19.0
+  - @did-btcr2/common@9.3.0
+  - @did-btcr2/method@0.56.0
+
 ## 0.18.1
 
 ### Patch Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -287,10 +287,10 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `--btc-rest <url>` | Override Bitcoin REST endpoint (Esplora API) |
 | `--btc-rpc-url <url>` | Override Bitcoin Core RPC endpoint |
 | `--btc-rpc-user <user>` | Bitcoin Core RPC username |
-| `--btc-rpc-pass <pass>` | Bitcoin Core RPC password (accepts an `env:<VAR>` or `file:<path>` secret reference) |
 | `--btc-rpc-wallet <name>` | Bitcoin Core wallet name for wallet-scoped RPCs (`/wallet/<name>`) |
-| `--btc-rpc-header <header>` | Extra Bitcoin Core RPC header `"Key: Value"` (repeatable) |
-| `--btc-rest-header <header>` | Extra Bitcoin REST header `"Key: Value"` (repeatable), e.g. an API key |
+| `--btc-rpc-header <header>` | Extra Bitcoin Core RPC header `"Key: Value"` (repeatable). A credential passed here is on argv: prefer `btc.rpcHeaders` in a profile |
+| `--btc-signal-discovery <mode>` | Where beacon signals are read from `<indexer\|fullnode>` (default: `indexer`; `fullnode` scans blocks over Bitcoin Core RPC) |
+| `--btc-rest-header <header>` | Extra Bitcoin REST header `"Key: Value"` (repeatable). A credential passed here (an API key, a bearer token) is on argv and readable through `ps`: prefer `btc.headers` in a profile |
 | `--btc-timeout <ms>` | Bitcoin REST/RPC request timeout in milliseconds (default: unbounded) |
 | `--cas-gateway <url>` | IPFS HTTP gateway for CAS reads (read-only) |
 | `--cas-rpc-url <url>` | IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables `--publish-to-cas`) |
@@ -306,10 +306,11 @@ Override precedence, highest wins: CLI flags, then environment variables, then c
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` |
+| `BTCR2_BTC_RPC_PASS` | no flag: a password on argv is readable through `ps` and shell history |
 | `BTCR2_BTC_RPC_PASS_FILE` | file whose contents are the RPC password |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |
+| `BTCR2_BTC_SIGNAL_DISCOVERY` | `--btc-signal-discovery` |
 | `BTCR2_BTC_TIMEOUT` | `--btc-timeout` |
 | `BTCR2_CAS_TIMEOUT` | `--cas-timeout` |
 | `BTCR2_FEE_RATE` | `--fee-rate` |
@@ -365,7 +366,8 @@ Profiles are matched by network name when `--profile` is not specified. For exam
 Field notes:
 
 - **`defaults`**: `profile` selects the active profile; `network` fixes the network `create` encodes when `-n` is absent; `output` sets the default output format. `schemaVersion` is stamped on every write; a file written by a newer CLI is refused.
-- **`btc`**: `rest`/`rpcUrl`/`rpcUser`/`rpcPass` are endpoints and credentials; `wallet` targets a Bitcoin Core wallet (`/wallet/<name>`); `headers`/`rpcHeaders` add REST/RPC headers; `feeRate` (sats/vByte), `changeAddress`, and `timeoutMs` set broadcast and request behavior. The RPC url, user, and pass are resolved as one atomic unit, so a URL from a higher-precedence layer never inherits credentials from a lower one.
+- **`btc`**: `rest`/`rpcUrl`/`rpcUser`/`rpcPass` are endpoints and credentials; `wallet` targets a Bitcoin Core wallet (`/wallet/<name>`); `headers`/`rpcHeaders` add REST/RPC headers; `feeRate` (sats/vByte), `changeAddress`, and `timeoutMs` set broadcast and request behavior;
+`signalDiscovery` (`"indexer"` or `"fullnode"`) picks where beacon signals are read from. The RPC url, user, and pass are resolved as one atomic unit, so a URL from a higher-precedence layer never inherits credentials from a lower one.
 - **`cas`**: `gateway` is a read-only IPFS HTTP gateway; `cas.rpcUrl` is a writable IPFS HTTP RPC endpoint (enables `--publish-to-cas`; `rpcUrl` wins over `gateway`); `timeoutMs` bounds CAS operations (`0` disables).
 - **`identity`**: `keystore` points the profile at its own keystore file, and `default` is the profile's default signing key. Both fall **below** the corresponding `--keystore` / `--signing-key` flags.
 

--- a/packages/cli/docs/DEMO.md
+++ b/packages/cli/docs/DEMO.md
@@ -639,16 +639,28 @@ control:
 
 ```bash
 btcr2 resolve -i "$DID" --btc-rest https://esplora.internal/api      # your own Esplora
+export BTCR2_BTC_RPC_PASS_FILE=~/.bitcoin/rpcpass                    # never on argv
 btcr2 --btc-rpc-url http://127.0.0.1:38332 \
-      --btc-rpc-user demo --btc-rpc-pass demo \
+      --btc-rpc-user demo \
       --btc-rpc-wallet btcr2 \
       update ...                                                     # your own Bitcoin Core
 ```
 
-`--btc-rest-header` / `--btc-rpc-header` attach authentication headers (for example
-`'Authorization: Bearer ...'`) for gated endpoints, `--btc-timeout` bounds slow ones, and
-all of it can live in a per-network config profile instead of on the command line. The
-self-sovereignty story goes end to end: your keys, your node, your resolution.
+There is no `--btc-rpc-pass` flag: a password in argv is readable by any local user
+through `ps` and `/proc/<pid>/cmdline`, and it persists in shell history and CI logs.
+`BTCR2_BTC_RPC_PASS_FILE` is the channel to pair with a url given on the command line, as
+above. `BTCR2_BTC_RPC_PASS` and a profile `rpcPass` (which may hold an `env:<VAR>` /
+`file:<path>` reference) supply the password alongside a url from their own layer, since
+url, user, and pass resolve as one atomic unit per layer.
+
+`--btc-rest-header` / `--btc-rpc-header` attach authentication headers to gated endpoints
+(a hosted Esplora, an authenticating proxy), and `--btc-timeout` bounds slow ones. The same
+argv caveat applies to a header that carries a credential: a bearer token or API key passed
+as a flag value is just as readable through `ps` as a password would be. Put credential
+headers in the profile's `btc.headers` / `btc.rpcHeaders` instead, where `profile show`
+redacts them, and keep the flags for headers that are not secret. All of it can live in a
+per-network config profile instead of on the command line. The self-sovereignty story goes
+end to end: your keys, your node, your resolution.
 
 ### Shell completion
 
@@ -726,7 +738,7 @@ btcr2 completion [bash|zsh|fish]
 ```
 Global flags: -o json|text  --verbose  --quiet  --home <dir>  -c <config>  --profile <name>
               --keystore <path>  --passphrase-file <path>  --signing-key <ref>
-              --btc-rest <url>  --btc-rpc-url <url>  --btc-rpc-user <u>  --btc-rpc-pass <p>
+              --btc-rest <url>  --btc-rpc-url <url>  --btc-rpc-user <u>
               --btc-rpc-wallet <name>  --btc-rest-header <h>  --btc-rpc-header <h>
               --cas-gateway <url>  --cas-rpc-url <url>  --btc-timeout <ms>  --cas-timeout <ms>
 ```

--- a/packages/cli/docs/README.md
+++ b/packages/cli/docs/README.md
@@ -38,14 +38,14 @@ command; each command doc lists which globals it actually consumes. The table be
 | `--btc-rest <url>` | URL | per-network SDK default (mempool.space-style endpoints; tabulated in [resolve.md](./resolve.md#environment--configuration)) | Override the Bitcoin REST (Esplora) endpoint. |
 | `--btc-rpc-url <url>` | URL | `http://localhost:18443` on regtest; none on other networks | Override the Bitcoin Core RPC endpoint. |
 | `--btc-rpc-user <user>` | string | none | Bitcoin Core RPC username. |
-| `--btc-rpc-pass <pass>` | string, or a secret reference `env:<VAR>` / `file:<path>` | none | Bitcoin Core RPC password. RPC url, user, and pass resolve as one atomic unit per precedence layer (ADR 074). |
 | `--cas-gateway <url>` | URL | `https://ipfs.io` | IPFS HTTP gateway for CAS reads (read-only). |
 | `--cas-rpc-url <url>` | URL | none | IPFS HTTP RPC endpoint for a writable CAS (reads + writes). Configuring one is what makes `--publish-to-cas auto`/`always` on `update`/`deactivate` meaningful. |
 | `--btc-timeout <ms>` | finite number >= 1 | unset (unbounded) | Bitcoin REST/RPC request timeout in milliseconds. |
 | `--cas-timeout <ms>` | finite number >= 0; `0` disables | unset; the api layer then applies 30000 ms | CAS request timeout in milliseconds. |
-| `--btc-rest-header <header>` | `'Key: Value'`, repeatable | `[]` | Extra Bitcoin REST header. Merges over the profile's `btc.headers`, flag winning per key. A value without a `Key: Value` colon is rejected. |
+| `--btc-rest-header <header>` | `'Key: Value'`, repeatable | `[]` | Extra Bitcoin REST header. Merges over the profile's `btc.headers`, flag winning per key. A value without a `Key: Value` colon is rejected. A header value given here is on argv, so a credential in it (an API key, a bearer token) is readable by any local user through `ps` and persists in shell history and CI logs: put credential headers in the profile's `btc.headers`, which `profile show` redacts. |
 | `--btc-rpc-wallet <name>` | string | none | Bitcoin Core wallet name for wallet-scoped RPCs. |
-| `--btc-rpc-header <header>` | `'Key: Value'`, repeatable | `[]` | Extra Bitcoin Core RPC header. Merges over the profile's `btc.rpcHeaders`. |
+| `--btc-rpc-header <header>` | `'Key: Value'`, repeatable | `[]` | Extra Bitcoin Core RPC header. Merges over the profile's `btc.rpcHeaders`. Same argv exposure as `--btc-rest-header`: keep credential headers in the profile. |
+| `--btc-signal-discovery <mode>` | `indexer` \| `fullnode` | `indexer` | Where beacon signals are read from. `fullnode` scans blocks over Bitcoin Core RPC instead of querying the Esplora indexer, and fails at connection setup on a network with no RPC client (only regtest has a default RPC host). |
 | `--keystore <path>` | file path | active profile's `identity.keystore`, else `<home>/keystore.json` | Path to the keystore file. The flag short-circuits before any config read. |
 | `--passphrase-file <path>` | file path | none | Read the keystore passphrase from a file (unattended use). Note: `BTCR2_KEYSTORE_PASSPHRASE` is consulted BEFORE this file. |
 | `--signing-key <ref>` | key URN (`urn:kms:secp256k1:<32 hex>`), unique `name` tag, or unique fingerprint prefix | active profile's `identity.default`, else the keystore's active key | Key for `create`/`update`/`deactivate` signing. |
@@ -76,10 +76,11 @@ Every `BTCR2_*` variable the CLI consults, from `src/config.ts`, `src/paths.ts`,
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` (also accepts `env:<VAR>` / `file:<path>` secret references) |
+| `BTCR2_BTC_RPC_PASS` | Bitcoin Core RPC password (also accepts `env:<VAR>` / `file:<path>` secret references). No flag equivalent: a password on argv is readable through `ps` and `/proc/<pid>/cmdline` and persists in shell history and CI logs. RPC url, user, and pass resolve as one atomic unit per precedence layer (ADR 074), so a flag-supplied url takes its password from `BTCR2_BTC_RPC_PASS_FILE` rather than from this variable. |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file whose contents are the RPC password. No flag equivalent; the final fallback when no layer supplies a password, read lazily only when an RPC config is actually built. |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` |
+| `BTCR2_BTC_SIGNAL_DISCOVERY` | `--btc-signal-discovery` |
 | `BTCR2_BTC_TIMEOUT` | `--btc-timeout` |
 | `BTCR2_CAS_TIMEOUT` | `--cas-timeout` |
 | `BTCR2_FEE_RATE` | `--fee-rate` (a per-command flag on `update`/`deactivate`) |

--- a/packages/cli/docs/config.md
+++ b/packages/cli/docs/config.md
@@ -156,7 +156,7 @@ where `source` is one of `flag`, `env`, `file`, or `default`; an unresolved valu
 (json output drops undefined) and reports `source: "default"`.
 
 Shape: top-level `network` and `profile` (the active profile name; omitted when no profile is
-active), `btc.{rest,rpcUrl,rpcUser,rpcPass,rpcWallet,timeoutMs}`, and
+active), `btc.{rest,rpcUrl,rpcUser,rpcPass,rpcWallet,signalDiscovery,timeoutMs}`, and
 `cas.{gateway,rpcUrl,timeoutMs}`.
 
 Network selection: `-n/--network` when given (validated against the supported list), else the
@@ -179,6 +179,10 @@ Resolution notes:
   `http://localhost:18443` (regtest only, no default credentials); CAS gateway `https://ipfs.io`.
 - Timeouts have no defaults; `btc.timeoutMs` must be >= 1 ms and `cas.timeoutMs` >= 0 ms (`0`
   disables the CAS timeout). An invalid `--btc-timeout`/`--cas-timeout` value aborts.
+- `btc.signalDiscovery` is read back from the constructed API, so it always carries a value:
+  `indexer` with `source: "default"` when no layer sets it. `fullnode` is only resolvable on a
+  network that ends up with an RPC client; asking for it without one aborts the subcommand at
+  API construction rather than reporting an unusable mode.
 
 By default the resolved RPC password prints as `********` and any `user:pass@` userinfo embedded
 in the REST, RPC, or CAS endpoint URLs is masked; provenance still shows where each value came
@@ -264,10 +268,11 @@ Environment variables consulted:
 | `BTCR2_BTC_REST` | `effective`, `doctor` | Bitcoin REST endpoint override (as `--btc-rest`). |
 | `BTCR2_BTC_RPC_URL` | `effective`, `doctor` | Bitcoin Core RPC endpoint override (as `--btc-rpc-url`). |
 | `BTCR2_BTC_RPC_USER` | `effective`, `doctor` | RPC username (as `--btc-rpc-user`). |
-| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (as `--btc-rpc-pass`; accepts `env:<VAR>` / `file:<path>` secret references). |
+| `BTCR2_BTC_RPC_PASS` | `effective`, `doctor` | RPC password (accepts `env:<VAR>` / `file:<path>` secret references). No flag equivalent: a password on argv is readable through `ps` and shell history. |
 | `BTCR2_BTC_RPC_PASS_FILE` | `effective`, `doctor` | Path to a file whose contents are the RPC password; consulted only when no layer supplies a password and an RPC config is being built. |
 | `BTCR2_CAS_GATEWAY` | `effective`, `doctor` | IPFS HTTP gateway for CAS reads (as `--cas-gateway`). |
 | `BTCR2_CAS_RPC_URL` | `effective`, `doctor` | IPFS HTTP RPC endpoint for a writable CAS (as `--cas-rpc-url`). |
+| `BTCR2_BTC_SIGNAL_DISCOVERY` | `effective`, `doctor` | Where beacon signals are read from, `indexer` or `fullnode` (as `--btc-signal-discovery`). A value outside that pair aborts. |
 | `BTCR2_BTC_TIMEOUT` | `effective`, `doctor` | Bitcoin request timeout in ms, >= 1 (as `--btc-timeout`). |
 | `BTCR2_CAS_TIMEOUT` | `effective`, `doctor` | CAS request timeout in ms, >= 0; `0` disables (as `--cas-timeout`). |
 
@@ -290,6 +295,7 @@ Known config-file keys (the schema `config set` validates against and `config va
 | `profiles.<name>.btc.headers` | object | Extra REST headers, e.g. an API key. Secret-named header keys are redacted in output. |
 | `profiles.<name>.btc.wallet` | string | Bitcoin Core wallet name for wallet-scoped RPCs. |
 | `profiles.<name>.btc.rpcHeaders` | object | Extra Bitcoin Core RPC headers. |
+| `profiles.<name>.btc.signalDiscovery` | `"indexer"` \| `"fullnode"` | Where beacon signals are read from; `fullnode` scans blocks over Bitcoin Core RPC. |
 | `profiles.<name>.cas.gateway` | string | IPFS HTTP gateway (read-only CAS). |
 | `profiles.<name>.cas.rpcUrl` | string | IPFS HTTP RPC endpoint (writable CAS); takes precedence over the gateway. |
 | `profiles.<name>.cas.timeoutMs` | number | CAS timeout; api default 30000 ms; `0` disables. |
@@ -317,9 +323,9 @@ the active profile for `effective`, `doctor`, and the keystore path in `config p
 `--keystore` overrides the keystore path `config path` reports; `-o/--output` switches text/json;
 `--quiet` suppresses the unknown-path warning from `config set`; `--verbose` prints full error
 objects; and the connection override flags (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`,
-`--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
-`--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`) feed the `flag` layer of `effective` and
-`doctor`.
+`--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-signal-discovery`,
+`--btc-timeout`, `--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`) feed the `flag` layer of
+`effective` and `doctor`.
 
 ## Examples
 

--- a/packages/cli/docs/deactivate.md
+++ b/packages/cli/docs/deactivate.md
@@ -84,7 +84,7 @@ built-in default. Exceptions are called out below.
 | `BTCR2_BTC_REST` | Bitcoin REST (Esplora) endpoint | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | Bitcoin Core RPC endpoint | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | Bitcoin Core RPC username | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | Bitcoin Core RPC password (supports `env:<VAR>` / `file:<path>` refs) | `--btc-rpc-pass` |
+| `BTCR2_BTC_RPC_PASS` | Bitcoin Core RPC password (supports `env:<VAR>` / `file:<path>` refs) | none (a password on argv is readable through `ps` and shell history) |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file holding the RPC password (fallback when no layer supplies one) | none |
 | `BTCR2_BTC_TIMEOUT` | Bitcoin REST/RPC timeout in ms (>= 1) | `--btc-timeout` |
 | `BTCR2_CAS_GATEWAY` | Read-only IPFS gateway for CAS reads | `--cas-gateway` |
@@ -144,7 +144,7 @@ Dev (plaintext) keystores need no passphrase but are refused outright for mainne
 See the [docs README](./README.md#global-options) for the shared global flags. Globals this command notably interacts
 with: `--signing-key`, `--keystore`, `--passphrase-file`, `--home`, `-c/--config`, `--profile`,
 `-o/--output`, `--quiet`, `--verbose`, the Bitcoin connection overrides (`--btc-rest`,
-`--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`,
+`--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`, `--btc-rest-header`,
 `--btc-rpc-header`, `--btc-timeout`), and the CAS overrides (`--cas-gateway`, `--cas-rpc-url`,
 `--cas-timeout`; a writable `--cas-rpc-url` is what makes `--publish-to-cas auto|always`
 meaningful).

--- a/packages/cli/docs/quickstart.md
+++ b/packages/cli/docs/quickstart.md
@@ -165,7 +165,7 @@ Environment variables this command consults:
 | `BTCR2_KEYSTORE_PASSPHRASE` | Keystore passphrase for unattended use; consulted before `--passphrase-file` and the prompt, both at establishment and for `--unlock` verification. |
 | `BTCR2_KEYSTORE_TTL` | Default session TTL when `--ttl` is absent (same value domain as the flag). |
 | `BTCR2_OUTPUT` | Output format (`json` or `text`) when `-o/--output` is absent. |
-| `BTCR2_BTC_REST`, `BTCR2_BTC_RPC_URL`, `BTCR2_BTC_RPC_USER`, `BTCR2_BTC_RPC_PASS`, `BTCR2_BTC_RPC_PASS_FILE`, `BTCR2_CAS_GATEWAY`, `BTCR2_CAS_RPC_URL`, `BTCR2_BTC_TIMEOUT`, `BTCR2_CAS_TIMEOUT` | Endpoint overrides consulted only by the doctor probe (they shape which endpoints get probed). |
+| `BTCR2_BTC_REST`, `BTCR2_BTC_RPC_URL`, `BTCR2_BTC_RPC_USER`, `BTCR2_BTC_RPC_PASS`, `BTCR2_BTC_RPC_PASS_FILE`, `BTCR2_CAS_GATEWAY`, `BTCR2_CAS_RPC_URL`, `BTCR2_BTC_SIGNAL_DISCOVERY`, `BTCR2_BTC_TIMEOUT`, `BTCR2_CAS_TIMEOUT` | Endpoint overrides consulted only by the doctor probe (they shape which endpoints get probed). |
 
 Config-file keys that feed the command (in `<home>/config.json`, or the file named by
 `-c/--config`):
@@ -177,7 +177,7 @@ Config-file keys that feed the command (in `<home>/config.json`, or the file nam
 | `defaults.profile` | Selects the active profile when `--profile` is absent (affects the keystore path and the doctor probe). |
 | `profiles.<name>.identity.keystore` | Keystore path for the active profile; overridden by `--keystore`, falls back to `<home>/keystore.json`. |
 | `profiles.<name>.network` | The network a profile declares; a mismatch with the network being recorded surfaces as the doctor report's `coherence` warning. |
-| `profiles.<name>.btc.*` (`rest`, `rpcUrl`, `rpcUser`, `rpcPass`, `timeoutMs`, `headers`, `wallet`, `rpcHeaders`) and `profiles.<name>.cas.*` (`gateway`, `rpcUrl`, `timeoutMs`) | Endpoint configuration consulted by the doctor probe. |
+| `profiles.<name>.btc.*` (`rest`, `rpcUrl`, `rpcUser`, `rpcPass`, `timeoutMs`, `headers`, `wallet`, `rpcHeaders`, `signalDiscovery`) and `profiles.<name>.cas.*` (`gateway`, `rpcUrl`, `timeoutMs`) | Endpoint configuration consulted by the doctor probe. |
 
 A freshly scaffolded config contains `schemaVersion: 1`, `defaults.output: "text"`, and one empty
 profile per supported network; `defaults.network` is added by the network-recording step.
@@ -204,9 +204,9 @@ written by a newer CLI (`schemaVersion` above 1) aborts the network-recording wr
 Shared global flags are documented in the [docs README](./README.md#global-options); `quickstart` notably
 interacts with `--home`, `-c/--config`, `--profile`, `--keystore`, `--passphrase-file`,
 `-o/--output`, `--quiet`, `--verbose`, and (through the doctor probe) the endpoint overrides
-(`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`,
-`--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`, `--cas-gateway`, `--cas-rpc-url`,
-`--cas-timeout`).
+(`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`,
+`--btc-rest-header`, `--btc-rpc-header`, `--btc-signal-discovery`, `--btc-timeout`,
+`--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`).
 
 ## Examples
 

--- a/packages/cli/docs/resolve.md
+++ b/packages/cli/docs/resolve.md
@@ -117,11 +117,12 @@ Settings that feed this command:
 | Bitcoin REST endpoint | `--btc-rest <url>` | `BTCR2_BTC_REST` | `profiles.<name>.btc.rest` | per network, see below |
 | Bitcoin Core RPC URL | `--btc-rpc-url <url>` | `BTCR2_BTC_RPC_URL` | `profiles.<name>.btc.rpcUrl` | `http://localhost:18443` (regtest only); none elsewhere |
 | RPC username | `--btc-rpc-user <user>` | `BTCR2_BTC_RPC_USER` | `profiles.<name>.btc.rpcUser` | none |
-| RPC password | `--btc-rpc-pass <pass>` | `BTCR2_BTC_RPC_PASS` | `profiles.<name>.btc.rpcPass` | none |
+| RPC password | none (never argv) | `BTCR2_BTC_RPC_PASS` | `profiles.<name>.btc.rpcPass` | none |
 | RPC password file | none | `BTCR2_BTC_RPC_PASS_FILE` | none | none |
 | RPC wallet | `--btc-rpc-wallet <name>` | none | `profiles.<name>.btc.wallet` | none |
 | Extra REST headers | `--btc-rest-header <header>` (repeatable, `'Key: Value'`) | none | `profiles.<name>.btc.headers` | none |
 | Extra RPC headers | `--btc-rpc-header <header>` (repeatable, `'Key: Value'`) | none | `profiles.<name>.btc.rpcHeaders` | none |
+| Beacon signal discovery | `--btc-signal-discovery <mode>` (`indexer` \| `fullnode`) | `BTCR2_BTC_SIGNAL_DISCOVERY` | `profiles.<name>.btc.signalDiscovery` | `indexer` |
 | Bitcoin timeout (ms) | `--btc-timeout <ms>` (finite number >= 1) | `BTCR2_BTC_TIMEOUT` | `profiles.<name>.btc.timeoutMs` | unbounded |
 | CAS gateway (read-only) | `--cas-gateway <url>` | `BTCR2_CAS_GATEWAY` | `profiles.<name>.cas.gateway` | `https://ipfs.io` |
 | CAS RPC endpoint (writable) | `--cas-rpc-url <url>` | `BTCR2_CAS_RPC_URL` | `profiles.<name>.cas.rpcUrl` | none |
@@ -174,8 +175,8 @@ Behavior details, all confirmed against the source:
 Shared global flags are documented in the [docs README](./README.md#global-options). `resolve` notably interacts
 with: `-o, --output` (text vs json envelope), `--verbose` (full structured error output for
 CLI-typed errors), the connection overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`,
-`--btc-rpc-pass`, `--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`,
-`--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`), and the state-location flags (`--home`,
+`--btc-rpc-wallet`, `--btc-rest-header`, `--btc-rpc-header`, `--btc-signal-discovery`,
+`--btc-timeout`, `--cas-gateway`, `--cas-rpc-url`, `--cas-timeout`), and the state-location flags (`--home`,
 `-c, --config`, `--profile`). `--quiet`, `--keystore`, `--passphrase-file`, and `--signing-key`
 are accepted but have no effect on this command.
 

--- a/packages/cli/docs/update.md
+++ b/packages/cli/docs/update.md
@@ -84,7 +84,7 @@ Environment variables consulted by `update`:
 | `BTCR2_BTC_REST` | `--btc-rest` |
 | `BTCR2_BTC_RPC_URL` | `--btc-rpc-url` |
 | `BTCR2_BTC_RPC_USER` | `--btc-rpc-user` |
-| `BTCR2_BTC_RPC_PASS` | `--btc-rpc-pass` (supports `env:<VAR>` and `file:<path>` secret refs) |
+| `BTCR2_BTC_RPC_PASS` | no flag (a password on argv is readable through `ps` and shell history); supports `env:<VAR>` and `file:<path>` secret refs |
 | `BTCR2_BTC_RPC_PASS_FILE` | Path to a file holding the RPC password (fallback when no layer supplies one) |
 | `BTCR2_CAS_GATEWAY` | `--cas-gateway` |
 | `BTCR2_CAS_RPC_URL` | `--cas-rpc-url` (a writable CAS; enables `--publish-to-cas auto|always`) |
@@ -143,7 +143,7 @@ A dev (plaintext) keystore needs no passphrase but is refused for mainnet operat
 See the [docs README](./README.md#global-options) for the shared global flags. Globals this command notably interacts
 with: `--signing-key`, `--keystore`, `--passphrase-file`, `--profile`, `--home`, `-c/--config`,
 `-o/--output`, `--quiet` (suppresses the stderr `Watch:` hint), `--verbose`, the Bitcoin endpoint
-overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-pass`, `--btc-rpc-wallet`,
+overrides (`--btc-rest`, `--btc-rpc-url`, `--btc-rpc-user`, `--btc-rpc-wallet`,
 `--btc-rest-header`, `--btc-rpc-header`, `--btc-timeout`), and the CAS overrides (`--cas-gateway`,
 `--cas-rpc-url`, `--cas-timeout`, which gate `--publish-to-cas`).
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cli",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "description": "CLI for interacting with did-btcr2-js, the JavaScript/TypeScript reference implementation of the did:btcr2 method. Exposes various parts of multiple packages in the did-btcr2-js monorepo.",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -53,7 +53,12 @@ export class DidBtcr2Cli {
       .option('--btc-rest <url>', 'Override Bitcoin REST endpoint (Esplora API)')
       .option('--btc-rpc-url <url>', 'Override Bitcoin Core RPC endpoint')
       .option('--btc-rpc-user <user>', 'Bitcoin Core RPC username')
-      .option('--btc-rpc-pass <pass>', 'Bitcoin Core RPC password')
+      // There is deliberately no --btc-rpc-pass flag. A password in argv is
+      // readable by any local user through `ps` and /proc/<pid>/cmdline while the
+      // process runs, and outlives it in shell history and CI logs. The password
+      // reaches the CLI through BTCR2_BTC_RPC_PASS, BTCR2_BTC_RPC_PASS_FILE, or a
+      // profile `rpcPass` holding an `env:`/`file:` secret reference, matching the
+      // keystore passphrase, which is likewise never taken from a flag (ADR 077).
       .option('--cas-gateway <url>', 'IPFS HTTP gateway for CAS reads (read-only)')
       .option('--cas-rpc-url <url>', 'IPFS HTTP RPC endpoint for a writable CAS (reads + writes; enables --publish-to-cas)')
       .option('--btc-timeout <ms>', 'Bitcoin REST/RPC request timeout in milliseconds (default: unbounded)')
@@ -61,6 +66,7 @@ export class DidBtcr2Cli {
       .option('--btc-rest-header <header>', 'Extra Bitcoin REST header "Key: Value" (repeatable)', collectHeader, [])
       .option('--btc-rpc-wallet <name>', 'Bitcoin Core wallet name for wallet-scoped RPCs')
       .option('--btc-rpc-header <header>', 'Extra Bitcoin Core RPC header "Key: Value" (repeatable)', collectHeader, [])
+      .option('--btc-signal-discovery <mode>', 'Where beacon signals are read from <indexer|fullnode> (default: indexer; fullnode scans blocks over Bitcoin Core RPC)')
       .option('--keystore <path>', 'Path to the keystore file (default: <home>/keystore.json)')
       .option('--passphrase-file <path>', 'Read the keystore passphrase from a file (unattended use)')
       .option('--signing-key <ref>', 'Key for create/update/deactivate signing: a URN, fingerprint prefix, or name');

--- a/packages/cli/src/config-schema.ts
+++ b/packages/cli/src/config-schema.ts
@@ -19,16 +19,17 @@ const CONFIG_SCHEMA: SchemaNode = {
     '*' : {
       network : 'enum:network',
       btc     : {
-        rest          : 'string',
-        rpcUrl        : 'string',
-        rpcUser       : 'string',
-        rpcPass       : 'string',
-        feeRate       : 'number',
-        changeAddress : 'string',
-        timeoutMs     : 'number',
-        headers       : 'object',
-        wallet        : 'string',
-        rpcHeaders    : 'object',
+        rest            : 'string',
+        rpcUrl          : 'string',
+        rpcUser         : 'string',
+        rpcPass         : 'string',
+        feeRate         : 'number',
+        changeAddress   : 'string',
+        timeoutMs       : 'number',
+        headers         : 'object',
+        wallet          : 'string',
+        rpcHeaders      : 'object',
+        signalDiscovery : 'enum:signalDiscovery',
       },
       cas : {
         gateway   : 'string',
@@ -96,6 +97,13 @@ function assertLeafValue(kind: SchemaLeaf, dotted: string, value: unknown): void
   if (kind === 'enum:output' && value !== 'json' && value !== 'text') {
     throw new CLIError(
       `Invalid value for ${dotted}: "${String(value)}". Expected "json" or "text".`,
+      'INVALID_ARGUMENT_ERROR',
+      { path: dotted, value },
+    );
+  }
+  if (kind === 'enum:signalDiscovery' && value !== 'indexer' && value !== 'fullnode') {
+    throw new CLIError(
+      `Invalid value for ${dotted}: "${String(value)}". Expected "indexer" or "fullnode".`,
       'INVALID_ARGUMENT_ERROR',
       { path: dotted, value },
     );

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { createApi, DEFAULT_BITCOIN_NETWORK_CONFIG, DEFAULT_CAS_GATEWAY, Identifier, type BitcoinApiConfig, type CasConfig, type DidBtcr2Api } from '@did-btcr2/api';
+import { createApi, DEFAULT_BITCOIN_NETWORK_CONFIG, DEFAULT_CAS_GATEWAY, Identifier, type BitcoinApiConfig, type CasConfig, type DidBtcr2Api, type SignalDiscoveryMode } from '@did-btcr2/api';
 import type { KeyManager } from '@did-btcr2/key-manager';
 import { StaticFeeEstimator } from '@did-btcr2/method';
 import type { BroadcastOptions } from '@did-btcr2/method';
@@ -43,6 +43,8 @@ export type ConnectionOverrides = {
   btcRpcWallet?   : string;
   /** Extra Bitcoin Core RPC headers as raw `Key: Value` flag values (repeatable). */
   btcRpcHeader?   : string[];
+  /** Where beacon signals are read from (raw flag/env/profile string). */
+  btcSignalDiscovery? : string;
   /** CLI home root from `--home`. Colocates config.json + keystore.json (ADR 079). */
   home?           : string;
   config?         : string;
@@ -112,6 +114,12 @@ export type ConfigFile = {
       wallet?        : string;
       /** Extra headers sent on Bitcoin Core RPC requests. */
       rpcHeaders?    : Record<string, string>;
+      /**
+       * Where beacon signals are read from: `indexer` (Esplora, the default) or
+       * `fullnode` (scan blocks over Bitcoin Core RPC). `fullnode` needs an
+       * RPC-capable connection.
+       */
+      signalDiscovery? : SignalDiscoveryMode;
     };
     cas?: {
       /** IPFS HTTP gateway for CAS reads (read-only). */
@@ -231,23 +239,25 @@ export type ApiFactory = (network?: NetworkOption, overrides?: ConnectionOverrid
  * | `BTCR2_BTC_REST`      | `--btc-rest`       |
  * | `BTCR2_BTC_RPC_URL`   | `--btc-rpc-url`    |
  * | `BTCR2_BTC_RPC_USER`  | `--btc-rpc-user`   |
- * | `BTCR2_BTC_RPC_PASS`  | `--btc-rpc-pass`   |
+ * | `BTCR2_BTC_RPC_PASS`  | (no flag: never argv) |
  * | `BTCR2_CAS_GATEWAY`   | `--cas-gateway`    |
  * | `BTCR2_CAS_RPC_URL`   | `--cas-rpc-url`    |
  * | `BTCR2_BTC_TIMEOUT`   | `--btc-timeout`    |
  * | `BTCR2_CAS_TIMEOUT`   | `--cas-timeout`    |
  * | `BTCR2_FEE_RATE`      | `--fee-rate`       |
+ * | `BTCR2_BTC_SIGNAL_DISCOVERY` | `--btc-signal-discovery` |
  */
 export const ENV_VARS = {
-  BTC_REST     : 'BTCR2_BTC_REST',
-  BTC_RPC_URL  : 'BTCR2_BTC_RPC_URL',
-  BTC_RPC_USER : 'BTCR2_BTC_RPC_USER',
-  BTC_RPC_PASS : 'BTCR2_BTC_RPC_PASS',
-  CAS_GATEWAY  : 'BTCR2_CAS_GATEWAY',
-  CAS_RPC_URL  : 'BTCR2_CAS_RPC_URL',
-  BTC_TIMEOUT  : 'BTCR2_BTC_TIMEOUT',
-  CAS_TIMEOUT  : 'BTCR2_CAS_TIMEOUT',
-  FEE_RATE     : 'BTCR2_FEE_RATE',
+  BTC_REST             : 'BTCR2_BTC_REST',
+  BTC_RPC_URL          : 'BTCR2_BTC_RPC_URL',
+  BTC_RPC_USER         : 'BTCR2_BTC_RPC_USER',
+  BTC_RPC_PASS         : 'BTCR2_BTC_RPC_PASS',
+  CAS_GATEWAY          : 'BTCR2_CAS_GATEWAY',
+  CAS_RPC_URL          : 'BTCR2_CAS_RPC_URL',
+  BTC_TIMEOUT          : 'BTCR2_BTC_TIMEOUT',
+  CAS_TIMEOUT          : 'BTCR2_CAS_TIMEOUT',
+  FEE_RATE             : 'BTCR2_FEE_RATE',
+  BTC_SIGNAL_DISCOVERY : 'BTCR2_BTC_SIGNAL_DISCOVERY',
 } as const;
 
 /**
@@ -257,12 +267,13 @@ export const ENV_VARS = {
 export function readEnvOverrides(): ConnectionOverrides {
   const env = (key: string): string | undefined => process.env[key] || undefined;
   return {
-    btcRest    : env(ENV_VARS.BTC_REST),
-    btcRpcUrl  : env(ENV_VARS.BTC_RPC_URL),
-    btcRpcUser : env(ENV_VARS.BTC_RPC_USER),
-    btcRpcPass : env(ENV_VARS.BTC_RPC_PASS),
-    casGateway : env(ENV_VARS.CAS_GATEWAY),
-    casRpcUrl  : env(ENV_VARS.CAS_RPC_URL),
+    btcRest            : env(ENV_VARS.BTC_REST),
+    btcRpcUrl          : env(ENV_VARS.BTC_RPC_URL),
+    btcRpcUser         : env(ENV_VARS.BTC_RPC_USER),
+    btcRpcPass         : env(ENV_VARS.BTC_RPC_PASS),
+    casGateway         : env(ENV_VARS.CAS_GATEWAY),
+    casRpcUrl          : env(ENV_VARS.CAS_RPC_URL),
+    btcSignalDiscovery : env(ENV_VARS.BTC_SIGNAL_DISCOVERY),
   };
 }
 
@@ -343,12 +354,13 @@ export function profileToOverrides(
   const profile = config.profiles?.[profileName];
   if (!profile) return {};
   return {
-    btcRest    : profile.btc?.rest,
-    btcRpcUrl  : profile.btc?.rpcUrl,
-    btcRpcUser : profile.btc?.rpcUser,
-    btcRpcPass : profile.btc?.rpcPass,
-    casGateway : profile.cas?.gateway,
-    casRpcUrl  : profile.cas?.rpcUrl,
+    btcRest            : profile.btc?.rest,
+    btcRpcUrl          : profile.btc?.rpcUrl,
+    btcRpcUser         : profile.btc?.rpcUser,
+    btcRpcPass         : profile.btc?.rpcPass,
+    casGateway         : profile.cas?.gateway,
+    casRpcUrl          : profile.cas?.rpcUrl,
+    btcSignalDiscovery : profile.btc?.signalDiscovery,
   };
 }
 
@@ -563,6 +575,27 @@ function resolveRpcUnit(
   return undefined;
 }
 
+/** The accepted `--btc-signal-discovery` values, in help/error order. */
+const SIGNAL_DISCOVERY_MODES: readonly SignalDiscoveryMode[] = ['indexer', 'fullnode'];
+
+/**
+ * Validates a beacon signal-discovery mode drawn from any precedence layer.
+ * A bad value is rejected here rather than passed to the SDK, so a typo in an
+ * env var or a profile fails with the same named-flag message as a bad flag.
+ */
+function resolveSignalDiscovery(value?: string): SignalDiscoveryMode | undefined {
+  const mode = blankToUndef(value);
+  if (mode === undefined) return undefined;
+  if (!SIGNAL_DISCOVERY_MODES.includes(mode as SignalDiscoveryMode)) {
+    throw new CLIError(
+      `Invalid --btc-signal-discovery value "${mode}". Expected ${SIGNAL_DISCOVERY_MODES.join(' or ')}.`,
+      'INVALID_ARGUMENT_ERROR',
+      { value: mode },
+    );
+  }
+  return mode as SignalDiscoveryMode;
+}
+
 /**
  * Resolves the Bitcoin and CAS connection config for a network by merging,
  * in precedence order, CLI flags, environment variables, and the config-file
@@ -640,6 +673,14 @@ export function resolveConnectionConfig(
       ...(rpcHeaders ? { headers: rpcHeaders } : {}),
     };
   }
+
+  // Where beacon signals are read from. `fullnode` scans blocks over Bitcoin
+  // Core RPC and is rejected by BitcoinApi when the resolved connection has no
+  // RPC client, which includes the networks that carry no default RPC host.
+  const signalDiscovery = resolveSignalDiscovery(
+    pick(overrides?.btcSignalDiscovery, env.btcSignalDiscovery, fileOverrides.btcSignalDiscovery),
+  );
+  if (signalDiscovery) btc.signalDiscovery = signalDiscovery;
 
   // Bitcoin request timeout. No default: honored only when explicitly set, so
   // callers that rely on unbounded waits are unaffected (ADR 076).
@@ -839,12 +880,13 @@ export interface EffectiveConfig {
   network : NetworkOption;
   profile : string | undefined;
   btc : {
-    rest      : EffectiveEntry;
-    rpcUrl    : EffectiveEntry;
-    rpcUser   : EffectiveEntry;
-    rpcPass   : EffectiveEntry;
-    rpcWallet : EffectiveEntry;
-    timeoutMs : EffectiveEntry;
+    rest            : EffectiveEntry;
+    rpcUrl          : EffectiveEntry;
+    rpcUser         : EffectiveEntry;
+    rpcPass         : EffectiveEntry;
+    rpcWallet       : EffectiveEntry;
+    signalDiscovery : EffectiveEntry;
+    timeoutMs       : EffectiveEntry;
   };
   cas : {
     gateway   : EffectiveEntry;
@@ -897,12 +939,16 @@ export function resolveEffectiveConfig(network: NetworkOption, overrides?: Conne
     network,
     profile : activeProfile,
     btc     : {
-      rest      : { value: restCfg.host,     source: src(overrides?.btcRest, env.btcRest, fileOv.btcRest) },
-      rpcUrl    : { value: rpcCfg?.host,      source: rpcUnit?.url  !== undefined ? rpcSrc : 'default' },
-      rpcUser   : { value: rpcCfg?.username,  source: rpcUnit?.user !== undefined ? rpcSrc : 'default' },
-      rpcPass   : { value: rpcCfg?.password,  source: rpcUnit?.pass !== undefined ? rpcSrc : (passFromFile ? 'env' : 'default') },
-      rpcWallet : { value: rpcCfg?.wallet,    source: src(overrides?.btcRpcWallet, undefined, profileBtc?.wallet) },
-      timeoutMs : { value: conn.btc?.timeoutMs, source: src(overrides?.btcTimeout, process.env[ENV_VARS.BTC_TIMEOUT], profileBtc?.timeoutMs) },
+      rest            : { value: restCfg.host,     source: src(overrides?.btcRest, env.btcRest, fileOv.btcRest) },
+      rpcUrl          : { value: rpcCfg?.host,      source: rpcUnit?.url  !== undefined ? rpcSrc : 'default' },
+      rpcUser         : { value: rpcCfg?.username,  source: rpcUnit?.user !== undefined ? rpcSrc : 'default' },
+      rpcPass         : { value: rpcCfg?.password,  source: rpcUnit?.pass !== undefined ? rpcSrc : (passFromFile ? 'env' : 'default') },
+      rpcWallet       : { value: rpcCfg?.wallet,    source: src(overrides?.btcRpcWallet, undefined, profileBtc?.wallet) },
+      // Read back from the constructed api, like the endpoints above, so the
+      // reported value is the mode a live command would actually resolve with
+      // (the SDK's `indexer` default included) rather than only an explicit setting.
+      signalDiscovery : { value: api.btc.signalDiscovery, source: src(overrides?.btcSignalDiscovery, env.btcSignalDiscovery, fileOv.btcSignalDiscovery) },
+      timeoutMs       : { value: conn.btc?.timeoutMs, source: src(overrides?.btcTimeout, process.env[ENV_VARS.BTC_TIMEOUT], profileBtc?.timeoutMs) },
     },
     cas : {
       gateway   : { value: casGatewayVal,       source: src(overrides?.casGateway, env.casGateway,                    fileOv.casGateway) },

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -88,24 +88,27 @@ export type CommandResult =
   | { action: 'profile-remove'; data: { profile: string } };
 
 export interface GlobalOptions {
-  output         : OutputFormat;
-  verbose        : boolean;
-  quiet          : boolean;
-  home?          : string;
-  config?        : string;
-  profile?       : string;
-  btcRest?       : string;
-  btcRpcUrl?     : string;
-  btcRpcUser?    : string;
-  btcRpcPass?    : string;
-  casGateway?    : string;
-  casRpcUrl?     : string;
-  btcTimeout?    : string;
-  casTimeout?    : string;
-  btcRestHeader? : string[];
-  btcRpcWallet?  : string;
-  btcRpcHeader?  : string[];
-  keystore?      : string;
-  passphraseFile?: string;
-  signingKey?    : string;
+  output              : OutputFormat;
+  verbose             : boolean;
+  quiet               : boolean;
+  home?               : string;
+  config?             : string;
+  profile?            : string;
+  btcRest?            : string;
+  btcRpcUrl?          : string;
+  btcRpcUser?         : string;
+  // No btcRpcPass: the RPC password is never accepted as a flag, so it cannot be
+  // parsed off argv. It reaches the connection from the environment, a pass file,
+  // or a profile secret reference instead (see the flag list in `cli.ts`).
+  casGateway?         : string;
+  casRpcUrl?          : string;
+  btcTimeout?         : string;
+  casTimeout?         : string;
+  btcRestHeader?      : string[];
+  btcRpcWallet?       : string;
+  btcRpcHeader?       : string[];
+  btcSignalDiscovery? : string;
+  keystore?           : string;
+  passphraseFile?     : string;
+  signingKey?         : string;
 }

--- a/packages/cli/tests/cli-helpers.spec.ts
+++ b/packages/cli/tests/cli-helpers.spec.ts
@@ -1,4 +1,5 @@
 import { createApi } from '@did-btcr2/api';
+import { CommanderError, type Command } from 'commander';
 import { DidBtcr2Cli } from '../src/cli.js';
 import type { ApiFactory, ConnectionOverrides } from '../src/config.js';
 import { createTestApiFactory, expect, originalConsoleError, originalConsoleLog } from './helpers.js';
@@ -107,7 +108,7 @@ describe('CLI Helpers', () => {
     expect(capturedOverrides?.btcRest).to.equal('http://custom:3000');
   });
 
-  it('passes --btc-rpc-* overrides to factory on resolve', async () => {
+  it('passes --btc-rpc-url and --btc-rpc-user overrides to factory on resolve', async () => {
     let capturedOverrides: ConnectionOverrides | undefined;
     const spy: ApiFactory = (_network, overrides) => {
       capturedOverrides = overrides;
@@ -121,12 +122,60 @@ describe('CLI Helpers', () => {
       'node', 'btcr2',
       '--btc-rpc-url', 'http://node:18443',
       '--btc-rpc-user', 'alice',
-      '--btc-rpc-pass', 'secret',
       'resolve', '-i', validDid,
     ]);
 
     expect(capturedOverrides?.btcRpcUrl).to.equal('http://node:18443');
     expect(capturedOverrides?.btcRpcUser).to.equal('alice');
-    expect(capturedOverrides?.btcRpcPass).to.equal('secret');
+    expect(capturedOverrides?.btcRpcPass).to.be.undefined;
+  });
+
+  it('rejects an RPC password on argv instead of accepting it as a flag', async () => {
+    let factoryCalled = false;
+    const spy: ApiFactory = () => {
+      factoryCalled = true;
+      return createApi();
+    };
+    const cli = new DidBtcr2Cli(spy);
+    cli.program.exitOverride();
+    cli.program.configureOutput({ writeErr: () => {} });
+
+    const errors: any[] = [];
+    console.error = (...args: any[]) => errors.push(args[0]);
+
+    const validDid = 'did:btcr2:k1qqpyerymt5aaxm2jyh7za2594hgrq24uhqanxe5h94rf42flxkwhvmqd03t47';
+    await cli.run([
+      'node', 'btcr2',
+      '--btc-rpc-pass', 'secret',
+      'resolve', '-i', validDid,
+    ]);
+
+    // Parsing must fail on the unknown option, so the command never runs and the
+    // password never reaches the connection config.
+    expect(errors[0]).to.be.instanceOf(CommanderError);
+    expect(errors[0].code).to.equal('commander.unknownOption');
+    expect(factoryCalled).to.be.false;
+    expect(process.exitCode).to.equal(1);
+  });
+
+  it('registers no option whose value is itself a secret', () => {
+    // A secret on argv is readable through `ps` and /proc/<pid>/cmdline while the
+    // process runs, and persists in shell history and CI logs. Options naming a
+    // secret without carrying one are fine: a path (--passphrase-file,
+    // --secret-file) or a boolean (--secret, --show-secrets) leaks nothing.
+    const SECRET_VALUE_NAMES = ['pass', 'password', 'passphrase', 'secret', 'token', 'credential'];
+    const offenders: string[] = [];
+    const walk = (command: Command): void => {
+      for (const option of command.options) {
+        const takesValue = option.required || option.optional;
+        const leaf = (option.long ?? option.short ?? '').split('-').pop() ?? '';
+        if (takesValue && SECRET_VALUE_NAMES.includes(leaf)) offenders.push(option.flags);
+      }
+      command.commands.forEach(walk);
+    };
+
+    walk(new DidBtcr2Cli(createTestApiFactory()).program);
+
+    expect(offenders).to.deep.equal([]);
   });
 });

--- a/packages/cli/tests/config-commands.spec.ts
+++ b/packages/cli/tests/config-commands.spec.ts
@@ -175,6 +175,35 @@ describe('config and profile commands', () => {
     expect(parsed.btc.rest.source).to.equal('file');
   });
 
+  it('config effective reports the default signal-discovery mode', async () => {
+    await run('config', 'init');
+    out = [];
+    await run('config', 'effective', '-n', 'regtest');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.btc.signalDiscovery.value).to.equal('indexer');
+    expect(parsed.btc.signalDiscovery.source).to.equal('default');
+  });
+
+  it('config effective reports a profile signal-discovery mode with provenance', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.signalDiscovery', 'fullnode');
+    out = [];
+    await run('config', 'effective', '-n', 'regtest');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.btc.signalDiscovery.value).to.equal('fullnode');
+    expect(parsed.btc.signalDiscovery.source).to.equal('file');
+  });
+
+  it('config effective reports a flag signal-discovery mode as flag-sourced', async () => {
+    await run('config', 'init');
+    await run('config', 'set', 'profiles.regtest.btc.signalDiscovery', 'fullnode');
+    out = [];
+    await run('--btc-signal-discovery', 'indexer', 'config', 'effective', '-n', 'regtest');
+    const parsed = JSON.parse(out.join('\n'));
+    expect(parsed.btc.signalDiscovery.value).to.equal('indexer');
+    expect(parsed.btc.signalDiscovery.source).to.equal('flag');
+  });
+
   it('config doctor reports unreachable endpoints', async function () {
     this.timeout(15000);
     out = [];

--- a/packages/cli/tests/config-schema.spec.ts
+++ b/packages/cli/tests/config-schema.spec.ts
@@ -39,6 +39,16 @@ describe('config-schema', () => {
     it('rejects an invalid output enum value', () => {
       expect(() => validateConfigSet('defaults.output', 'yaml')).to.throw(CLIError, /"json" or "text"/);
     });
+
+    it('rejects an invalid signalDiscovery enum value', () => {
+      expect(() => validateConfigSet('profiles.regtest.btc.signalDiscovery', 'esplora'))
+        .to.throw(CLIError, /"indexer" or "fullnode"/);
+    });
+
+    it('accepts a valid signalDiscovery enum value', () => {
+      expect(validateConfigSet('profiles.regtest.btc.signalDiscovery', 'fullnode'))
+        .to.deep.equal({ unknownPath: false });
+    });
   });
 
   describe('findConfigIssues', () => {

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -80,6 +80,11 @@ describe('readEnvOverrides', () => {
     expect(overrides.casRpcUrl).to.equal('http://127.0.0.1:5001');
   });
 
+  it('reads BTCR2_BTC_SIGNAL_DISCOVERY', () => {
+    process.env[ENV_VARS.BTC_SIGNAL_DISCOVERY] = 'fullnode';
+    expect(readEnvOverrides().btcSignalDiscovery).to.equal('fullnode');
+  });
+
   it('treats empty string as undefined', () => {
     process.env[ENV_VARS.BTC_REST] = '';
     const overrides = readEnvOverrides();
@@ -638,6 +643,25 @@ describe('connection resolution (non-vacuous precedence)', () => {
     const api = defaultApiFactory('regtest', { config: cfg });
     expect(api.btc.connection.rpc?.config.wallet).to.equal('primary');
   });
+
+  it('a profile signalDiscovery reaches the resolved BitcoinApi', () => {
+    const cfg = writeCfg('signal-discovery.json', {
+      profiles : { regtest: { btc: { signalDiscovery: 'fullnode' } } },
+    });
+    // regtest carries a default RPC host, so fullnode needs no explicit rpc config.
+    expect(defaultApiFactory('regtest', { config: cfg }).btc.signalDiscovery).to.equal('fullnode');
+  });
+
+  it('defaults to indexer discovery when nothing configures it', () => {
+    const cfg = writeCfg('signal-discovery-default.json', {});
+    expect(defaultApiFactory('regtest', { config: cfg }).btc.signalDiscovery).to.equal('indexer');
+  });
+
+  it('rejects fullnode discovery on a network with no RPC client', () => {
+    const cfg = writeCfg('signal-discovery-no-rpc.json', {});
+    expect(() => defaultApiFactory('bitcoin', { config: cfg, btcSignalDiscovery: 'fullnode' }).btc)
+      .to.throw(/no rpc config was resolved/);
+  });
 });
 
 describe('parseHeaderList', () => {
@@ -740,6 +764,47 @@ describe('resolveConnectionConfig (I/O knobs)', () => {
     }));
     const { btc } = resolveConnectionConfig('regtest', { config: cfg, btcRestHeader: [ 'X-Api-Key: flag' ] });
     expect(btc?.rest?.headers).to.deep.equal({ 'X-Api-Key': 'flag', 'X-Env': 'prod' });
+  });
+
+  it('defaults signalDiscovery to unset so the api applies indexer', () => {
+    const { btc } = resolveConnectionConfig('regtest', { config: cfgPath });
+    expect(btc?.signalDiscovery).to.be.undefined;
+  });
+
+  it('maps --btc-signal-discovery into BitcoinApiConfig', () => {
+    const { btc } = resolveConnectionConfig('regtest', { config: cfgPath, btcSignalDiscovery: 'fullnode' });
+    expect(btc?.signalDiscovery).to.equal('fullnode');
+  });
+
+  it('reads btc.signalDiscovery from the config-file profile', () => {
+    const cfg = join(tempDir, 'signal-discovery.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { signalDiscovery: 'fullnode' } } },
+    }));
+    expect(resolveConnectionConfig('regtest', { config: cfg }).btc?.signalDiscovery).to.equal('fullnode');
+  });
+
+  it('lets --btc-signal-discovery override the profile', () => {
+    const cfg = join(tempDir, 'signal-discovery-override.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { signalDiscovery: 'fullnode' } } },
+    }));
+    const { btc } = resolveConnectionConfig('regtest', { config: cfg, btcSignalDiscovery: 'indexer' });
+    expect(btc?.signalDiscovery).to.equal('indexer');
+  });
+
+  it('rejects an unknown --btc-signal-discovery mode', () => {
+    expect(() => resolveConnectionConfig('regtest', { config: cfgPath, btcSignalDiscovery: 'esplora' }))
+      .to.throw(CLIError, /Invalid --btc-signal-discovery value "esplora"/);
+  });
+
+  it('rejects an unknown signalDiscovery in the config-file profile', () => {
+    const cfg = join(tempDir, 'signal-discovery-bad.json');
+    writeFileSync(cfg, JSON.stringify({
+      profiles : { regtest: { btc: { signalDiscovery: 'nope' } } },
+    }));
+    expect(() => resolveConnectionConfig('regtest', { config: cfg }))
+      .to.throw(CLIError, /Invalid --btc-signal-discovery value "nope"/);
   });
 
   it('maps --btc-rpc-wallet and --btc-rpc-header into RpcConfig alongside the url', () => {
@@ -882,6 +947,23 @@ describe('resolveSecretRef and RPC password sources', () => {
       profiles : { regtest: { btc: { rpcUrl: 'http://node:18443', rpcUser: 'u' } } },
     }));
     const api = defaultApiFactory('regtest', { config: cfg });
+    expect(api.btc.connection.rpc?.config.password).to.equal('file-secret');
+  });
+
+  it('supplies the password for a flag-given RPC url from BTCR2_BTC_RPC_PASS_FILE', () => {
+    // The pass file is the layer-independent password channel, so it still
+    // reaches an RPC url given on the command line. BTCR2_BTC_RPC_PASS does not:
+    // the atomic credential unit binds url and credentials to one layer, and the
+    // url came from the flag layer.
+    const file = join(tempDir, 'flag-passfile.txt');
+    writeFileSync(file, 'file-secret\n');
+    process.env.BTCR2_BTC_RPC_PASS_FILE = file;
+    process.env[ENV_VARS.BTC_RPC_PASS] = 'env-secret';
+    const api = defaultApiFactory('regtest', {
+      config     : join(tempDir, 'no-such-config.json'),
+      btcRpcUrl  : 'http://node-b:18443',
+      btcRpcUser : 'bob',
+    });
     expect(api.btc.connection.rpc?.config.password).to.equal('file-secret');
   });
 });

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @did-btcr2/common
 
+## 9.3.0
+
+### Minor Changes
+
+- Keep prototype machinery out of JSON Patch pointers and out of JSON walks.
+
+  - `JSONPatch.validateOperations` rejects any `path` or `from` whose RFC 6901 segments, unescaped, include `__proto__`, `constructor`, or `prototype`, at any position. `fast-json-patch` bans `__proto__` and a trailing `constructor/prototype` pair, but it still traverses an intermediate `constructor` segment, at which point the cursor is the global `Object` or `Array` function and the operation writes a static member process-wide. Patches carried by untrusted DID updates reach this validator, so the segments are refused before any application.
+  - **Semantic change:** a document key literally named `constructor`, `prototype`, or `__proto__` is no longer addressable by patch. No DID Core or btcr2 vocabulary defines such a property, and patching every other key of such a document still works.
+  - `JSONUtils.clone`, `deleteKeys`, and `sanitize` define copied keys as own enumerable data properties instead of assigning them. A plain `result[key] = value` routes the key `__proto__` through the inherited `Object.prototype` setter, which discards the key and swaps the copy's prototype for the supplied value. `JSON.parse` produces `__proto__` as an own enumerable key, so a document carrying one previously lost it on every walk while the copy inherited attacker-supplied properties. Canonicalization and `canonicalHash` are byte-identical to before for every input without such a key.
+
 ## 9.2.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/common",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "type": "module",
   "description": "Common utilities, types, interfaces, etc. shared across the did-btcr2-js monorepo packages.",
   "main": "./dist/cjs/index.js",

--- a/packages/common/src/json-patch.ts
+++ b/packages/common/src/json-patch.ts
@@ -5,6 +5,27 @@ import type { JSONObject } from './types.js';
 
 const { applyPatch, compare, deepClone } = jsonPatch;
 
+/**
+ * JSON Pointer segments that resolve to inherited prototype machinery instead of document data.
+ * `fast-json-patch` bans `__proto__` and a trailing `constructor/prototype` pair, but it still
+ * traverses an intermediate `constructor` segment, at which point the cursor becomes the global
+ * `Object` or `Array` function and the operation writes a static member process-wide.
+ */
+const UNSAFE_POINTER_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Find the first JSON Pointer segment that traverses into prototype machinery. Segments are
+ * unescaped per RFC 6901 first, matching how `fast-json-patch` resolves them.
+ * @param {string} pointer - The JSON Pointer to inspect.
+ * @returns {string | undefined} The offending segment, or undefined if the pointer is safe.
+ */
+function findUnsafeSegment(pointer: string): string | undefined {
+  return pointer
+    .split('/')
+    .map(segment => segment.replace(/~1/g, '/').replace(/~0/g, '~'))
+    .find(segment => UNSAFE_POINTER_SEGMENTS.has(segment));
+}
+
 export type PatchOpCode = 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
 /**
  * A JSON Patch operation, as defined in {@link https://datatracker.ietf.org/doc/html/rfc6902 | RFC 6902}.
@@ -105,8 +126,22 @@ export class JSONPatch {
       if (!op || typeof op !== 'object') return new MethodError('Operation must be an object', 'JSON_PATCH_VALIDATION_ERROR');
       if (typeof op.op !== 'string') return new MethodError('Operation.op must be a string', 'JSON_PATCH_VALIDATION_ERROR');
       if (typeof op.path !== 'string') return new MethodError('Operation.path must be a string', 'JSON_PATCH_VALIDATION_ERROR');
+      const unsafePathSegment = findUnsafeSegment(op.path);
+      if (unsafePathSegment) {
+        return new MethodError(
+          `Operation.path traverses prototype machinery: ${unsafePathSegment}`, 'JSON_PATCH_VALIDATION_ERROR'
+        );
+      }
       if ((op.op === 'move' || op.op === 'copy') && typeof op.from !== 'string') {
         return new MethodError(`Operation.from must be a string for op=${op.op}`, 'JSON_PATCH_VALIDATION_ERROR');
+      }
+      if (typeof op.from === 'string') {
+        const unsafeFromSegment = findUnsafeSegment(op.from);
+        if (unsafeFromSegment) {
+          return new MethodError(
+            `Operation.from traverses prototype machinery: ${unsafeFromSegment}`, 'JSON_PATCH_VALIDATION_ERROR'
+          );
+        }
       }
     }
     return null;

--- a/packages/common/src/utils/json.ts
+++ b/packages/common/src/utils/json.ts
@@ -10,6 +10,22 @@ type CloneOptions = {
 };
 
 /**
+ * Copy a key onto a freshly built result as an own, enumerable data property.
+ *
+ * A plain `result[key] = value` assignment routes the key `__proto__` through the inherited
+ * `Object.prototype` setter, which discards the key and swaps the result's prototype for the
+ * attacker-supplied value. `JSON.parse` produces `__proto__` as an own enumerable key, so any
+ * document that survives a walk here would lose it. Defining the property instead bypasses
+ * inherited accessors while matching what assignment does for every other key.
+ * @param {any} target - The result object receiving the property.
+ * @param {string} key - The property key, taken from the source object's own keys.
+ * @param {any} value - The property value.
+ */
+function defineOwn(target: any, key: string, value: any): void {
+  Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+}
+
+/**
  * Utilities for working with JSON data.
  * @name JSONUtils
  * @class JSONUtils
@@ -211,7 +227,7 @@ export class JSONUtils {
         const result: any = {};
         for (const key of Object.keys(candidate)) {
           if (keySet.has(key)) continue;
-          result[key] = walk(candidate[key]);
+          defineOwn(result, key, walk(candidate[key]));
         }
         return result;
       }
@@ -238,7 +254,7 @@ export class JSONUtils {
         for (const [key, val] of Object.entries(candidate)) {
           const sanitized = walk(val);
           if (sanitized !== undefined) {
-            result[key] = sanitized;
+            defineOwn(result, key, sanitized);
           }
         }
         return result;
@@ -301,7 +317,7 @@ export class JSONUtils {
     seen.set(value as object, result);
 
     for (const key of Object.keys(value as object)) {
-      result[key] = this.cloneInternal((value as any)[key], options, seen, depth + 1);
+      defineOwn(result, key, this.cloneInternal((value as any)[key], options, seen, depth + 1));
     }
 
     return result;

--- a/packages/common/tests/json-patch.spec.ts
+++ b/packages/common/tests/json-patch.spec.ts
@@ -28,6 +28,80 @@ describe('JSONPatch', () => {
     expect(() => JSONPatch.apply(source, ops)).to.throw(MethodError, 'Invalid JSON Patch operations');
   });
 
+  describe('prototype-traversal path segments', () => {
+    const exploits: Array<{ name: string; op: PatchOperation; owner: any; prop: string }> = [
+      {
+        name  : 'Object.keys via /constructor/keys',
+        op    : { op: 'replace', path: '/constructor/keys', value: null },
+        owner : Object,
+        prop  : 'keys'
+      },
+      {
+        name  : 'Object.assign via /constructor/assign',
+        op    : { op: 'replace', path: '/constructor/assign', value: null },
+        owner : Object,
+        prop  : 'assign'
+      },
+      {
+        name  : 'Array.of via /arr/constructor/of',
+        op    : { op: 'replace', path: '/arr/constructor/of', value: null },
+        owner : Array,
+        prop  : 'of'
+      },
+      {
+        name  : 'Object.freeze via a move `from` pointer',
+        op    : { op: 'move', from: '/constructor/freeze', path: '/sink/moved' },
+        owner : Object,
+        prop  : 'freeze'
+      },
+      {
+        name  : 'Object.entries via a copy `from` pointer',
+        op    : { op: 'copy', from: '/constructor/entries', path: '/sink/copied' },
+        owner : Object,
+        prop  : 'entries'
+      }
+    ];
+
+    for (const { name, op, owner, prop } of exploits) {
+      it(`rejects ${name} and leaves the global intact`, () => {
+        const original = owner[prop];
+        const source = { id: 'did:btcr2:x', arr: [1, 2], sink: {} };
+        try {
+          expect(() => JSONPatch.apply(source, [op])).to.throw(MethodError, 'Invalid JSON Patch operations');
+          expect(owner[prop]).to.equal(original);
+          expect(typeof owner[prop]).to.equal('function');
+        } finally {
+          // Repair the global if the guard ever regresses, so one failure cannot cascade.
+          owner[prop] = original;
+        }
+      });
+    }
+
+    it('rejects __proto__ and prototype segments at any position', () => {
+      const paths = ['/__proto__/polluted', '/constructor/prototype/polluted', '/a/__proto__/b', '/a/prototype/b'];
+      for (const path of paths) {
+        expect(() => JSONPatch.apply({ a: {} }, [{ op: 'add', path, value: 'x' }]))
+          .to.throw(MethodError, 'Invalid JSON Patch operations');
+      }
+      expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
+    });
+
+    it('reports the offending segment on the validation error', () => {
+      const error = JSONPatch.validateOperations([{ op: 'replace', path: '/constructor/keys', value: null }]);
+      expect(error).to.be.instanceOf(MethodError);
+      expect(error?.message).to.include('constructor');
+    });
+
+    it('still allows escaped literal keys that merely resemble unsafe segments', () => {
+      const source = { 'co~nstructor': 1, 'a/constructor': 2 };
+      const result = JSONPatch.apply(source, [
+        { op: 'replace', path: '/co~0nstructor', value: 9 },
+        { op: 'replace', path: '/a~1constructor', value: 8 }
+      ]);
+      expect(result).to.deep.equal({ 'co~nstructor': 9, 'a/constructor': 8 });
+    });
+  });
+
   it('computes diffs and prefixes paths with escaping', () => {
     const source = { 'a/b': 1 };
     const target = { 'a/b': 2, c: 3 };

--- a/packages/common/tests/utils-json.spec.ts
+++ b/packages/common/tests/utils-json.spec.ts
@@ -144,4 +144,56 @@ describe('utils/json', () => {
     const sanitizeB = JSONUtils.sanitize(['b', undefined, 2, { d: undefined, e: 5 }]);
     expect(sanitizeB).to.deep.equal(['b', 2, { e: 5 }]);
   });
+
+  describe('own __proto__ keys', () => {
+    // JSON.parse produces `__proto__` as an own enumerable key, unlike an object literal.
+    const parse = (): any => JSON.parse('{"id":"did:btcr2:x","__proto__":{"admin":true}}');
+
+    const walkers: Array<{ name: string; walk: (value: any) => any }> = [
+      { name: 'normalize', walk: (value) => JSONUtils.normalize(value) },
+      { name: 'deleteKeys', walk: (value) => JSONUtils.deleteKeys(value, ['unrelated']) },
+      { name: 'sanitize', walk: (value) => JSONUtils.sanitize(value) },
+      { name: 'cloneReplace', walk: (value) => JSONUtils.cloneReplace(value, /nomatch/, 'x') }
+    ];
+
+    for (const { name, walk } of walkers) {
+      it(`${name} keeps __proto__ as data instead of swapping the prototype`, () => {
+        const source = parse();
+        expect(Object.prototype.hasOwnProperty.call(source, '__proto__')).to.be.true;
+
+        const result = walk(source);
+
+        expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).to.be.true;
+        expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+        expect(Object.keys(result)).to.deep.equal(['id', '__proto__']);
+        expect((result as any).admin).to.be.undefined;
+      });
+
+      it(`${name} does not lose a nested __proto__ key`, () => {
+        const source = JSON.parse('{"a":{"__proto__":{"admin":true}}}');
+        const nested = walk(source).a;
+
+        expect(Object.prototype.hasOwnProperty.call(nested, '__proto__')).to.be.true;
+        expect(Object.getPrototypeOf(nested)).to.equal(Object.prototype);
+        expect(nested.admin).to.be.undefined;
+      });
+    }
+
+    it('normalize round-trips a document byte-for-byte, so hashes cannot diverge', () => {
+      const source = parse();
+      expect(JSON.stringify(JSONUtils.normalize(source))).to.equal(JSON.stringify(source));
+    });
+
+    it('leaves Object.prototype itself untouched', () => {
+      JSONUtils.normalize(parse());
+      JSONUtils.sanitize(parse());
+      expect(({} as any).admin).to.be.undefined;
+    });
+
+    it('deleteKeys still removes __proto__ when it is named', () => {
+      const result: any = JSONUtils.deleteKeys(parse(), ['__proto__']);
+      expect(Object.keys(result)).to.deep.equal(['id']);
+      expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+    });
+  });
 });

--- a/packages/cryptosuite/CHANGELOG.md
+++ b/packages/cryptosuite/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @did-btcr2/cryptosuite
+
+## 10.0.0
+
+### Major Changes
+
+- Correct the inverted domain check and stop serializing secret keys out of a multikey.
+
+  - **BREAKING:** `SchnorrMultikey.toJSON()` serializes public material only. `keyPair` is now `SchnorrKeyPair.toJSON()` (public key alone) rather than the secret-bearing `exportJSON()` shape, and `MultikeyObject.keyPair` narrows to match. `toJSON` is called implicitly by `JSON.stringify`, so anything that logged, posted, or stringified a multikey (or an object holding one) emitted the raw secret key. Serialize secret material deliberately with `multikey.keyPair.exportJSON()`.
+  - **BREAKING:** `toJSON()` reports `signer: false` for a public-key-only keypair instead of letting the `secretKey` getter's throw escape out of serialization. `JSON.stringify` of a watch-only multikey previously crashed.
+  - **BREAKING:** the `verifyProof` domain check was inverted: a proof whose domain list contained every expected domain was rejected, and one whose contents differed was accepted whenever the lengths matched, which allowed cross-domain replay of a Data Integrity proof. Both sides are normalized to lists and compared for set equality, per W3C Data Integrity. Callers that passed `expectedDomain` will see results flip.
+  - **BREAKING:** thrown `PROOF_*` errors carry `data.suite` (`{ type, cryptosuite, verificationMethod }`) in place of `data.this`, which was the live cryptosuite instance and reached the multikey's secret key through any error logger or telemetry sink. These throws fire on routine failures such as a type or verificationMethod mismatch, so they are exactly the payloads most likely to be serialized.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/common@9.3.0

--- a/packages/cryptosuite/package.json
+++ b/packages/cryptosuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@did-btcr2/cryptosuite",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "type": "module",
   "description": "W3C Data Integrity proof suite using BIP-340 Schnorr signatures over JCS-canonicalized documents. Creates and verifies bip340-jcs-2025 proofs for did:btcr2 DID updates.",
   "main": "./dist/cjs/index.js",

--- a/packages/cryptosuite/src/cryptosuite/index.ts
+++ b/packages/cryptosuite/src/cryptosuite/index.ts
@@ -21,6 +21,16 @@ import type { SchnorrMultikey } from '../multikey/index.js';
 import type { Cryptosuite, VerificationResult } from './interface.js';
 
 /**
+ * Non-sensitive description of a cryptosuite, attached to error `data` in place
+ * of the suite instance itself (which reaches the multikey and its secret key).
+ */
+type SuiteContext = {
+  type: string;
+  cryptosuite: string;
+  verificationMethod: string;
+};
+
+/**
  * An implementation of a {@link Cryptosuite} using BIP340 Schnorr signatures and JCS canonicalization.
  * @implements {Cryptosuite}
  * @class BIP340Cryptosuite
@@ -59,6 +69,21 @@ export class BIP340Cryptosuite implements Cryptosuite {
    */
   toDataIntegrityProof(): BIP340DataIntegrityProof {
     return new BIP340DataIntegrityProof(this);
+  }
+
+  /**
+   * Describe this suite for an error `data` payload. Errors are routinely logged
+   * and shipped to telemetry, and this suite holds a multikey which may hold a
+   * secret key, so the suite itself must never be attached to one. This carries
+   * only what a caller needs to see what the suite expected.
+   * @returns {SuiteContext} The suite's type, name and verification method id.
+   */
+  #suiteContext(): SuiteContext {
+    return {
+      type               : this.type,
+      cryptosuite        : this.cryptosuite,
+      verificationMethod : this.multikey.fullId()
+    };
   }
 
   /**
@@ -145,7 +170,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
     if (config.type !== this.type) {
       throw new MethodError(
         'Type mismatch: config.type !== this.type',
-        PROOF_VERIFICATION_ERROR, {config, this: this}
+        PROOF_VERIFICATION_ERROR, {config, suite: this.#suiteContext()}
       );
     }
 
@@ -153,7 +178,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
     if (config.cryptosuite !== this.cryptosuite) {
       throw new MethodError(
         'Cryptosuite mismatch: config.cryptosuite !== this.cryptosuite',
-        PROOF_VERIFICATION_ERROR, {config, this: this}
+        PROOF_VERIFICATION_ERROR, {config, suite: this.#suiteContext()}
       );
     }
 
@@ -192,7 +217,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
     if (config.type !== this.type) {
       throw new CryptosuiteError(
         'Type mismatch: config.type !== this.type',
-        PROOF_GENERATION_ERROR, {config, this: this}
+        PROOF_GENERATION_ERROR, {config, suite: this.#suiteContext()}
       );
     }
 
@@ -200,7 +225,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
     if (config.cryptosuite !== this.cryptosuite) {
       throw new CryptosuiteError(
         'Cryptosuite mismatch: config.cryptosuite !== this.cryptosuite',
-        PROOF_GENERATION_ERROR, {config, this: this},
+        PROOF_GENERATION_ERROR, {config, suite: this.#suiteContext()},
       );
     }
 
@@ -230,7 +255,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
       // Throw CryptosuiteError
       throw new CryptosuiteError(
         'Id mismatch: config.verificationMethod !== this.multikey.fullId()',
-        PROOF_SERIALIZATION_ERROR, {config, this: this}
+        PROOF_SERIALIZATION_ERROR, {config, suite: this.#suiteContext()}
       );
     }
 
@@ -255,7 +280,7 @@ export class BIP340Cryptosuite implements Cryptosuite {
     if (config.verificationMethod !== this.multikey.fullId()) {
       throw new CryptosuiteError(
         `Id mismatch: config.verificationMethod !== this.multikey.fullId()`,
-        PROOF_VERIFICATION_ERROR, {config, this: this}
+        PROOF_VERIFICATION_ERROR, {config, suite: this.#suiteContext()}
       );
     }
 

--- a/packages/cryptosuite/src/data-integrity-proof/index.ts
+++ b/packages/cryptosuite/src/data-integrity-proof/index.ts
@@ -4,6 +4,18 @@ import type { VerificationResult } from '../cryptosuite/interface.js';
 import type { DataIntegrityProof, DataIntegrityProofOptions, SecuredDocument, UnsecuredDocument } from './interface.js';
 
 /**
+ * Normalize a `domain` value to a list of urls. A domain is one or more urls, expressed either as a
+ * single string or as an array of strings; an absent domain is an empty list. Normalizing before
+ * comparison keeps a string domain from being treated as an array (where `length` is the character
+ * count and `includes` is a substring test).
+ * @param {string | string[] | undefined} domain The domain value to normalize.
+ * @returns {string[]} The domain as a list of urls.
+ */
+function toDomainList(domain?: string | string[]): string[] {
+  return domain === undefined ? [] : Array.isArray(domain) ? domain : [domain];
+}
+
+/**
  * Implements section {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1/#dataintegrityproof | 2.2.1 DataIntegrityProof}
  * of the {@link https://dcdpr.github.io/data-integrity-schnorr-secp256k1 | Data Integrity BIP-340 Cryptosuite} spec
  * @implements {DataIntegrityProof}
@@ -123,29 +135,25 @@ export class BIP340DataIntegrityProof implements DataIntegrityProof {
 
     // Check if the expectedDomain is defined
     if(expectedDomain) {
-      // Check if expectedDomain is an array with at least one entry
-      if(Array.isArray(expectedDomain) && expectedDomain.length) {
-        // Check that the domain arrays match in length
-        if(expectedDomain.length !== proof.domain?.length) {
-          // Else throw DataIntegrityProofError
-          throw new DataIntegrityProofError(
-            'Domain mismatch: expectedDomain length does not match proof.domain length',
-            PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
-          );
-        }
-        // Check that each entry in expectedDomain can be found in proof.domain
-        else if(expectedDomain.every(url => proof.domain?.includes(url))) {
-          // Else throw DataIntegrityProofError
-          throw new DataIntegrityProofError(
-            'Domain mismatch: expectedDomain and proof.domain do not match',
-            PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
-          );
-        }
-      }
-      // Else expectedDomain is a string, check that it matches proof.domain
-      else if(proof.domain !== expectedDomain) {
+      // Normalize both sides to arrays: a domain is one or more urls (string | string[])
+      const expectedDomains = toDomainList(expectedDomain);
+      const proofDomains = toDomainList(proof.domain);
+
+      // Check that the domain lists match in length
+      if(expectedDomains.length !== proofDomains.length) {
+        // Else throw DataIntegrityProofError
         throw new DataIntegrityProofError(
-          'Domain mismatch: proof.domain !== expectedDomain',
+          'Domain mismatch: expectedDomain length does not match proof.domain length',
+          PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
+        );
+      }
+
+      // Check that the two lists contain the same urls, in either order
+      if(!expectedDomains.every(url => proofDomains.includes(url))
+        || !proofDomains.every(url => expectedDomains.includes(url))) {
+        // Else throw DataIntegrityProofError
+        throw new DataIntegrityProofError(
+          'Domain mismatch: expectedDomain and proof.domain do not match',
           PROOF_VERIFICATION_ERROR, { proof, expectedDomain }
         );
       }

--- a/packages/cryptosuite/src/multikey/index.ts
+++ b/packages/cryptosuite/src/multikey/index.ts
@@ -212,16 +212,32 @@ export class SchnorrMultikey implements Multikey {
   }
 
   /**
-   * Convert the multikey to a JSON object.
+   * Convert the multikey to a JSON object. Public material only: the keyPair is
+   * serialized with {@link SchnorrKeyPair.toJSON}, which omits the secret key.
+   * Called implicitly by JSON.stringify(), so anything that logs, posts or
+   * otherwise serializes a multikey (or an object holding one) gets the public
+   * view. To serialize secret material deliberately, call
+   * `multikey.keyPair.exportJSON()`.
    * @returns {MultikeyObject} The multikey as a JSON object.
    */
   public toJSON(): MultikeyObject {
+    // The `signer` getter throws for a public-key-only keyPair with no external
+    // signer: SchnorrKeyPair.secretKey throws when absent, which is the error
+    // contract sign() relies on. Serialization must not inherit that throw, so
+    // report "cannot sign" instead.
+    let canSign: boolean;
+    try {
+      canSign = this.signer;
+    } catch {
+      canSign = false;
+    }
+
     return {
       id                 : this.id,
       controller         : this.controller,
       fullId             : this.fullId(),
-      signer             : this.signer,
-      keyPair            : this.keyPair.exportJSON(),
+      signer             : canSign,
+      keyPair            : this.keyPair.toJSON(),
       verificationMethod : this.toVerificationMethod()
     };
   }

--- a/packages/cryptosuite/src/multikey/interface.ts
+++ b/packages/cryptosuite/src/multikey/interface.ts
@@ -1,4 +1,4 @@
-import type { KeyBytes, MessageBytes, SchnorrKeyPairObject, SignatureBytes } from '@did-btcr2/common';
+import type { KeyBytes, MessageBytes, PublicKeyObject, SignatureBytes } from '@did-btcr2/common';
 import type { CompressedSecp256k1PublicKey, SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
 import type { DidVerificationMethod } from '@web5/dids';
 
@@ -7,7 +7,12 @@ export type MultikeyObject = {
   controller: string;
   fullId: string;
   signer: boolean;
-  keyPair: SchnorrKeyPairObject;
+  /**
+   * Public key material only, matching {@link SchnorrKeyPair.toJSON}. Secret key
+   * material is never part of a serialized multikey; obtain it deliberately via
+   * `multikey.keyPair.exportJSON()`.
+   */
+  keyPair: { publicKey: PublicKeyObject };
   verificationMethod: DidVerificationMethod;
 }
 export interface DidParams {

--- a/packages/cryptosuite/tests/cryptosuite.spec.ts
+++ b/packages/cryptosuite/tests/cryptosuite.spec.ts
@@ -80,4 +80,96 @@ describe('Cryptosuite', () => {
       expect(canonicalDocument).to.be.a.string;
     });
   });
+
+  /**
+   * Errors are routinely logged and shipped to telemetry, and these throws sit
+   * on routine failure paths (type / cryptosuite / verificationMethod
+   * mismatch). The suite reaches the multikey and its secret key, so an error's
+   * `data` must describe the suite rather than carry it.
+   */
+  describe('Error data (secret material)', () => {
+    const secretHex = secretKey.hex;
+    const secretSeed = secretKey.seed.toString();
+    const secretBytes = JSON.stringify(Array.from(secretKey.bytes));
+    const expectedSuite = {
+      type               : 'DataIntegrityProof',
+      cryptosuite        : 'bip340-jcs-2025',
+      verificationMethod : multikey.fullId()
+    };
+
+    // The suite mutates the config it is handed (createProof casts it and
+    // attaches proofValue), so every case builds its own.
+    const freshConfig = (overrides: Record<string, unknown> = {}): DataIntegrityProofOptions => ({
+      type               : 'DataIntegrityProof',
+      cryptosuite        : 'bip340-jcs-2025',
+      verificationMethod : `${controller}${id}`,
+      proofPurpose       : 'attestationMethod',
+      ...overrides
+    } as DataIntegrityProofOptions);
+
+    const dataFrom = (fn: () => unknown): Record<string, any> => {
+      try {
+        fn();
+      } catch (error: any) {
+        return error.data;
+      }
+      throw new Error('expected the call to throw');
+    };
+
+    const expectSafe = (data: Record<string, any>) => {
+      expect(data).to.not.have.property('this');
+      expect(data).to.have.property('config');
+      expect(data.suite).to.deep.equal(expectedSuite);
+      const serialized = JSON.stringify(data);
+      expect(serialized).to.not.include(secretHex);
+      expect(serialized).to.not.include(secretSeed);
+      expect(serialized).to.not.include(secretBytes);
+    };
+
+    it('transformDocument type mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.transformDocument(unsecuredDocument, freshConfig({ type: 'NotAProof' }))));
+    });
+
+    it('transformDocument cryptosuite mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.transformDocument(unsecuredDocument, freshConfig({ cryptosuite: 'eddsa-jcs-2022' }))));
+    });
+
+    it('proofConfiguration type mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.proofConfiguration(freshConfig({ type: 'NotAProof' }))));
+    });
+
+    it('proofConfiguration cryptosuite mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.proofConfiguration(freshConfig({ cryptosuite: 'eddsa-jcs-2022' }))));
+    });
+
+    it('proofSerialization verificationMethod mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.proofSerialization(
+          new Uint8Array(32),
+          freshConfig({ verificationMethod: `${controller}#otherKey` })
+        )));
+    });
+
+    it('proofVerification verificationMethod mismatch carries no secret', () => {
+      expectSafe(dataFrom(() =>
+        cryptosuite.proofVerification(
+          new Uint8Array(32),
+          new Uint8Array(64),
+          freshConfig({ verificationMethod: `${controller}#otherKey` })
+        )));
+    });
+
+    it('a serialized error data payload still names what the suite expected', () => {
+      // The replacement is not just a deletion: the diagnostic a caller needs
+      // (what this suite is, and which key it speaks for) survives.
+      const data = dataFrom(() =>
+        cryptosuite.transformDocument(unsecuredDocument, freshConfig({ type: 'NotAProof' })));
+      expect(JSON.parse(JSON.stringify(data)).suite).to.deep.equal(expectedSuite);
+      expect(data.config.type).to.equal('NotAProof');
+    });
+  });
 });

--- a/packages/cryptosuite/tests/data-integrity-proof.spec.ts
+++ b/packages/cryptosuite/tests/data-integrity-proof.spec.ts
@@ -1,3 +1,4 @@
+import { DataIntegrityProofError } from '@did-btcr2/common';
 import { SchnorrKeyPair, Secp256k1SecretKey } from '@did-btcr2/keypair';
 import { expect } from 'chai';
 import type {
@@ -55,6 +56,74 @@ describe('Data Integrity Proof', () => {
 
       const verifiedProof = diProof.verifyProof(JSON.stringify(securedDocument), 'attestationMethod');
       expect(verifiedProof.verified).to.be.true;
+    });
+  });
+
+  describe('verifyProof domain binding', () => {
+    // Sign a fresh document with the given domain. Both arguments are built from scratch every
+    // call: addProof mutates the document (attaching `proof`) and createProof mutates the config
+    // (attaching `proofValue`), so reusing either across calls corrupts the hash.
+    const sign = (domain?: string | string[]): string => {
+      const document = { id: 'http://university.example/credentials/58473', validFrom: '2020-01-01T00:00:00Z' };
+      const proofConfig: DataIntegrityProofOptions = {
+        type               : 'DataIntegrityProof',
+        cryptosuite        : 'bip340-jcs-2025',
+        verificationMethod : `${controller}#initialKey`,
+        proofPurpose       : 'attestationMethod'
+      };
+      if (domain !== undefined) proofConfig.domain = domain;
+      return JSON.stringify(diProof.addProof(document, proofConfig));
+    };
+    const verify = (signed: string, expectedDomain?: string | string[]) =>
+      diProof.verifyProof(signed, 'attestationMethod', undefined, expectedDomain);
+    const MISMATCH = 'Domain mismatch: expectedDomain and proof.domain do not match';
+    const LENGTH_MISMATCH = 'Domain mismatch: expectedDomain length does not match proof.domain length';
+
+    it('should verify a proof whose domain matches the expected domain', () => {
+      expect(verify(sign(['victim.example']), ['victim.example']).verified).to.be.true;
+      expect(verify(sign(['a.example', 'b.example']), ['a.example', 'b.example']).verified).to.be.true;
+    });
+
+    it('should verify a matching domain regardless of order', () => {
+      expect(verify(sign(['a.example', 'b.example']), ['b.example', 'a.example']).verified).to.be.true;
+    });
+
+    it('should reject a proof bound to a different domain of the same length', () => {
+      expect(() => verify(sign(['attacker.example']), ['victim.example']))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+      expect(() => verify(sign(['a.example', 'attacker.example']), ['a.example', 'victim.example']))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+    });
+
+    it('should reject a proof whose domain list differs in length', () => {
+      expect(() => verify(sign(['a.example']), ['a.example', 'b.example']))
+        .to.throw(DataIntegrityProofError, LENGTH_MISMATCH);
+      expect(() => verify(sign(), ['victim.example']))
+        .to.throw(DataIntegrityProofError, LENGTH_MISMATCH);
+    });
+
+    it('should reject an unexpected domain hidden behind a duplicated expected entry', () => {
+      expect(() => verify(sign(['attacker.example', 'victim.example']), ['victim.example', 'victim.example']))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+    });
+
+    it('should treat a string domain as a single-entry list, not as a character sequence', () => {
+      // Equivalent forms match in either direction.
+      expect(verify(sign('victim.example'), ['victim.example']).verified).to.be.true;
+      expect(verify(sign(['victim.example']), 'victim.example').verified).to.be.true;
+      expect(verify(sign('victim.example'), 'victim.example').verified).to.be.true;
+
+      // A string domain is never compared by character count or by substring.
+      expect(() => verify(sign('victim.example.attacker.example'), ['victim.example']))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+      expect(() => verify(sign('x'), ['a']))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+      expect(() => verify(sign('attacker.example'), 'victim.example'))
+        .to.throw(DataIntegrityProofError, MISMATCH);
+    });
+
+    it('should not check the domain when no expected domain is given', () => {
+      expect(verify(sign(['victim.example'])).verified).to.be.true;
     });
   });
 });

--- a/packages/cryptosuite/tests/multikey.spec.ts
+++ b/packages/cryptosuite/tests/multikey.spec.ts
@@ -413,4 +413,74 @@ describe('SchnorrMultikey', () => {
       expect(multikey.verify(sig, message)).to.be.true;
     });
   });
+
+  /**
+   * Serialization must never carry secret key material. toJSON() is called
+   * implicitly by JSON.stringify(), so a log line, an HTTP response body or a
+   * telemetry payload holding a multikey anywhere in its object graph would
+   * otherwise emit the secret key.
+   */
+  describe('toJSON (secret material)', () => {
+    const secretHex = Buffer.from(skBytes).toString('hex');
+    const secretSeed = BigInt(`0x${secretHex}`).toString();
+    const secretBytes = JSON.stringify(Array.from(skBytes));
+    const secretMultibase = keyPair.secretKey.multibase;
+    const multikey = new SchnorrMultikey({ id, controller, keyPair });
+
+    it('does not leak the secret key through JSON.stringify', () => {
+      const serialized = JSON.stringify(multikey);
+      expect(serialized).to.not.include(secretHex);
+      expect(serialized).to.not.include(secretHex.toUpperCase());
+      expect(serialized).to.not.include(secretSeed);
+      expect(serialized).to.not.include(secretBytes);
+      expect(serialized).to.not.include(secretMultibase);
+    });
+
+    it('does not leak the secret key when nested inside another object', () => {
+      // The realistic shape: something serializing an object graph that happens
+      // to hold a multikey, rather than the multikey directly.
+      const serialized = JSON.stringify({ ctx: { note: 'sign failed', multikey } });
+      expect(serialized).to.not.include(secretHex);
+      expect(serialized).to.not.include(secretSeed);
+      expect(serialized).to.not.include(secretBytes);
+    });
+
+    it('serializes the keyPair as public material only', () => {
+      const json = multikey.toJSON();
+      expect(json.keyPair).to.have.property('publicKey');
+      expect(json.keyPair).to.not.have.property('secretKey');
+      expect(json.keyPair.publicKey.hex).to.equal(publicKey.hex);
+      expect(json.keyPair.publicKey.multibase.encoded).to.equal(publicKeyMultibase);
+    });
+
+    it('keeps every non-secret field', () => {
+      const json = multikey.toJSON();
+      expect(json.id).to.equal(id);
+      expect(json.controller).to.equal(controller);
+      expect(json.fullId).to.equal(fullId);
+      expect(json.signer).to.be.true;
+      expect(JSONUtils.deepEqual(json.verificationMethod, verificationMethod)).to.equal(true);
+    });
+
+    it('serializes a public-key-only multikey instead of throwing', () => {
+      // The `signer` getter throws when there is no secret key and no external
+      // signer; serialization must not inherit that throw.
+      const pubOnly = new SchnorrMultikey({ id, controller, keyPair: new SchnorrKeyPair({ publicKey }) });
+      expect(() => JSON.stringify(pubOnly)).to.not.throw();
+      expect(pubOnly.toJSON().signer).to.be.false;
+      expect(pubOnly.toJSON().keyPair.publicKey.hex).to.equal(publicKey.hex);
+    });
+
+    it('reports signer true for an external-signer multikey, without leaking', () => {
+      const external = SchnorrMultikey.fromSigner(id, controller, new LocalSigner(skBytes));
+      expect(external.toJSON().signer).to.be.true;
+      expect(JSON.stringify(external)).to.not.include(secretHex);
+    });
+
+    it('still allows deliberate secret export through the keyPair', () => {
+      // Only the accidental path is removed, not the explicit one.
+      const exported = multikey.keyPair.exportJSON();
+      expect(exported.secretKey.hex).to.equal(secretHex);
+    });
+  });
 });

--- a/packages/method/CHANGELOG.md
+++ b/packages/method/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @did-btcr2/method
 
+## 0.56.0
+
+### Minor Changes
+
+- Require `capabilityInvocation` authorization on the read path, and recognize beacon signals from the spending transaction's script (ADRs 086, 088).
+
+  - **BREAKING:** resolution rejects an update whose `proof.verificationMethod` is not listed in the contemporary document's `capabilityInvocation`, with a typed `INVALID_DID_UPDATE`, per the spec's "Check update.proof" step. Locating the method in `verificationMethod[]` and verifying its signature was not sufficient on its own: a key published only for authentication, or under no relationship at all, could authorize an update on the read path, where the write path has always refused. Bare-fragment entries and embedded verification methods are normalized against the document id before comparison, so a reference naming another DID cannot collapse onto this one. **A DID whose history was signed by a key outside `capabilityInvocation` no longer resolves**, including an EXTERNAL genesis document that omits the relationship entirely.
+  - **BREAKING:** `extractOpReturnSignal(asm)` is now `extractOpReturnSignalHash(scriptPubKey)` and takes the serialized script rather than a rendered `asm` string. `asm` is a per-backend rendering (Bitcoin Core prints `OP_RETURN <hash>`, Esplora prints `OP_RETURN OP_PUSHBYTES_32 <hash>`), so an asm-shaped check written against one backend silently discards every signal from the other. The serialized script is identical on both and is what is committed to the chain. The accepted set of signals is unchanged.
+  - **BREAKING:** `BeaconUtils.getBeaconServicesMap` is removed. Its only caller needs the caller's own service objects, which the map replaced with re-parsed copies, breaking the identity-keyed result map it feeds. Build the map inline with `BeaconUtils.parseBitcoinAddress`.
+  - Indexer discovery requires a candidate transaction to spend an output of the beacon address before its OP_RETURN is read as a signal. An address transaction listing returns inbound payments too, so anyone able to pay dust to a beacon address could attach a 32-byte OP_RETURN and have it resolved as that beacon's signal, which permanently fails resolution for a hash no one can fulfil. The spent output is read from the embedded `vin[].prevout`, and from the funding transaction when a backend omits it, so a missing field cannot drop a real signal.
+  - Full-node discovery reads the signal from the last output of the spending transaction rather than from the output being spent, which carries a plain locking script and never a signal: the path previously discovered nothing at all, and every resolver driven by it returned a stale document with no error. One transaction now yields one signal per beacon however many of that beacon's UTXOs it spends.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @did-btcr2/bitcoin@0.10.0
+  - @did-btcr2/common@9.3.0
+  - @did-btcr2/cryptosuite@10.0.0
+
 ## 0.55.0
 
 ### Minor Changes

--- a/packages/method/docs/aggregation.md
+++ b/packages/method/docs/aggregation.md
@@ -4,6 +4,8 @@ Multi-party coordination for aggregated BTCR2 updates, implementing the [Aggrega
 
 This guide is a step-by-step walkthrough. If you've never used the aggregation subsystem before, read it top to bottom. If you already know what you're doing, jump to the [Service Step-by-Step](#service-step-by-step) or [Participant Step-by-Step](#participant-step-by-step) sections.
 
+> **Which package exports what.** Aggregation lives in the standalone `@did-btcr2/aggregation` package: every runner, state machine, transport, message type, and beacon strategy in this guide is imported from there, not from `@did-btcr2/method`. `@did-btcr2/method` has no dependency on it and exports no aggregation symbols; what method contributes is the did:btcr2 side of the examples (`DidBtcr2`, `Identifier`, `Resolver`, `Updater`) plus `resolveBtcr2SenderPk`, the DID-to-key decode the transports take as `resolveSenderPk`. The examples below import the whole aggregation surface from the umbrella entry `@did-btcr2/aggregation`; applications that want to keep client code out of a server bundle (or the reverse) can import the same symbols from the role entries `@did-btcr2/aggregation/core`, `/participant`, and `/service`.
+
 ---
 
 ## Table of Contents
@@ -104,9 +106,9 @@ This section walks through the Nostr setup. For the HTTP walkthrough (wire proto
 A single `Transport` instance can serve multiple registered actors. In production each process typically registers exactly one actor (its own identity); in tests one transport often serves several actors at once for easy in-process round-trips.
 
 ```typescript
-import { NostrTransport, SILENT_LOGGER } from '@did-btcr2/method';
+import { NostrTransport, SILENT_LOGGER } from '@did-btcr2/aggregation';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
-import { DidBtcr2 } from '@did-btcr2/method';
+import { DidBtcr2, resolveBtcr2SenderPk } from '@did-btcr2/method';
 
 // 1. Generate identity
 const keys = SchnorrKeyPair.generate();
@@ -125,6 +127,10 @@ const transport = new NostrTransport({
   // Some relays don't backfill historical events to late subscribers; this
   // gives them a bounded window of recent events to replay. Default 5 min.
   broadcastLookbackMs : 5 * 60 * 1000,
+  // Authenticates inbound senders: binds each message's declared `from` DID to
+  // the key that signed the event carrying it. Without it the transport accepts
+  // messages only from peers already registered via registerPeer().
+  resolveSenderPk     : resolveBtcr2SenderPk,
 });
 
 // 3. Register the actor (DID + keys) with the transport
@@ -146,6 +152,7 @@ That's the entire transport setup. From here on, you only interact with the Runn
 | `relays` | `DEFAULT_NOSTR_RELAYS` (4 public relays) | Array of relay URLs to connect to |
 | `logger` | `CONSOLE_LOGGER` | Injectable `Logger` for transport diagnostics |
 | `broadcastLookbackMs` | 5 min | `since` filter on broadcast (COHORT_ADVERT) subscription. Set to `0` to disable. |
+| `resolveSenderPk` | none | DID-to-key decode used to authenticate inbound senders. Without it, only already-registered peers are accepted. See [Sender authentication](#sender-authentication). |
 
 ### Choosing between Nostr and HTTP
 
@@ -163,23 +170,29 @@ Both transports carry identical protocol semantics. Differences that matter at d
 Factory invocation for each:
 
 ```typescript
+import { TransportFactory } from '@did-btcr2/aggregation';
+import { resolveBtcr2SenderPk } from '@did-btcr2/method';
+
 // Nostr
 const transport = TransportFactory.establish({
-  type   : 'nostr',
-  relays : ['wss://relay.damus.io', 'wss://nos.lol'],
+  type            : 'nostr',
+  relays          : ['wss://relay.damus.io', 'wss://nos.lol'],
+  resolveSenderPk : resolveBtcr2SenderPk,
 });
 
 // HTTP client (participant side)
 const transport = TransportFactory.establish({
-  type    : 'http',
-  role    : 'client',
-  baseUrl : 'https://aggregator.example.com/',
+  type            : 'http',
+  role            : 'client',
+  baseUrl         : 'https://aggregator.example.com/',
+  resolveSenderPk : resolveBtcr2SenderPk,
 });
 
 // HTTP server (operator side): mount handleRequest + handleSse in a web framework
 const transport = TransportFactory.establish({
-  type : 'http',
-  role : 'server',
+  type            : 'http',
+  role            : 'server',
+  resolveSenderPk : resolveBtcr2SenderPk,
 });
 ```
 
@@ -203,7 +216,7 @@ The service is the coordinator. It creates a cohort, advertises it, accepts part
 ### Step 1: Construct the runner
 
 ```typescript
-import { AggregationServiceRunner } from '@did-btcr2/method';
+import { AggregationServiceRunner } from '@did-btcr2/aggregation';
 
 const runner = new AggregationServiceRunner({
   transport,                     // from previous section
@@ -314,7 +327,9 @@ The participant joins cohorts advertised by services, submits its own DID update
 ### Step 1: Construct the runner
 
 ```typescript
-import { AggregationParticipantRunner, Resolver, Update } from '@did-btcr2/method';
+import { AggregationParticipantRunner } from '@did-btcr2/aggregation';
+import { LocalSigner } from '@did-btcr2/keypair';
+import { Resolver, Updater } from '@did-btcr2/method';
 
 const runner = new AggregationParticipantRunner({
   transport,                    // from the transport setup section
@@ -336,7 +351,7 @@ const runner = new AggregationParticipantRunner({
       network      : 'mutinynet',
     });
 
-    const unsigned = Update.construct(doc, [{
+    const unsigned = Updater.construct(doc, [{
       op    : 'add',
       path  : '/service/-',
       value : {
@@ -346,7 +361,9 @@ const runner = new AggregationParticipantRunner({
       }
     }], 1);
 
-    return Update.sign(myDid, unsigned, doc.verificationMethod![0], myKeys.raw.secret!);
+    // Updater.sign takes a Signer, not raw key bytes. LocalSigner is the
+    // in-process one; a KMS/HSM-backed key uses KeyManagerSigner instead.
+    return Updater.sign(myDid, unsigned, doc.verificationMethod![0], new LocalSigner(myKeys.raw.secret!));
   },
 });
 ```
@@ -478,7 +495,7 @@ console.log(`Joined cohort ${result.cohortId}, beacon: ${result.beaconAddress}`)
 | `nonce-received` | `{ participantDid }` | A participant's MuSig2 nonce arrives |
 | `signing-complete` | `AggregationResult` | Final signature computed (also resolves `run()`) |
 | `cohort-failed` | `{ cohortId, reason }` | Cohort entered a terminal failure state (validation rejection, TTL/phase timeout). Also rejects `run()`. |
-| `message-rejected` | `Rejection & { cohortId }` | The state machine silently dropped an incoming message. `code` distinguishes `WRONG_VERSION`, `UPDATE_TOO_LARGE`, `UPDATE_MALFORMED`, `UPDATE_VERIFICATION_FAILED`. |
+| `message-rejected` | `Rejection & { cohortId }` | The state machine dropped an incoming message. `code` distinguishes `WRONG_VERSION`, `UPDATE_TOO_LARGE`, `UPDATE_MALFORMED`, `UPDATE_VERIFICATION_FAILED`, `NOT_A_MEMBER`, `DUPLICATE_RESPONSE`, `INVALID_NONCE`, `INVALID_PARTIAL_SIG`, `INVALID_PARTICIPANT_KEY`. |
 | `error` | `Error` | Protocol or transport error (rejects `run()` for fatal errors) |
 
 ### `AggregationParticipantRunner` events
@@ -540,9 +557,12 @@ For tests, custom transports, or fine-grained control, drop down to the sans-I/O
 ### Service state machine
 
 ```typescript
-import { AggregationService } from '@did-btcr2/method';
+import { AggregationService } from '@did-btcr2/aggregation';
 
-const session = new AggregationService({ did: serviceDid, keys: serviceKeys });
+// The coordinator never signs: it aggregates public nonces and partial signatures,
+// so the state machine takes only the public half of the operator's keypair (ADR 038).
+// The full keypair stays the operator's transport/communication identity.
+const session = new AggregationService({ did: serviceDid, publicKey: serviceKeys.publicKey });
 
 // Step 1: Cohort Formation
 const cohortId = session.createCohort({ minParticipants: 2, network: 'mutinynet', beaconType: 'CASBeacon' });
@@ -577,9 +597,13 @@ const result = session.getResult(cohortId);
 ### Participant state machine
 
 ```typescript
-import { AggregationParticipant } from '@did-btcr2/method';
+import { AggregationParticipant, KeyPairAggregationSigner } from '@did-btcr2/aggregation';
 
-const session = new AggregationParticipant({ did: myDid, keys: myKeys });
+// The participant does sign, so it takes an AggregationSigner rather than a raw
+// keypair. KeyPairAggregationSigner backs one with an in-memory keypair and
+// materializes the secret only for a single nonce/partial-sign step (ADR 038).
+// An x1 participant also passes its genesisDocument here.
+const session = new AggregationParticipant({ did: myDid, signer: new KeyPairAggregationSigner(myKeys) });
 
 // Receive an advert
 session.receive(cohortAdvertMessage);
@@ -631,7 +655,7 @@ await runner.run();
 
 ## Running the E2E Demos
 
-Four runnable scripts in `lib/operations/aggregation/` demonstrate the runner API in different deployment configurations:
+Five runnable scripts in `packages/aggregation/lib/operations/aggregation/` demonstrate the runner API in different deployment configurations. The commands below are run from `packages/aggregation`:
 
 | Script | Description |
 |---|---|
@@ -709,6 +733,34 @@ Both are unset by default: enable them in any production deployment.
 
 `AggregationService` enforces `maxUpdateSizeBytes` (default 256 KiB) on the canonicalized size of each `SUBMIT_UPDATE` body, before the expensive BIP-340 proof verification. Oversized payloads are dropped silently at the state-machine level and surfaced as `message-rejected` events with code `UPDATE_TOO_LARGE`. This protects against cheap bandwidth/CPU exhaustion from a hostile participant. Tune downward if your DID documents are typically smaller.
 
+### Inbound messages never fail a cohort
+
+`AggregationService.receive()` does not throw on anything a sender controls. Every receive-path handler checks membership, round/session duplication, and cryptographic validity itself, and records a `Rejection` for what it drops rather than letting a cohort or signing-session invariant throw. This matters because `AggregationServiceRunner` treats an escaping error as a cohort failure (`removeCohort` + rejected completion), so a single throw on that path would be a cohort-kill available to anyone who can reach the service: a non-member ack, a never-accepted opt-in's submission, a duplicated nonce from a transport retry, or one malformed nonce.
+
+This covers cohort formation as well. `COHORT_OPT_IN` carries the sender's own `participantPk` and `communicationPk`, and the wire guard asks only that they be bytes: a three-byte or off-curve key is checked on arrival and dropped as `INVALID_PARTICIPANT_KEY`. A stored one would not be refused until the operator accepted the sender, at which point sorting the cohort keys (or aggregating them at keygen) throws inside an operator action the runner is driving, i.e. the cohort dies for a message anyone could have sent. `AggregationCohort.isValidCohortKey()` is the shared check, and the `cohortKeys` setter applies it to every key it stores, so no inbound path can carry a malformed key as far as key aggregation.
+
+Two consequences worth designing around:
+
+- A contribution that is rejected is not stored, so the sender can simply send a correct one. A member blamed for a bad partial signature (`INVALID_PARTIAL_SIG`) can retry within the same round.
+- A round whose members never send valid contributions now stalls rather than failing fast, exactly as it would for a silent member. Set `phaseTimeoutMs` / `cohortTtlMs` (and `autoFallbackOnStall` for the k-of-n script path) so stalls terminate in bounded time.
+
+The operator-facing action methods (`acceptParticipant`, `finalizeKeygen`, `startSigning`, ...) still throw: those are programming errors in the caller, not untrusted input.
+
+Rejections are retained per cohort until drained, capped at `MAX_RETAINED_REJECTIONS` (256, oldest dropped first). The runner drains after every message, so the cap only applies to callers driving the state machine directly.
+
+### Sender authentication
+
+Every protocol message declares its own sender in `from`, and the protocol acts on that claim: a participant records the service DID an advert names and encrypts to the key it declares; a service seats the DID an opt-in names and verifies that member's updates against the key it declares. Each transport separately authenticates a *key*: Nostr by the event signature (`event.pubkey`), HTTP by the signed envelope (`envelope.from`). The two must be bound, or anyone able to reach the wire can speak as any DID.
+
+Both transports enforce that bind on every receive path, and it is what `resolveSenderPk` is for:
+
+- **`resolveSenderPk` is required for inbound traffic from anyone who is not already a registered peer.** It maps a DID to its communication key without the transport knowing anything about did:btcr2; `@did-btcr2/method` exports `resolveBtcr2SenderPk` as that decode. A message whose `from` resolves to no key is dropped, not trusted. Pass it to `NostrTransport`, `HttpClientTransport` and `HttpServerTransport` alike.
+- A message whose declared `from` did not sign the event or envelope carrying it is dropped (HTTP answers `401 sender_mismatch` on the POST routes).
+- A message that advertises a `communicationPk` (a cohort advert, an opt-in) must advertise the key it just authenticated with, so a sender cannot authenticate as itself while having the cohort encrypt to, or attribute keys to, a different key.
+- An EXTERNAL (`x1`) sender is authenticated from the self-verifying genesis document it carries in-band on its opt-in, on both transports (ADR 066).
+
+`AggregationParticipant` then holds every service-originated message (`COHORT_READY`, `DISTRIBUTE_AGGREGATED_DATA`, `AUTHORIZATION_REQUEST`, `AGGREGATED_NONCE`, `FALLBACK_AUTHORIZATION_REQUEST`) to `from === serviceDid` for the cohort it names, and the nonce and fallback messages to the active signing session's id, so a stranger cannot drive a member's cohort even on a transport that does not authenticate at all. `InMemoryTransport` is exactly that transport: it is an in-process test harness and performs no inbound authentication.
+
 ### Injectable logger
 
 `NostrTransport` takes an optional `logger: Logger` in its config. `CONSOLE_LOGGER` is the default; `SILENT_LOGGER` is provided for tests and environments that want to suppress transport diagnostics. Implement the `Logger` interface (`debug`/`info`/`warn`/`error`) to route to pino, winston, Sentry, or a structured-logging pipeline.
@@ -770,8 +822,8 @@ Every `BaseMessage` carries a `version: number` field. The current version is ex
 New beacon types can be added without touching the service or participant state machines. Implement `AggregateBeaconStrategy` and call `registerBeaconStrategy(strategy)`.
 
 ```typescript
-import type { AggregateBeaconStrategy } from '@did-btcr2/method';
-import { registerBeaconStrategy } from '@did-btcr2/method';
+import type { AggregateBeaconStrategy } from '@did-btcr2/aggregation';
+import { registerBeaconStrategy } from '@did-btcr2/aggregation';
 
 const MyBeaconStrategy: AggregateBeaconStrategy = {
   type : 'MyBeacon',
@@ -790,6 +842,16 @@ const MyBeaconStrategy: AggregateBeaconStrategy = {
   validateParticipantView({ participantDid, submittedUpdate, expectedHash, body }) {
     return { matches: /* boolean */ };
   },
+
+  // Participant-side: recompute the 32-byte signal from the data just
+  // validated, the same way buildAggregatedData derives cohort.signalBytes.
+  // The participant refuses to sign unless the coordinator's announced signal
+  // is this value, so a strategy that cannot derive one (returns undefined)
+  // never gets a signature. Do not read the announced signal back out of
+  // `body`: that would bind the data to itself and authorize anything.
+  deriveSignal(result) {
+    return /* Uint8Array | undefined */;
+  },
 };
 
 registerBeaconStrategy(MyBeaconStrategy);
@@ -799,15 +861,15 @@ Once registered, passing `beaconType: 'MyBeacon'` in `CohortConfig` routes throu
 
 ### Discriminated message types
 
-For consumers writing custom transports or middleware, every message type has a narrow body interface and a type guard exported from `@did-btcr2/method`:
+For consumers writing custom transports or middleware, every message type has a narrow body interface and a type guard exported from `@did-btcr2/aggregation`:
 
 ```typescript
-import type { AggregationMessage, CohortOptInBody } from '@did-btcr2/method';
+import type { AggregationMessage, BaseMessage, CohortOptInBody } from '@did-btcr2/aggregation';
 import {
   isCohortOptInMessage,
   isSubmitUpdateMessage,
   isAuthorizationRequestMessage,
-} from '@did-btcr2/method';
+} from '@did-btcr2/aggregation';
 
 function route(msg: BaseMessage) {
   if(isCohortOptInMessage(msg)) {

--- a/packages/method/docs/http-transport.md
+++ b/packages/method/docs/http-transport.md
@@ -1,6 +1,6 @@
 # HTTP/REST Transport
 
-The `@did-btcr2/method` package ships an additive HTTP/REST transport alongside the Nostr transport for aggregation. Both implement the same `Transport` interface, so runners, state machines, and message factories don't change when you swap transports.
+The `@did-btcr2/aggregation` package ships an additive HTTP/REST transport alongside the Nostr transport. Both implement the same `Transport` interface, so runners, state machines, and message factories don't change when you swap transports. Every symbol imported below comes from `@did-btcr2/aggregation` (or its role entries `@did-btcr2/aggregation/core`, `/participant`, `/service`), not from `@did-btcr2/method`, which owns no aggregation code.
 
 This document walks through the wire protocol, shows a minimal Hono server, and demonstrates a browser-compatible client.
 
@@ -79,9 +79,9 @@ The server is sans-I/O. Mount `handleRequest` and `handleSse` into any framework
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 import { streamSSE } from 'hono/streaming';
-import { TransportFactory, AggregationServiceRunner } from '@did-btcr2/method';
+import { TransportFactory, AggregationServiceRunner } from '@did-btcr2/aggregation';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
-import type { SseStream } from '@did-btcr2/method';
+import type { SseStream } from '@did-btcr2/aggregation';
 
 const serviceKeys = SchnorrKeyPair.generate();
 const serviceDid  = /* did:btcr2:k… derived from serviceKeys */;
@@ -132,7 +132,7 @@ The `toReq` / `toSseStream` adapters are thin (~20 lines) glue that turn Hono's 
 ## Participant-side (browser or Node)
 
 ```ts
-import { TransportFactory, AggregationParticipantRunner } from '@did-btcr2/method';
+import { TransportFactory, AggregationParticipantRunner } from '@did-btcr2/aggregation';
 import { SchnorrKeyPair } from '@did-btcr2/keypair';
 
 const participantKeys = /* loaded from browser key storage */;

--- a/packages/method/package.json
+++ b/packages/method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@did-btcr2/method",
-    "version": "0.55.0",
+    "version": "0.56.0",
     "type": "module",
     "description": "Reference implementation for the did:btcr2 DID method written in TypeScript and JavaScript. did:btcr2 is a censorship resistant DID Method using the Bitcoin blockchain as a Verifiable Data Registry to announce changes to the DID document. This is the core method implementation for the did-btcr2-js monorepo.",
     "main": "./dist/cjs/index.js",

--- a/packages/method/src/core/beacon/signal-discovery.ts
+++ b/packages/method/src/core/beacon/signal-discovery.ts
@@ -1,6 +1,7 @@
 import type {
   BitcoinConnection,
   BlockV3,
+  RawTransactionRest,
   RawTransactionV2} from '@did-btcr2/bitcoin';
 import {
   GENESIS_TX_ID,
@@ -11,37 +12,44 @@ import type { BeaconService, BeaconSignal } from './interfaces.js';
 import { BeaconUtils } from './utils.js';
 
 /**
- * Parses a scriptPubKey asm string and returns the beacon signal hash if and only
- * if the output is exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hex>`.
+ * The serialized form of a Beacon Signal output: `OP_RETURN` (`0x6a`), the 32-byte push
+ * opcode (`0x20`), then the 32-byte hash. This is the exact inverse of `opReturnScript`,
+ * which encodes signals as `0x6a 0x20 <32 bytes>` and is pinned byte for byte by
+ * `op-return-script.spec.ts`.
+ */
+const BEACON_SIGNAL_SCRIPT = /^6a20([0-9a-f]{64})$/i;
+
+/**
+ * Parses a serialized scriptPubKey and returns the beacon signal hash if and only if the
+ * output is exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
  *
- * Beacon signals encode a single 32-byte update or announcement hash in an
- * OP_RETURN data push. Any other shape (a bare `OP_RETURN`, a push of the wrong
- * size, or a non-hex payload) is not a valid signal and returns `null`, so a
- * malformed or adversarial on-chain output cannot be mistaken for a real signal
- * downstream.
+ * Beacon signals encode a single 32-byte update or announcement hash in an OP_RETURN data
+ * push. Any other shape (a bare `OP_RETURN`, a push of the wrong size, a second push, or a
+ * non-canonical push opcode such as `OP_PUSHDATA1`) is not a valid signal and returns
+ * `null`, so a malformed or adversarial on-chain output cannot be mistaken for a real
+ * signal downstream.
  *
- * @param {string | undefined} asm The scriptPubKey asm string to parse.
+ * The input is the script itself, not a rendered `asm` string, because `asm` is a
+ * human-readable rendering whose dialect differs per backend: Bitcoin Core prints
+ * `OP_RETURN <hash>` while Esplora prints `OP_RETURN OP_PUSHBYTES_32 <hash>`. Both return
+ * the identical serialized script (Esplora as `scriptpubkey`, Core as `scriptPubKey.hex`),
+ * so decoding the script is backend-agnostic and matches the bytes actually committed to
+ * the chain.
+ *
+ * @param {string | undefined} scriptPubKey Hex-encoded scriptPubKey of the output to parse.
  * @returns {string | null} The lowercased 32-byte hex hash, or `null` if not a valid signal.
  */
-export function extractOpReturnSignal(asm: string | undefined): string | null {
-  if(!asm) {
+export function extractOpReturnSignalHash(scriptPubKey: string | undefined): string | null {
+  if(!scriptPubKey) {
     return null;
   }
 
-  // A standard NULL_DATA beacon output is exactly three asm tokens: the OP_RETURN
-  // opcode, the 32-byte push opcode, and the 64-character hex payload.
-  const tokens = asm.trim().split(/\s+/);
-  if(tokens.length !== 3 || tokens[0] !== 'OP_RETURN' || tokens[1] !== 'OP_PUSHBYTES_32') {
+  const signal = BEACON_SIGNAL_SCRIPT.exec(scriptPubKey.trim());
+  if(!signal) {
     return null;
   }
 
-  // The payload must be exactly 32 bytes of hex (64 hex characters).
-  const signalHash = tokens[2];
-  if(!/^[0-9a-fA-F]{64}$/.test(signalHash)) {
-    return null;
-  }
-
-  return signalHash.toLowerCase();
+  return signal[1].toLowerCase();
 }
 
 /**
@@ -51,6 +59,52 @@ export function extractOpReturnSignal(asm: string | undefined): string | null {
  * @class BeaconSignalDiscovery
  */
 export class BeaconSignalDiscovery {
+
+  /**
+   * Determines whether a candidate transaction spends an output controlled by the given
+   * beacon address.
+   *
+   * A Beacon Signal is a transaction that *spends from* a Beacon Address, but an address
+   * transaction listing returns every transaction touching the address in either
+   * direction. Without this check, anyone able to pay dust to a beacon address could
+   * attach an arbitrary 32-byte OP_RETURN and have it read as a signal, so the input side
+   * has to be inspected before a transaction is treated as one.
+   *
+   * Esplora embeds the spent output in `vin[].prevout`; when a backend omits it the
+   * funding transaction is fetched instead, so a missing field cannot silently drop a
+   * real signal.
+   *
+   * @param {RawTransactionRest} tx The candidate transaction.
+   * @param {string} address The beacon address the transaction must spend from.
+   * @param {BitcoinConnection} bitcoin Bitcoin network connection to use for REST calls.
+   * @returns {Promise<boolean>} True if at least one input spends an output of the beacon address.
+   */
+  private static async spendsFromAddress(
+    tx: RawTransactionRest,
+    address: string,
+    bitcoin: BitcoinConnection
+  ): Promise<boolean> {
+    for(const vin of tx.vin ?? []) {
+      // A coinbase input spends no prior output, so it can never spend from a beacon.
+      if(vin.is_coinbase) {
+        continue;
+      }
+
+      let prevout = vin.prevout;
+
+      // Fall back to the funding transaction when the backend does not embed the prevout.
+      if(!prevout && vin.txid) {
+        const fundingTx = await bitcoin.rest.transaction.get(vin.txid);
+        prevout = fundingTx?.vout?.[vin.vout];
+      }
+
+      if(prevout?.scriptpubkey_address === address) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   /**
    * Retrieves the beacon signals for the given array of BeaconService objects
@@ -71,10 +125,9 @@ export class BeaconSignalDiscovery {
     // Iterate over each beacon
     for (const beaconService of beaconServices) {
       beaconServiceSignals.set(beaconService, []);
+      const beaconAddress = BeaconUtils.parseBitcoinAddress(beaconService.serviceEndpoint as string);
       // Get the transactions for the beacon address via REST
-      const beaconSignals = await bitcoin.rest.address.getTxs(
-        BeaconUtils.parseBitcoinAddress(beaconService.serviceEndpoint as string)
-      );
+      const beaconSignals = await bitcoin.rest.address.getTxs(beaconAddress);
 
       // If no signals are found, continue
       if (!beaconSignals || !beaconSignals.length) {
@@ -84,10 +137,11 @@ export class BeaconSignalDiscovery {
       // Iterate over each signal
       for (const beaconSignal of beaconSignals) {
         // Get the last vout in the transaction
-        const signalVout = beaconSignal.vout.slice(-1)[0];
+        const lastSignalVout = beaconSignal.vout.slice(-1)[0];
 
         /**
-         * Look for OP_RETURN in last vout scriptpubkey_asm
+         * Decode the signal from the serialized script, not from `scriptpubkey_asm`: the
+         * asm rendering is backend-specific, the script is not.
          * Vout (rest) format:
          * {
          *  scriptpubkey: '6a20570f177c65e64fb5cf61180b664cdddf09ab76153c2b192e22006e5b22a3917a',
@@ -96,15 +150,21 @@ export class BeaconSignalDiscovery {
          *  value: 0
          * }
          */
-        if(!signalVout) {
+        if(!lastSignalVout) {
           continue;
         }
 
         // A beacon signal output must be exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
         // Reject any other shape (bare OP_RETURN, wrong push size, non-hex payload) so a
         // malformed on-chain output cannot masquerade as a phantom signal downstream.
-        const updateHash = extractOpReturnSignal(signalVout.scriptpubkey_asm);
+        const updateHash = extractOpReturnSignalHash(lastSignalVout.scriptpubkey);
         if(!updateHash) {
+          continue;
+        }
+
+        // The address listing returns inbound payments too, so require the transaction to
+        // spend from the beacon before treating its OP_RETURN as a signal.
+        if(!await BeaconSignalDiscovery.spendsFromAddress(beaconSignal, beaconAddress, bitcoin)) {
           continue;
         }
 
@@ -154,8 +214,16 @@ export class BeaconSignalDiscovery {
     // Get the current block height once before the loop
     const targetHeight = await rpc.getBlockCount();
 
-    // Hoist the beacon services map before the loop
-    const beaconServicesMap = BeaconUtils.getBeaconServicesMap(beaconServices);
+    /**
+     * Hoist the beacon address lookup before the loop, mapping each address to the caller's
+     * own service object. The results below are keyed by object identity, so the map has to
+     * hold those exact instances rather than copies of them. Addresses are parsed the same
+     * way as on the indexer path, so a BIP21 endpoint carrying query parameters resolves to
+     * the bare address a spent output reports.
+     */
+    const beaconServicesMap = new Map<string, BeaconService>(
+      beaconServices.map(service => [BeaconUtils.parseBitcoinAddress(service.serviceEndpoint as string), service])
+    );
 
     // Set genesis height
     let height = 0;
@@ -167,10 +235,49 @@ export class BeaconSignalDiscovery {
     while (block.height <= targetHeight) {
       // Iterate over each transaction in the block
       for (const tx of block.tx) {
-        // If the txid is a coinbase, continue ...
+        // If the txid is a genesis transaction, continue ...
         if (tx.txid === GENESIS_TX_ID) {
           continue;
         }
+
+        /**
+         * A Beacon Signal announces its update hash in the last output of the *spending*
+         * transaction, so the hash is resolved once per transaction, before the input side
+         * is inspected. The output being spent carries a plain locking script and never a
+         * signal. A beacon signal output must be exactly
+         * `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`; rejecting any other shape here also
+         * keeps the free filter ahead of the prevout lookups below.
+         *
+         * The signal is decoded from `scriptPubKey.hex`, the same serialized script the
+         * indexer path reads as `scriptpubkey`. Core's `asm` renders a data push as bare
+         * hex (`OP_RETURN <hash>`) where Esplora names the push opcode
+         * (`OP_RETURN OP_PUSHBYTES_32 <hash>`), so an asm-shaped check written against one
+         * backend silently discards every signal from the other.
+         * Vout (rpc) format:
+         * {
+         *  value: 0,
+         *  n: 1,
+         *  scriptPubKey: {
+         *    asm: "OP_RETURN 7af2be9fcb371dfcc5465a74373d499c11b1f7bba47e0507fce892ea12ec1cd6",
+         *    desc: "raw(6a207af2be9fcb371dfcc5465a74373d499c11b1f7bba47e0507fce892ea12ec1cd6)#g064zwfr",
+         *    hex: "6a207af2be9fcb371dfcc5465a74373d499c11b1f7bba47e0507fce892ea12ec1cd6",
+         *    type: "nulldata",
+         *  },
+         * }
+         */
+        const lastSignalVout = tx.vout.slice(-1)[0];
+        if (!lastSignalVout) {
+          continue;
+        }
+
+        const updateHash = extractOpReturnSignalHash(lastSignalVout.scriptPubKey?.hex);
+        if (!updateHash) {
+          continue;
+        }
+
+        // One transaction is one signal per beacon, however many of that beacon's UTXOs
+        // it spends, so track the services already credited with this transaction.
+        const signaled = new Set<BeaconService>();
 
         // Iterate over each input in the transaction
         for (const vin of tx.vin) {
@@ -213,21 +320,13 @@ export class BeaconSignalDiscovery {
 
           // Use the hoisted beaconServicesMap instead of rebuilding per-vin
           const beaconService = beaconServicesMap.get(scriptPubKey.address);
-          if (!beaconService) {
+          if (!beaconService || signaled.has(beaconService)) {
             continue;
           }
-
-          // A beacon signal output must be exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hash>`.
-          // Reject any other shape so a malformed on-chain output cannot masquerade as a
-          // phantom signal downstream.
-          const txVoutScriptPubkeyAsm = prevout.vout[vin.vout].scriptPubKey.asm;
-          const updateHash = extractOpReturnSignal(txVoutScriptPubkeyAsm);
-          if(!updateHash) {
-            continue;
-          }
+          signaled.add(beaconService);
 
           // Log the found txid and beacon
-          console.info(`Tx ${tx.txid} contains beacon service address ${scriptPubKey.address} and OP_RETURN!`, tx);
+          console.info(`Tx ${tx.txid} contains beacon address ${scriptPubKey.address}`);
 
           // Push the beacon signal object to the beacon signals array for that beacon service
           beaconServiceSignals.get(beaconService)?.push({

--- a/packages/method/src/core/beacon/utils.ts
+++ b/packages/method/src/core/beacon/utils.ts
@@ -173,19 +173,6 @@ export class BeaconUtils {
   }
 
   /**
-   * Create a map of address => beaconService with address field.
-   * @param {Array<BeaconService>} beacons The list of beacon services.
-   * @returns {Map<string, BeaconService>} A map of address => beaconService.
-   */
-  static getBeaconServicesMap(beacons: Array<BeaconService>): Map<string, BeaconService> {
-    return new Map<string, BeaconService>(
-      beacons
-        .map(this.parseBeaconServiceEndpoint)
-        .map((beacon) => ([beacon.serviceEndpoint as string, beacon]))
-    );
-  }
-
-  /**
    * Get the beacon service ids from a list of beacon services.
    * @param {DidDocument} didDocument The DID Document to extract the services from.
    * @returns {string[]} An array of beacon service ids.

--- a/packages/method/src/core/resolver.ts
+++ b/packages/method/src/core/resolver.ts
@@ -149,6 +149,32 @@ function isSMTProof(value: unknown): value is SMTProof {
     && Array.isArray(value.hashes);
 }
 
+// ─── verification relationship membership ────────────────────────────────────
+
+/**
+ * Resolves a verification relationship entry to the absolute DID URL of the
+ * method it names, or `undefined` when the entry names no method.
+ *
+ * An entry is either a reference (a bare fragment such as `#key-0`, or an
+ * absolute DID URL) or an embedded verification method object. A bare fragment
+ * is relative to the document that carries it, so it is resolved against
+ * `documentId` before comparison; every other string is returned unchanged, so
+ * a reference naming a different DID can never collapse onto this document's.
+ *
+ * Malformed entries yield `undefined` rather than a placeholder string, so two
+ * unusable values never compare equal to each other.
+ *
+ * @param {string} documentId The `id` of the DID document carrying the entry.
+ * @param {unknown} entry The relationship entry: a reference or an embedded method.
+ * @returns {string | undefined} The absolute DID URL, or undefined if unusable.
+ */
+function relationshipMethodId(documentId: string, entry: unknown): string | undefined {
+  // An embedded method names itself with its `id`; a reference is the id itself.
+  const id = isRecord(entry) ? entry.id : entry;
+  if(typeof id !== 'string' || id.length === 0) return undefined;
+  return id.startsWith('#') ? `${documentId}${id}` : id;
+}
+
 /**
  * Different possible Resolver states representing phases in the resolution process.
  */
@@ -599,6 +625,29 @@ export class Resolver {
     if(!verificationMethodId) {
       // If it does not exist, throw INVALID_DID_UPDATE error
       throw new ResolveError('No verificationMethod found in update', INVALID_DID_UPDATE, update);
+    }
+
+    // Spec "Check update.proof": raise INVALID_DID_UPDATE if
+    // currentDocument.capabilityInvocation does not contain
+    // update.proof.verificationMethod. Locating the method in verificationMethod[] and
+    // verifying its signature is not sufficient on its own: a key the controller
+    // published only for authentication (or for no relationship at all) must not be
+    // able to authorize a DID update. The write path enforces this in DidBtcr2.update();
+    // without it here the read path applies an update signed by any key in the document.
+    // Checked before the method is located so an unauthorized method always fails with
+    // this typed error, whether or not it also appears in verificationMethod[].
+    const authorizedMethodId = relationshipMethodId(currentDocument.id, verificationMethodId);
+    const authorized = authorizedMethodId !== undefined && currentDocument.capabilityInvocation?.some(
+      entry => relationshipMethodId(currentDocument.id, entry) === authorizedMethodId
+    );
+    if(!authorized) {
+      throw new ResolveError(
+        'Invalid update: verificationMethod is not authorized for capabilityInvocation',
+        INVALID_DID_UPDATE, {
+          verificationMethodId,
+          capabilityInvocation : currentDocument.capabilityInvocation
+        }
+      );
     }
 
     // Get the verificationMethod from the DID Document using the verificationMethodId.

--- a/packages/method/tests/resolver.spec.ts
+++ b/packages/method/tests/resolver.spec.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 import { canonicalHash, encode, hash, canonicalize, INTERNAL_ERROR, INVALID_DID_UPDATE, JSONPatch, LATE_PUBLISHING_ERROR } from '@did-btcr2/common';
 import type { PatchOperation } from '@did-btcr2/common';
 import { getNetwork } from '@did-btcr2/bitcoin';
-import { LocalSigner } from '@did-btcr2/keypair';
+import { CompressedSecp256k1PublicKey, LocalSigner } from '@did-btcr2/keypair';
 import { BTCR2MerkleTree, hashToHex } from '@did-btcr2/smt';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -12,6 +12,7 @@ import { DidBtcr2 } from '../src/did-btcr2.js';
 import { BeaconUtils } from '../src/core/beacon/utils.js';
 import type { BeaconService, BeaconSignal } from '../src/core/beacon/interfaces.js';
 import type { DidDocument } from '../src/utils/did-document.js';
+import { DidVerificationMethod } from '../src/utils/did-document.js';
 import type { SignedBTCR2Update } from '../src/core/btcr2-update.js';
 import { Resolver } from '../src/core/resolver.js';
 import type { DidResolutionResponse, NeedBeaconSignals, NeedCASAnnouncement, NeedGenesisDocument, NeedSMTProof, NeedSignedUpdate } from '../src/core/resolver.js';
@@ -1641,6 +1642,207 @@ describe('Resolver', () => {
       const updateNeed = state.needs[0] as NeedSignedUpdate;
       expect(updateNeed.updateHash).to.equal(craftedHashHex);
       expect(() => resolver.provide(updateNeed, crafted as any)).to.throw(/not a signed BTCR2 update/i);
+    });
+  });
+
+  describe('capabilityInvocation authorization on the read path', () => {
+    // The spec's "Check update.proof" step requires current_document.capabilityInvocation
+    // to contain update.proof.verificationMethod. The read path used to locate the method
+    // anywhere in verificationMethod[] and verify only its signature, so a key the
+    // controller published for authentication only (or for no relationship at all) could
+    // authorize a DID update: full takeover with a key deliberately excluded from update
+    // authority. The write path (DidBtcr2.update) has always enforced membership.
+    const fixture = deterministicData[2]; // regtest - has a known secretKey
+
+    /**
+     * A distinct, valid secp256k1 key that is not the DID's identity key, paired with
+     * the verification method that publishes it under the given fragment.
+     */
+    function otherKey(seed: number, fragment: string): { signer: LocalSigner; vm: DidVerificationMethod } {
+      const secret = new Uint8Array(32);
+      secret[31] = seed;
+      const publicKeyMultibase = new CompressedSecp256k1PublicKey(
+        secp256k1.getPublicKey(secret, true)
+      ).multibase.encoded;
+      return {
+        signer : new LocalSigner(secret),
+        vm     : new DidVerificationMethod({
+          id         : `${fixture.did}#${fragment}`,
+          type       : 'Multikey',
+          controller : fixture.did,
+          publicKeyMultibase
+        })
+      };
+    }
+
+    /** Sign one version hop with an explicit verification method and signer. */
+    function signHop(
+      document: DidDocument,
+      patches: PatchOperation[],
+      sourceVersionId: number,
+      vm: DidVerificationMethod,
+      signer: LocalSigner
+    ): SignedBTCR2Update {
+      return Updater.sign(fixture.did, Updater.construct(document, patches, sourceVersionId), vm, signer);
+    }
+
+    /** Resolve the fixture DID, then apply `patches` as a legitimate v1->v2 update. */
+    function v2(patches: PatchOperation[]): {
+      source: DidDocument; document: DidDocument; update: SignedBTCR2Update; vm: DidVerificationMethod;
+    } {
+      const source = resolveDeterministic(fixture.did);
+      const vm = source.verificationMethod![0]!;
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      return {
+        source,
+        vm,
+        update   : signHop(source, patches, 1, vm, signer),
+        document : JSONPatch.apply(source, patches) as DidDocument
+      };
+    }
+
+    /** Drive resolution and return whatever it threw, or undefined if it resolved. */
+    function thrownBy(updates: Array<SignedBTCR2Update>): any {
+      try {
+        driveSignalSequence(fixture.did, updates, updates);
+        return undefined;
+      } catch(error) {
+        return error;
+      }
+    }
+
+    /** Publish `vm` under verificationMethod plus the named relationships only. */
+    function publishKey(vm: DidVerificationMethod, relationships: Array<string>): PatchOperation[] {
+      return [
+        { op: 'add' as const, path: '/verificationMethod/-', value: { ...vm } },
+        ...relationships.map(relationship => ({
+          op    : 'add' as const,
+          path  : `/${relationship}/-`,
+          value : vm.id
+        }))
+      ];
+    }
+
+    it('rejects an update signed by an authentication-only verification method', () => {
+      const weak = otherKey(7, 'device');
+      // v1->v2 (legitimate): the controller publishes a weaker device key for
+      // authentication only, deliberately keeping it out of capabilityInvocation.
+      const { document, update: u2 } = v2(publishKey(weak.vm, [ 'authentication' ]));
+      // v2->v3 (attack): whoever holds the device key seizes capabilityInvocation.
+      const u3 = signHop(
+        document, [{ op: 'add', path: '/capabilityInvocation/-', value: weak.vm.id }], 2, weak.vm, weak.signer
+      );
+
+      const thrown = thrownBy([ u2, u3 ]);
+      expect(thrown, 'expected the unauthorized update to be rejected').to.exist;
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/not authorized for capabilityInvocation/i);
+    });
+
+    it('rejects an update signed by a method in no verification relationship at all', () => {
+      const loose = otherKey(9, 'loose');
+      // Published under verificationMethod[] only: locatable, but authorized for nothing.
+      const { document, update: u2 } = v2(publishKey(loose.vm, []));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, loose.vm, loose.signer);
+
+      const thrown = thrownBy([ u2, u3 ]);
+      expect(thrown, 'expected the unauthorized update to be rejected').to.exist;
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/not authorized for capabilityInvocation/i);
+    });
+
+    it('rejects every update once capabilityInvocation is removed from the document', () => {
+      // No capabilityInvocation means no method is authorized, including the identity key.
+      const { document, update: u2, vm } = v2([{ op: 'remove', path: '/capabilityInvocation' }]);
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, vm, signer);
+
+      const thrown = thrownBy([ u2, u3 ]);
+      expect(thrown, 'expected the update to be rejected').to.exist;
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/not authorized for capabilityInvocation/i);
+    });
+
+    it('rejects a capabilityInvocation entry that names the same fragment on a different DID', () => {
+      // A bare fragment resolves against the document that carries it, so an entry naming
+      // another DID must not authorize this document's method of the same name.
+      const foreignId = `${deterministicData[0].did}#initialKey`;
+      const { document, update: u2, vm } = v2([
+        { op: 'replace', path: '/capabilityInvocation/0', value: foreignId }
+      ]);
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, vm, signer);
+
+      const thrown = thrownBy([ u2, u3 ]);
+      expect(thrown, 'expected the foreign capabilityInvocation entry to authorize nothing').to.exist;
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/not authorized for capabilityInvocation/i);
+    });
+
+    it('rejects an update whose proof.verificationMethod is not a string', () => {
+      // A non-string id names no method, so it authorizes nothing. Before the membership
+      // check it reached getSigningMethod, whose fragment extraction returns undefined for
+      // a non-string and silently fell back to selecting assertionMethod[0].
+      const source = resolveDeterministic(fixture.did);
+      const vm = source.verificationMethod![0]!;
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const u2 = signHop(source, benignPatch(fixture.did), 1, vm, signer);
+      const crafted = { ...u2, proof: { ...u2.proof, verificationMethod: 12345 as any } };
+
+      const thrown = thrownBy([ crafted ]);
+      expect(thrown, 'expected the malformed verificationMethod to be rejected').to.exist;
+      expect(thrown.type).to.equal(INVALID_DID_UPDATE);
+      expect(thrown.message).to.match(/not authorized for capabilityInvocation/i);
+    });
+
+    it('applies an update signed by the authorized identity key (the check is not over-broad)', () => {
+      const source = resolveDeterministic(fixture.did);
+      const [ u2, u3 ] = buildUpdateChain(fixture.did, source, fixture.secretKey, [
+        benignPatch(fixture.did), benignPatch(fixture.did)
+      ]);
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u3 ]);
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.assertionMethod!.length).to.equal(source.assertionMethod!.length + 2);
+    });
+
+    it('accepts a key the previous update added to capabilityInvocation (membership is per-version)', () => {
+      const second = otherKey(11, 'second');
+      // v1->v2 grants the new key capabilityInvocation; v2->v3 exercises that grant, so the
+      // check must read the document as of the version being updated, not the genesis one.
+      const { document, update: u2 } = v2(publishKey(second.vm, [ 'capabilityInvocation' ]));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, second.vm, second.signer);
+
+      const { metadata } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u3 ]);
+      expect(metadata.versionId).to.equal('3');
+    });
+
+    it('accepts a bare-fragment capabilityInvocation reference to the signing method', () => {
+      // DID Core lets a document reference its own methods by bare fragment; an x1 genesis
+      // document written that way keeps the relative form after placeholder substitution,
+      // while its verificationMethod[] ids and the proof carry the absolute DID URL.
+      const { document, update: u2, vm } = v2([
+        { op: 'replace', path: '/capabilityInvocation/0', value: '#initialKey' }
+      ]);
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, vm, signer);
+
+      const { metadata, didDocument } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u3 ]);
+      expect(metadata.versionId).to.equal('3');
+      expect(didDocument.capabilityInvocation![0]).to.equal('#initialKey');
+    });
+
+    it('accepts an embedded verification method object in capabilityInvocation', () => {
+      // A relationship entry may embed the method rather than reference it.
+      const source = resolveDeterministic(fixture.did);
+      const embedded = { ...source.verificationMethod![0]! };
+      const { document, update: u2, vm } = v2([
+        { op: 'replace', path: '/capabilityInvocation/0', value: embedded }
+      ]);
+      const signer = new LocalSigner(hexToBytes(fixture.secretKey));
+      const u3 = signHop(document, benignPatch(fixture.did), 2, vm, signer);
+
+      const { metadata } = driveSignalSequence(fixture.did, [ u2, u3 ], [ u2, u3 ]);
+      expect(metadata.versionId).to.equal('3');
     });
   });
 });

--- a/packages/method/tests/signal-discovery.spec.ts
+++ b/packages/method/tests/signal-discovery.spec.ts
@@ -1,74 +1,746 @@
+import type { BitcoinConnection, BlockV3, RawTransactionRest, RawTransactionV2, Vin, Vout } from '@did-btcr2/bitcoin';
+import { TXIN_WITNESS_COINBASE } from '@did-btcr2/bitcoin';
 import { expect } from 'chai';
-import { extractOpReturnSignal } from '../src/core/beacon/signal-discovery.js';
+import type { BeaconService } from '../src/core/beacon/interfaces.js';
+import { BeaconSignalDiscovery, extractOpReturnSignalHash } from '../src/core/beacon/signal-discovery.js';
 
 /**
- * Beacon signal extraction from a scriptPubKey asm string.
+ * Beacon signal extraction from a serialized scriptPubKey.
  *
- * A beacon signal output is exactly `OP_RETURN OP_PUSHBYTES_32 <32-byte hex>`
- * (the on-the-wire `0x6a 0x20 <32 bytes>` NULL_DATA shape, see
- * `op-return-script.spec.ts` for the encode side). {@link extractOpReturnSignal}
- * is the strict decoder: it returns the 32-byte hash only for that exact shape
- * and `null` for everything else, so a malformed or adversarial on-chain output
- * cannot be mistaken for a real signal during resolution. Before this guard, any
- * output containing the `OP_RETURN` keyword had its last asm token taken verbatim
- * as the signal hash, so a bare `OP_RETURN` or a wrong-size push produced a
- * phantom signal (e.g. the literal string `OP_RETURN`, or a short hex) that flowed
- * downstream as a real update reference.
+ * A beacon signal output is exactly `0x6a 0x20 <32 bytes>`: `OP_RETURN`, the
+ * 32-byte push opcode, and the hash (see `op-return-script.spec.ts` for the
+ * encode side, which pins those bytes). {@link extractOpReturnSignalHash} is the
+ * strict decoder: it returns the 32-byte hash only for that exact script and
+ * `null` for everything else, so a malformed or adversarial on-chain output
+ * cannot be mistaken for a real signal during resolution.
+ *
+ * It decodes the script rather than a rendered `asm` string on purpose. `asm` is
+ * a human-readable rendering and its dialect is backend-specific: Bitcoin Core
+ * prints a data push as bare hex (`OP_RETURN <hash>`) while Esplora names the
+ * push opcode (`OP_RETURN OP_PUSHBYTES_32 <hash>`). A token-shaped check written
+ * against either dialect silently discards every signal produced by the other,
+ * which is fail-open on the read path: a resolver sees no updates at all and
+ * returns a stale document with no error. The serialized script is identical
+ * across backends, so decoding it removes the dialect from the trust path.
  */
-describe('extractOpReturnSignal', () => {
+describe('extractOpReturnSignalHash', () => {
   const HASH = '570f177c65e64fb5cf61180b664cdddf09ab76153c2b192e22006e5b22a3917a';
+  /** The canonical NULL_DATA beacon signal script: OP_RETURN + OP_PUSHBYTES_32 + hash. */
+  const script = (hash: string) => `6a20${hash}`;
 
   it('extracts the 32-byte hash from a well-formed beacon signal output', () => {
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(HASH);
+    expect(extractOpReturnSignalHash(script(HASH))).to.equal(HASH);
   });
 
-  it('lowercases an uppercase hex payload so it matches hex-keyed sidecar maps', () => {
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH.toUpperCase()}`)).to.equal(HASH);
+  it('decodes the same hash whatever asm dialect the backend renders', () => {
+    // Bitcoin Core prints `OP_RETURN <hash>`, Esplora prints
+    // `OP_RETURN OP_PUSHBYTES_32 <hash>`, and both serialize to this one script.
+    expect(extractOpReturnSignalHash('6a207af2be9fcb371dfcc5465a74373d499c11b1f7bba47e0507fce892ea12ec1cd6'))
+      .to.equal('7af2be9fcb371dfcc5465a74373d499c11b1f7bba47e0507fce892ea12ec1cd6');
   });
 
-  it('tolerates surrounding and repeated whitespace', () => {
-    expect(extractOpReturnSignal(`  OP_RETURN   OP_PUSHBYTES_32   ${HASH}  `)).to.equal(HASH);
+  it('lowercases an uppercase hex script so it matches hex-keyed sidecar maps', () => {
+    expect(extractOpReturnSignalHash(script(HASH).toUpperCase())).to.equal(HASH);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(extractOpReturnSignalHash(`  ${script(HASH)}  `)).to.equal(HASH);
   });
 
   it('returns null for undefined or empty input', () => {
-    expect(extractOpReturnSignal(undefined)).to.equal(null);
-    expect(extractOpReturnSignal('')).to.equal(null);
-    expect(extractOpReturnSignal('   ')).to.equal(null);
+    expect(extractOpReturnSignalHash(undefined)).to.equal(null);
+    expect(extractOpReturnSignalHash('')).to.equal(null);
+    expect(extractOpReturnSignalHash('   ')).to.equal(null);
   });
 
   it('returns null for a bare OP_RETURN with no data push', () => {
-    expect(extractOpReturnSignal('OP_RETURN')).to.equal(null);
+    expect(extractOpReturnSignalHash('6a')).to.equal(null);
   });
 
   it('returns null for a wrong-size push opcode (not OP_PUSHBYTES_32)', () => {
-    expect(extractOpReturnSignal('OP_RETURN OP_PUSHBYTES_4 deadbeef')).to.equal(null);
+    expect(extractOpReturnSignalHash('6a04deadbeef')).to.equal(null);
+  });
+
+  it('returns null for a non-canonical push of the right length (OP_PUSHDATA1)', () => {
+    // `6a 4c 20 <32 bytes>` pushes the same data, but no beacon writes it and
+    // Bitcoin Core rejects it as non-standard, so it is not a signal.
+    expect(extractOpReturnSignalHash(`6a4c20${HASH}`)).to.equal(null);
   });
 
   it('returns null when the payload is not exactly 32 bytes of hex (too short)', () => {
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH.slice(0, 62)}`)).to.equal(null);
+    expect(extractOpReturnSignalHash(`6a20${HASH.slice(0, 62)}`)).to.equal(null);
   });
 
   it('returns null when the payload is not exactly 32 bytes of hex (too long)', () => {
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH}ab`)).to.equal(null);
+    expect(extractOpReturnSignalHash(`6a20${HASH}ab`)).to.equal(null);
   });
 
-  it('returns null for a non-hex payload of the right length', () => {
-    const nonHex = 'z'.repeat(64);
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${nonHex}`)).to.equal(null);
+  it('returns null for a non-hex script', () => {
+    expect(extractOpReturnSignalHash(`6a20${'z'.repeat(64)}`)).to.equal(null);
   });
 
   it('returns null for a multi-push OP_RETURN (more than one data element)', () => {
-    expect(extractOpReturnSignal(`OP_RETURN OP_PUSHBYTES_32 ${HASH} OP_PUSHBYTES_4 deadbeef`)).to.equal(null);
+    // `6a 20 <32 bytes> 04 deadbeef`: a second push after the signal.
+    expect(extractOpReturnSignalHash(`6a20${HASH}04deadbeef`)).to.equal(null);
   });
 
   it('returns null for a non-OP_RETURN script', () => {
-    // A p2wpkh scriptPubKey asm: no OP_RETURN, must never yield a signal.
-    expect(extractOpReturnSignal('OP_0 OP_PUSHBYTES_20 751e76e8199196d454941c45d1b3a323f1433bd6')).to.equal(null);
+    // A p2wpkh scriptPubKey: `0x00 0x14 <20 bytes>`, must never yield a signal.
+    expect(extractOpReturnSignalHash('0014751e76e8199196d454941c45d1b3a323f1433bd6')).to.equal(null);
   });
 
   it('returns null when OP_RETURN is present but not the leading opcode', () => {
-    // OP_RETURN must be the first token of a NULL_DATA output; a script that merely
-    // contains the keyword elsewhere is not a beacon signal.
-    expect(extractOpReturnSignal(`OP_DUP OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(null);
+    // `OP_DUP OP_RETURN <push>`: a script that merely contains 0x6a is not a signal.
+    expect(extractOpReturnSignalHash(`766a20${HASH}`)).to.equal(null);
+  });
+
+  it('returns null for an asm rendering passed in place of the script', () => {
+    // The parameter changed from asm to the serialized script; the old input must
+    // not decode by accident.
+    expect(extractOpReturnSignalHash(`OP_RETURN OP_PUSHBYTES_32 ${HASH}`)).to.equal(null);
+    expect(extractOpReturnSignalHash(`OP_RETURN ${HASH}`)).to.equal(null);
+  });
+});
+
+/**
+ * Beacon signal discovery over an address transaction listing.
+ *
+ * A Beacon Signal is a transaction that *spends from* a Beacon Address, but
+ * `address.getTxs` returns every transaction touching the address in either
+ * direction. {@link BeaconSignalDiscovery.indexer} therefore has to inspect the
+ * input side before treating a transaction's OP_RETURN as a signal. Before that
+ * check, anyone able to pay dust to a beacon address could attach an arbitrary
+ * 32-byte OP_RETURN and have it discovered as a signal: the resolver then emits a
+ * data need for an update hash that nobody can ever supply, which blocks
+ * resolution of the DID for as long as that output stays on chain.
+ */
+describe('BeaconSignalDiscovery.indexer', () => {
+  // Two unrelated regtest p2wpkh addresses: the beacon, and an outsider paying it.
+  const BEACON = 'bcrt1ql3e9pgs3mmwuwrh95fecme0s0qtn2880hlwwpw';
+  const OUTSIDER = 'bcrt1q2vfxp232rx0z9rzn0hay9jptagk8c86ddphpjv';
+  const HASH = '570f177c65e64fb5cf61180b664cdddf09ab76153c2b192e22006e5b22a3917a';
+  const OTHER_HASH = 'a'.repeat(64);
+  const TIP = 110;
+  const HEIGHT = 100;
+
+  const beaconService = {
+    id              : '#beacon-0',
+    type            : 'SingletonBeacon',
+    serviceEndpoint : `bitcoin:${BEACON}`,
+  } as BeaconService;
+
+  /** Helper: an Esplora output paying an address. */
+  function payment(address: string, value: number = 10_000): Vout {
+    return {
+      scriptpubkey         : `0014${'11'.repeat(20)}`,
+      scriptpubkey_asm     : `OP_0 OP_PUSHBYTES_20 ${'11'.repeat(20)}`,
+      scriptpubkey_type    : 'v0_p2wpkh',
+      scriptpubkey_address : address,
+      value,
+    };
+  }
+
+  /** Helper: an Esplora OP_RETURN output carrying a beacon signal hash. */
+  function signalOutput(hash: string): Vout {
+    return {
+      scriptpubkey      : `6a20${hash}`,
+      scriptpubkey_asm  : `OP_RETURN OP_PUSHBYTES_32 ${hash}`,
+      scriptpubkey_type : 'op_return',
+      value             : 0,
+    };
+  }
+
+  /** Helper: an Esplora input, with the spent output embedded as Esplora returns it. */
+  function input(txid: string, vout: number, prevout: Vout | null): Vin {
+    return {
+      txid,
+      vout,
+      prevout,
+      scriptsig     : '',
+      scriptsig_asm : '',
+      witness       : [],
+      is_coinbase   : false,
+      sequence      : 0xffffffff,
+    };
+  }
+
+  /** Helper: a confirmed Esplora transaction. */
+  function transaction(txid: string, vin: Array<Vin>, vout: Array<Vout>): RawTransactionRest {
+    return {
+      txid,
+      version  : 2,
+      locktime : 0,
+      vin,
+      vout,
+      size     : 200,
+      weight   : 800,
+      fee      : 300,
+      status   : { confirmed: true, block_height: HEIGHT, block_hash: 'b'.repeat(64), block_time: 1700000000 },
+    };
+  }
+
+  /**
+   * Minimal BitcoinConnection over a fixed address transaction listing. Every
+   * `transaction.get` txid is recorded in `fetched` so a test can assert whether the
+   * prevout fallback was taken, and is answered from `funding`.
+   */
+  function mockBitcoin(
+    txs: Array<RawTransactionRest>,
+    funding: Record<string, RawTransactionRest> = {},
+    fetched: Array<string> = [],
+  ): BitcoinConnection {
+    return {
+      rest : {
+        block       : { count: async () => TIP },
+        address     : { getTxs: async () => txs },
+        transaction : {
+          get : async (txid: string) => {
+            fetched.push(txid);
+            const tx = funding[txid];
+            if(!tx) {
+              throw new Error(`unexpected transaction fetch: ${txid}`);
+            }
+            return tx;
+          },
+        },
+      },
+    } as unknown as BitcoinConnection;
+  }
+
+  /** Helper: run discovery for the single beacon service under test. */
+  async function discover(bitcoin: BitcoinConnection) {
+    const signals = await BeaconSignalDiscovery.indexer([beaconService], bitcoin);
+    return signals.get(beaconService) ?? [];
+  }
+
+  it('discovers a signal from a transaction that spends the beacon UTXO', async () => {
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(BEACON, 100_000))],
+      [payment(BEACON, 90_000), signalOutput(HASH)],
+    );
+
+    const signals = await discover(mockBitcoin([tx]));
+
+    expect(signals).to.have.lengthOf(1);
+    expect(signals[0].signalBytes).to.equal(HASH);
+    expect(signals[0].blockMetadata).to.deep.equal({
+      confirmations : TIP - HEIGHT + 1,
+      height        : HEIGHT,
+      time          : 1700000000,
+    });
+  });
+
+  it('ignores an inbound payment to the beacon that carries a well-formed OP_RETURN', async () => {
+    // The dust-payment denial of service: the outsider spends their own UTXO, pays dust
+    // to the beacon, and attaches a random 32-byte hash. Nothing here is a beacon spend.
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(OUTSIDER, 100_000))],
+      [payment(BEACON, 546), signalOutput(OTHER_HASH)],
+    );
+
+    expect(await discover(mockBitcoin([tx]))).to.have.lengthOf(0);
+  });
+
+  it('keeps the real signal and drops the inbound payment from the same listing', async () => {
+    const real = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(BEACON, 100_000))],
+      [payment(BEACON, 90_000), signalOutput(HASH)],
+    );
+    const inbound = transaction(
+      'e'.repeat(64),
+      [input('f'.repeat(64), 0, payment(OUTSIDER, 100_000))],
+      [payment(BEACON, 546), signalOutput(OTHER_HASH)],
+    );
+
+    const signals = await discover(mockBitcoin([inbound, real]));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('discovers a signal that spends the beacon UTXO without paying anything back to it', async () => {
+    // A beacon spend need not return change to the beacon; the input side decides.
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(BEACON, 100_000))],
+      [payment(OUTSIDER, 90_000), signalOutput(HASH)],
+    );
+
+    expect(await discover(mockBitcoin([tx]))).to.have.lengthOf(1);
+  });
+
+  it('discovers a signal when a later input is the one spending from the beacon', async () => {
+    const tx = transaction(
+      'c'.repeat(64),
+      [
+        input('d'.repeat(64), 0, payment(OUTSIDER, 50_000)),
+        input('e'.repeat(64), 1, payment(BEACON, 100_000)),
+      ],
+      [payment(BEACON, 140_000), signalOutput(HASH)],
+    );
+
+    expect(await discover(mockBitcoin([tx]))).to.have.lengthOf(1);
+  });
+
+  it('falls back to the funding transaction when the backend omits the prevout', async () => {
+    const fundingTx = transaction('d'.repeat(64), [], [payment(OUTSIDER, 1_000), payment(BEACON, 100_000)]);
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 1, null)],
+      [payment(BEACON, 90_000), signalOutput(HASH)],
+    );
+    const fetched: Array<string> = [];
+
+    const signals = await discover(mockBitcoin([tx], { ['d'.repeat(64)]: fundingTx }, fetched));
+
+    expect(signals).to.have.lengthOf(1);
+    expect(fetched).to.deep.equal(['d'.repeat(64)]);
+  });
+
+  it('ignores an inbound payment whose fetched funding output belongs to someone else', async () => {
+    const fundingTx = transaction('d'.repeat(64), [], [payment(OUTSIDER, 100_000)]);
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, null)],
+      [payment(BEACON, 546), signalOutput(OTHER_HASH)],
+    );
+    const fetched: Array<string> = [];
+
+    expect(await discover(mockBitcoin([tx], { ['d'.repeat(64)]: fundingTx }, fetched))).to.have.lengthOf(0);
+    expect(fetched).to.deep.equal(['d'.repeat(64)]);
+  });
+
+  it('does not fetch funding transactions when the prevouts are embedded', async () => {
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(BEACON, 100_000))],
+      [payment(BEACON, 90_000), signalOutput(HASH)],
+    );
+    const fetched: Array<string> = [];
+
+    await discover(mockBitcoin([tx], {}, fetched));
+
+    expect(fetched).to.deep.equal([]);
+  });
+
+  it('ignores a coinbase transaction paying the beacon, without resolving its input', async () => {
+    // A coinbase input spends no prior output, so it can never be a beacon spend and
+    // must not be looked up as one either.
+    const coinbaseInput: Vin = {
+      ...input('0'.repeat(64), 0xffffffff, null),
+      is_coinbase : true,
+    };
+    const tx = transaction('c'.repeat(64), [coinbaseInput], [payment(BEACON, 5_000_000), signalOutput(OTHER_HASH)]);
+    const fetched: Array<string> = [];
+
+    expect(await discover(mockBitcoin([tx], {}, fetched))).to.have.lengthOf(0);
+    expect(fetched).to.deep.equal([]);
+  });
+
+  it('still ignores a beacon spend whose last output is not a well-formed signal', async () => {
+    // The OP_RETURN shape check remains the first filter; the spend check does not widen it.
+    const tx = transaction(
+      'c'.repeat(64),
+      [input('d'.repeat(64), 0, payment(BEACON, 100_000))],
+      [signalOutput(HASH), payment(OUTSIDER, 90_000)],
+    );
+
+    expect(await discover(mockBitcoin([tx]))).to.have.lengthOf(0);
+  });
+});
+
+/**
+ * Beacon signal discovery over a full node.
+ *
+ * A Beacon Signal announces its update hash in the OP_RETURN output of the
+ * transaction that *spends* a Beacon UTXO, so {@link BeaconSignalDiscovery.fullnode}
+ * has to read that hash from the spending transaction's own last output: the output
+ * being spent carries an ordinary locking script and never a NULL_DATA one. Before
+ * this guard the scan parsed the *spent* output's script, which can never yield a
+ * signal, and attributed whatever it found to a copied service object that no caller
+ * holds a reference to. Both faults were silent and fail-open in the same direction:
+ * every DID resolved through this path saw zero signals and returned the stale genesis
+ * document with no error, so a rotated or revoked key still read as authorized.
+ */
+describe('BeaconSignalDiscovery.fullnode', () => {
+  // RPC (Bitcoin Core) wire shapes, distinct from the Esplora shapes used by the indexer.
+  type RpcVin = RawTransactionV2['vin'][number];
+  type RpcVout = RawTransactionV2['vout'][number];
+
+  // Two unrelated regtest beacons, and an outsider transacting alongside them.
+  const BEACON = 'bcrt1ql3e9pgs3mmwuwrh95fecme0s0qtn2880hlwwpw';
+  const BEACON_2 = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+  const OUTSIDER = 'bcrt1q2vfxp232rx0z9rzn0hay9jptagk8c86ddphpjv';
+  const HASH = '570f177c65e64fb5cf61180b664cdddf09ab76153c2b192e22006e5b22a3917a';
+  const OTHER_HASH = 'a'.repeat(64);
+  const TIP = 2;
+
+  const beaconService = {
+    id              : '#beacon-0',
+    type            : 'SingletonBeacon',
+    serviceEndpoint : `bitcoin:${BEACON}`,
+  } as BeaconService;
+
+  const beaconService2 = {
+    id              : '#beacon-1',
+    type            : 'SingletonBeacon',
+    serviceEndpoint : `bitcoin:${BEACON_2}`,
+  } as BeaconService;
+
+  // The scan narrates itself on console.info, dumping every discovered transaction in
+  // full; silence it for the duration so the suite output stays readable.
+  const consoleInfo = console.info;
+
+  beforeEach(() => {
+    console.info = () => undefined;
+  });
+
+  afterEach(() => {
+    console.info = consoleInfo;
+  });
+
+  /**
+   * Helper: an RPC output paying an address. Bitcoin Core renders a data push as bare
+   * hex, with no `OP_PUSHBYTES_n` token: the asm here is what `getblock` verbosity 3
+   * actually returns, not the Esplora rendering used by the indexer fixtures above.
+   */
+  function rpcPayment(address: string, value: number = 10_000): RpcVout {
+    return {
+      value,
+      n            : 0,
+      scriptPubKey : {
+        asm     : `OP_0 ${'11'.repeat(20)}`,
+        hex     : `0014${'11'.repeat(20)}`,
+        reqSigs : 1,
+        type    : 'witness_v0_keyhash',
+        address,
+        desc    : `addr(${address})`,
+      },
+    };
+  }
+
+  /** Helper: an RPC OP_RETURN output carrying a beacon signal hash, in Core's dialect. */
+  function rpcSignalOutput(hash: string): RpcVout {
+    return {
+      value        : 0,
+      n            : 0,
+      scriptPubKey : {
+        asm     : `OP_RETURN ${hash}`,
+        hex     : `6a20${hash}`,
+        reqSigs : 0,
+        type    : 'nulldata',
+        desc    : `raw(6a20${hash})`,
+      },
+    };
+  }
+
+  /**
+   * Helper: an RPC input spending a prior output. Bitcoin Core embeds the spent output
+   * in `prevout` at verbosity 3, but the scan resolves the funding transaction over RPC
+   * instead, so the fixtures leave the field off and the mock answers the lookup.
+   */
+  function rpcInput(txid: string, vout: number): RpcVin {
+    return { txid, vout, sequence: 0xffffffff } as RpcVin;
+  }
+
+  /** Helper: an RPC transaction, with its outputs numbered by position. */
+  function rpcTransaction(txid: string, vin: Array<RpcVin>, vout: Array<RpcVout>): RawTransactionV2 {
+    return {
+      txid,
+      hash     : txid,
+      hex      : '',
+      version  : 2,
+      locktime : 0,
+      size     : 200,
+      vsize    : 200,
+      weight   : 800,
+      vin,
+      vout     : vout.map((output, n) => ({ ...output, n })),
+    };
+  }
+
+  /** Helper: a block at a height, carrying transactions. */
+  function rpcBlock(height: number, tx: Array<RawTransactionV2>): BlockV3 {
+    return {
+      height,
+      tx,
+      hash          : String(height).padStart(64, '0'),
+      time          : 1700000000 + height,
+      confirmations : TIP - height + 1,
+    } as BlockV3;
+  }
+
+  /**
+   * Minimal BitcoinConnection over a fixed chain, indexed by height. Every
+   * `getRawTransaction` txid is recorded in `fetched` so a test can assert which prevouts
+   * the scan bothered to resolve, and is answered from `funding`.
+   */
+  function mockBitcoin(
+    blocks: Array<BlockV3>,
+    funding: Record<string, RawTransactionV2> = {},
+    fetched: Array<string> = [],
+  ): BitcoinConnection {
+    return {
+      rpc : {
+        getBlockCount     : async () => blocks.length - 1,
+        getBlock          : async ({ height }: { height: number }) => blocks[height],
+        getRawTransaction : async (txid: string) => {
+          fetched.push(txid);
+          const tx = funding[txid];
+          if(!tx) {
+            throw new Error(`unexpected transaction fetch: ${txid}`);
+          }
+          return tx;
+        },
+      },
+    } as unknown as BitcoinConnection;
+  }
+
+  /** Helper: a one-transaction chain, with the beacon UTXO it spends as block 1. */
+  function chain(tx: RawTransactionV2, funding: Array<RawTransactionV2>): Array<BlockV3> {
+    return [rpcBlock(0, []), rpcBlock(1, funding), rpcBlock(2, [tx])];
+  }
+
+  /** Helper: run discovery over a chain and return the signals for the first beacon. */
+  async function discover(bitcoin: BitcoinConnection, services: Array<BeaconService> = [beaconService]) {
+    const signals = await BeaconSignalDiscovery.fullnode(services, bitcoin);
+    return signals.get(services[0]) ?? [];
+  }
+
+  it('discovers a signal from a transaction that spends a beacon UTXO', async () => {
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcPayment(BEACON, 90_000), rpcSignalOutput(HASH)],
+    );
+
+    const signals = await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals).to.have.lengthOf(1);
+    expect(signals[0].signalBytes).to.equal(HASH);
+    expect(signals[0].tx.txid).to.equal('c'.repeat(64));
+    expect(signals[0].blockMetadata).to.deep.equal({
+      height        : 2,
+      time          : 1700000002,
+      confirmations : 1,
+    });
+  });
+
+  it('discovers a signal whose asm is rendered in a foreign dialect', async () => {
+    // A backend that names the push opcode (Esplora's rendering) serializes to the same
+    // script, so the same transaction must be discovered either way. The reverse of this
+    // case is what broke the path against a real node: Core omits the opcode name.
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const foreignDialect = rpcSignalOutput(HASH);
+    foreignDialect.scriptPubKey.asm = `OP_RETURN OP_PUSHBYTES_32 ${HASH}`;
+    const tx = rpcTransaction('c'.repeat(64), [rpcInput('d'.repeat(64), 0)], [foreignDialect]);
+
+    const signals = await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('discovers a signal from an output that carries no asm at all', async () => {
+    // The serialized script is the only field the decoder reads.
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const noAsm = rpcSignalOutput(HASH);
+    noAsm.scriptPubKey.asm = undefined as unknown as string;
+    const tx = rpcTransaction('c'.repeat(64), [rpcInput('d'.repeat(64), 0)], [noAsm]);
+
+    const signals = await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('reads the signal hash from the spending transaction, not from the output it spends', async () => {
+    // The spent output is given a NULL_DATA script *and* an address, which no real
+    // output has: it exists purely so the two candidate scripts yield different hashes
+    // and the test can prove which one is read.
+    const spentOutput = { ...rpcSignalOutput(OTHER_HASH) };
+    spentOutput.scriptPubKey.address = BEACON;
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [spentOutput]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcPayment(OUTSIDER, 90_000), rpcSignalOutput(HASH)],
+    );
+
+    const signals = await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('discovers signals across every block up to the chain tip', async () => {
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000), rpcPayment(BEACON, 100_000)]);
+    const first = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcSignalOutput(HASH)],
+    );
+    const second = rpcTransaction(
+      'e'.repeat(64),
+      [rpcInput('d'.repeat(64), 1)],
+      [rpcSignalOutput(OTHER_HASH)],
+    );
+    const blocks = [rpcBlock(0, []), rpcBlock(1, [fundingTx, first]), rpcBlock(2, [second])];
+
+    const signals = await discover(mockBitcoin(blocks, { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH, OTHER_HASH]);
+    expect(signals.map(s => s.blockMetadata.height)).to.deep.equal([1, 2]);
+  });
+
+  it('emits one signal for a transaction that spends several of the same beacon UTXOs', async () => {
+    // Two inputs, one beacon, one OP_RETURN: one signal. Counting per input would apply
+    // the same update twice during resolution.
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 50_000), rpcPayment(BEACON, 60_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0), rpcInput('d'.repeat(64), 1)],
+      [rpcPayment(BEACON, 100_000), rpcSignalOutput(HASH)],
+    );
+
+    const signals = await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }));
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('records the signal against each beacon service a transaction spends from', async () => {
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 50_000), rpcPayment(BEACON_2, 60_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0), rpcInput('d'.repeat(64), 1)],
+      [rpcSignalOutput(HASH)],
+    );
+
+    const discovered = await BeaconSignalDiscovery.fullnode(
+      [beaconService, beaconService2],
+      mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }),
+    );
+
+    // Results are keyed by the caller's own service objects, not by copies of them.
+    expect(discovered.get(beaconService)?.map(s => s.signalBytes)).to.deep.equal([HASH]);
+    expect(discovered.get(beaconService2)?.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('resolves a beacon endpoint that carries BIP21 query parameters', async () => {
+    const service = {
+      id              : '#beacon-0',
+      type            : 'SingletonBeacon',
+      serviceEndpoint : `bitcoin:${BEACON}?amount=0.001`,
+    } as BeaconService;
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcSignalOutput(HASH)],
+    );
+
+    const signals = await discover(
+      mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }),
+      [service],
+    );
+
+    expect(signals.map(s => s.signalBytes)).to.deep.equal([HASH]);
+  });
+
+  it('ignores a transaction with a well-formed OP_RETURN that spends from no beacon', async () => {
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(OUTSIDER, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcPayment(BEACON, 546), rpcSignalOutput(OTHER_HASH)],
+    );
+
+    expect(await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx })))
+      .to.have.lengthOf(0);
+  });
+
+  it('ignores a beacon spend whose last output is not a well-formed signal', async () => {
+    // The OP_RETURN must be the last output; an earlier one is not the beacon's signal.
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcSignalOutput(HASH), rpcPayment(OUTSIDER, 90_000)],
+    );
+
+    expect(await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx })))
+      .to.have.lengthOf(0);
+  });
+
+  it('does not resolve any prevout for a transaction whose last output is not a signal', async () => {
+    // The shape check is free and the prevout lookup is a round trip per input, so an
+    // ordinary payment must not cost one.
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcPayment(OUTSIDER, 90_000)],
+    );
+    const fetched: Array<string> = [];
+
+    await discover(mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }, fetched));
+
+    expect(fetched).to.deep.equal([]);
+  });
+
+  it('ignores a coinbase transaction paying a beacon, without resolving its input', async () => {
+    const coinbaseInput = { coinbase: '02', sequence: 0xffffffff } as RpcVin;
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [coinbaseInput],
+      [rpcPayment(BEACON, 5_000_000), rpcSignalOutput(OTHER_HASH)],
+    );
+    const fetched: Array<string> = [];
+
+    expect(await discover(mockBitcoin(chain(tx, []), {}, fetched))).to.have.lengthOf(0);
+    expect(fetched).to.deep.equal([]);
+  });
+
+  it('ignores an input carrying the coinbase witness marker', async () => {
+    const witnessInput = {
+      ...rpcInput('d'.repeat(64), 0),
+      txinwitness : [TXIN_WITNESS_COINBASE],
+    } as RpcVin;
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [witnessInput],
+      [rpcPayment(BEACON, 5_000_000), rpcSignalOutput(OTHER_HASH)],
+    );
+    const fetched: Array<string> = [];
+
+    expect(await discover(mockBitcoin(chain(tx, []), {}, fetched))).to.have.lengthOf(0);
+    expect(fetched).to.deep.equal([]);
+  });
+
+  it('returns an empty signal list for a beacon that was never spent from', async () => {
+    const fundingTx = rpcTransaction('d'.repeat(64), [], [rpcPayment(BEACON, 100_000)]);
+    const tx = rpcTransaction(
+      'c'.repeat(64),
+      [rpcInput('d'.repeat(64), 0)],
+      [rpcSignalOutput(HASH)],
+    );
+
+    const discovered = await BeaconSignalDiscovery.fullnode(
+      [beaconService, beaconService2],
+      mockBitcoin(chain(tx, [fundingTx]), { ['d'.repeat(64)]: fundingTx }),
+    );
+
+    expect(discovered.get(beaconService2)).to.deep.equal([]);
+  });
+
+  it('throws for a beacon service endpoint that is not a BIP21 bitcoin URI', async () => {
+    const service = { id: '#beacon-0', type: 'SingletonBeacon', serviceEndpoint: BEACON } as BeaconService;
+
+    try {
+      await BeaconSignalDiscovery.fullnode([service], mockBitcoin([rpcBlock(0, [])]));
+      expect.fail('expected a malformed beacon endpoint to throw');
+    } catch (error: any) {
+      expect(error.message).to.equal('Invalid Bitcoin URI format');
+    }
   });
 });


### PR DESCRIPTION
* fix(common): reject proto-traversal pointers; keep own __proto__ keys
* fix(cryptosuite): un-invert domain check; keep secrets out of toJSON
* fix(method): enforce capabilityInvocation; gate + decode signals
* refactor(method): remove BeaconUtils.getBeaconServicesMap
* feat(api): select beacon signal discovery on the Bitcoin connection
* fix(bitcoin): bind JSON-RPC responses to the ids sent
* feat(cli): configure beacon signal discovery from the CLI
* fix(aggregation): bind sigs to data + sender; never fail a cohort
* fix(cli): drop --btc-rpc-pass; report signal discovery in config
* docs(adr): 086-090 signals, secrets, authz, signing, transport auth
* docs: fix argv-secret guidance + aggregation package imports
* chore(release): common 9.3.0, cryptosuite 10.0.0, bitcoin 0.10.0, method 0.56.0, aggregation 0.6.0, api 0.19.0, cli 0.19.0